### PR TITLE
Fix for Memory leaks in spine-c

### DIFF
--- a/spine-c/src/spine/Animation.c
+++ b/spine-c/src/spine/Animation.c
@@ -474,7 +474,7 @@ void _AttachmentTimeline_dispose (Timeline* timeline) {
 	for (i = 0; i < self->framesLength; ++i)
 		FREE(self->attachmentNames[i]);
 	FREE(self->attachmentNames);
-
+    FREE(self->frames);
 	FREE(self);
 }
 

--- a/spine-c/src/spine/Atlas.c
+++ b/spine-c/src/spine/Atlas.c
@@ -40,6 +40,7 @@ AtlasPage* AtlasPage_create (const char* name) {
 void AtlasPage_dispose (AtlasPage* self) {
 	FREE(self->name);
 	_AtlasPage_disposeTexture(self);
+    FREE(self);
 }
 
 /**/

--- a/spine-c/src/spine/Attachment.c
+++ b/spine-c/src/spine/Attachment.c
@@ -52,6 +52,7 @@ void _Attachment_deinit (Attachment* self) {
 
 void Attachment_dispose (Attachment* self) {
 	VTABLE(Attachment, self) ->dispose(self);
+    FREE(self);
 }
 
 #ifdef __cplusplus

--- a/spine-c/src/spine/AttachmentLoader.c
+++ b/spine-c/src/spine/AttachmentLoader.c
@@ -52,6 +52,7 @@ void _AttachmentLoader_deinit (AttachmentLoader* self) {
 
 void AttachmentLoader_dispose (AttachmentLoader* self) {
 	VTABLE(AttachmentLoader, self) ->dispose(self);
+    FREE(self);
 }
 
 Attachment* AttachmentLoader_newAttachment (AttachmentLoader* self, Skin* skin, AttachmentType type, const char* name) {

--- a/spine-c/src/spine/Skeleton.c
+++ b/spine-c/src/spine/Skeleton.c
@@ -95,6 +95,7 @@ void Skeleton_dispose (Skeleton* self) {
 	FREE(self->slots);
 
 	FREE(self->drawOrder);
+    FREE(self);
 }
 
 void Skeleton_updateWorldTransform (const Skeleton* self) {


### PR DESCRIPTION
I've gone through the code using XCode's Profiler set to memory leaks, loaded and unloaded animations and fixed all memory leaks that I came across. Nothing appears to be leaking with any of the sample animations.

Code checked in Debug/Release on iOS, OSX and Win32.
