### PR TITLE
Fix parsing Animation/slots in SkeletonJson.cs

### DIFF
--- a/spine-csharp/src/SkeletonJson.cs
+++ b/spine-csharp/src/SkeletonJson.cs
@@ -228,7 +228,7 @@ namespace Spine {
 					Dictionary<String, Object> timelineMap = (Dictionary<String, Object>)entry.Value;
 
 					foreach (KeyValuePair<String, Object> timelineEntry in timelineMap) {
-						List<Dictionary<String, Object>> values = (List<Dictionary<String, Object>>)timelineEntry.Value;
+						List<Object> values = (List<Object>)timelineEntry.Value;
 						String timelineName = (String)timelineEntry.Key;
 						if (timelineName.Equals(TIMELINE_COLOR)) {
 							ColorTimeline timeline = new ColorTimeline(values.Count);


### PR DESCRIPTION
If you have an animation with slots then an error occurs when parsing the json file.  I fixed this by comparing with the libgdx version.
