### PR TITLE
Wong timeline being passed to array in spine code

### DIFF
--- a/spine-as3/spine-as3/src/spine/SkeletonJson.as
+++ b/spine-as3/spine-as3/src/spine/SkeletonJson.as
@@ -221,7 +221,7 @@ public class SkeletonJson {
 					for each (var valueMap3:Object in values2) {
 						timeline3.setFrame(frameIndex3++, valueMap3["time"], valueMap3["name"]);
 					}
-					timelines.push(timeline);
+					timelines.push(timeline3);
 					duration = Math.max(duration, timeline3.frames[timeline3.frameCount - 1]);
 
 				} else


### PR DESCRIPTION
This is a pretty simple bug and fix. Seems the wrong timeline was being pushed in the attachment timeline part of the readAnimation function.
