### PR TITLE
Add GWT module definition

### DIFF
--- a/spine-libgdx/src/com/esotericsoftware/spine.gwt.xml
+++ b/spine-libgdx/src/com/esotericsoftware/spine.gwt.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module rename-to="com.esotericsoftware.spine">
+	<source path="spine">
+		<include name="**/*"/>
+	</source>
+</module>


### PR DESCRIPTION
Add a GWT module definition for the libgdx runtime.

Note: Users will still need to inherit it in their own GWT module definitions.
