### PR TITLE
Fix a few Lua animation problems

### DIFF
--- a/spine-lua/Animation.lua
+++ b/spine-lua/Animation.lua
@@ -372,7 +372,7 @@ function Animation.ColorTimeline.new ()
 		local b = lastFrameB + (frames[frameIndex + FRAME_B] - lastFrameB) * percent
 		local a = lastFrameA + (frames[frameIndex + FRAME_A] - lastFrameA) * percent
 		if alpha < 1 then
-			slot:setColor(slot.r + (r - color.r) * alpha, slot.g + (g - color.g) * alpha, slot.b + (b - color.b) * alpha, slot.a + (a - color.a) * alpha)
+			slot:setColor(slot.r + (r - slot.r) * alpha, slot.g + (g - slot.g) * alpha, slot.b + (b - slot.b) * alpha, slot.a + (a - slot.a) * alpha)
 		else
 			slot:setColor(r, g, b, a)
 		end


### PR DESCRIPTION
Hey Nathan, 
  a couple of more quick fixes:
1) A probable typo in ColorTimeline:Apply, when alpha is < 1, you were using variable `color` to calculate the final color which isn't defined anywhere in the file (eg. Lua treats it as a global) when it most likely needs to be `slot`. 
2) When animation duration is 0 (eg. when all timelines have a duration of 0), it used to cause an infinite loop in binarysearch. This is because Lua treats 0 as a truthy value and `value % 0` equals -INF, causing the binarysearch never to finish. This is now fixed by making sure the duration is greater than 0 before calculating `time = time % duration`, due to it being the least surprising place to put it in. However, it has some issues - blending to such an animation for example - but I thought the least surprising way was better than anything else that I could think of like forcing duration to be >0 when loading it.  Let me know if you'd prefer another kind of a solution, I'd be happy to implement it your way.

Thanks again,
  Matias
