### PR TITLE
Fix scaling when attachment is rotated 90 degrees from the bone, Add relative paths to package.path when running in simulator to make the example work straight out of the box

### DIFF
--- a/spine-corona/spine-corona/spine.lua
+++ b/spine-corona/spine-corona/spine.lua
@@ -113,16 +113,16 @@ function spine.Skeleton.new (skeletonData, group)
 					image.y = -(slot.bone.worldY + attachment.x * slot.bone.m10 + attachment.y * slot.bone.m11)
 					image.rotation = -(slot.bone.worldRotation + attachment.rotation)
 
-                    -- fix scaling when attachment is rotated 90 degrees
-                    local rot = math.abs(attachment.rotation) % 180
-                    if (rot == 90) then
-                        image.xScale = slot.bone.worldScaleY * attachment.scaleX
-                        image.yScale = slot.bone.worldScaleX * attachment.scaleY
-                    else
-                        --if (rot ~= 0 and (slot.bone.worldScaleX ~= 1 or slot.bone.worldScaleY ~= 1)) then print("WARNING: Scaling bones with attachments not rotated to the cardinal angles will not work as expected in Corona!") end
-                        image.xScale = slot.bone.worldScaleX * attachment.scaleX
-                        image.yScale = slot.bone.worldScaleY * attachment.scaleY
-                    end
+					-- fix scaling when attachment is rotated 90 degrees
+					local rot = math.abs(attachment.rotation) % 180
+					if (rot == 90) then
+					    image.xScale = slot.bone.worldScaleY * attachment.scaleX
+					    image.yScale = slot.bone.worldScaleX * attachment.scaleY
+					else
+					    --if (rot ~= 0 and (slot.bone.worldScaleX ~= 1 or slot.bone.worldScaleY ~= 1)) then print("WARNING: Scaling bones with attachments not rotated to the cardinal angles will not work as expected in Corona!") end
+					    image.xScale = slot.bone.worldScaleX * attachment.scaleX
+					    image.yScale = slot.bone.worldScaleY * attachment.scaleY
+					end
 
 					if self.flipX then
 						image.xScale = -image.xScale


### PR DESCRIPTION
Sorry for putting two distinct changes in the pull request, I'm still a bit of a newbie with Github.. 

First, as discussed in e-mail, the Corona runtime can't work with freely rotated attachments when scaling the bone due to missing support for quads. 

However, we can support attachments that are rotated in the cardinal angles, and this adds support for it. There is also a commented-out warning message (when rotation is not cardinal and bone is scaled) that you might want to re-enable if this becomes more of an issue.

I'm not sure why the original code was bone.worldScaleX + attachment.scaleX - 1 as it doesnt seem like it's how it works in the editor (if attachment.scale = 0.1 and worldScale = 7, the result should not be 6.1 but 0.7, eg boneScale \* attachmentScale). All spines I tested work correctly with this, including the trampoline example I sent to you yesterday.

The second change adds the parent directory (spine-runtimes) to package.path allowing the example to work straight out of the box - currently it just throws an error and at least someone on the Corona forums was confused by it. 

However, I'm not sure if you really want to do this as it hides the reason why it's not working a bit deeper which probably will cause some problems later on for the inexperienced user or possibly just add some documentation to the example. Another option could be to use git itself to somehow include copy of spine-lua in the spine-corona directory? Not sure what the best way to do that would be, though.
