### PR TITLE
XNA RenderTarget2D Fix

### DIFF
--- a/spine-xna/src/Util.cs
+++ b/spine-xna/src/Util.cs
@@ -80,7 +80,7 @@ namespace Spine {
       			// So instead of using this directly, we create a non-voliate Texture2D.
       			// This is computationally slower, but should be safe as long as it is done
       			// on load.
-      			Texture2D resultTexture = new Texture2D(device, (int)file.Width, (int)file.Height);
+      			Texture2D resultTexture = new Texture2D(device, file.Width, file.Height);
       			Color[] resultContent = new Color[Convert.ToInt32(file.Width * file.Height)];
       			result.GetData(resultContent);
       			resultTexture.SetData(resultContent);


### PR DESCRIPTION
RenderTarget2D is volatile. This means when there is any change to screen resolution, the content will be lost. In games, this is very common when changing to full-screen, alt+tab from/to full-screen, screensaver activation, and locking/unlocking the computer. This is easily fixed by creating a Texture2D and directly setting the content of the texture.
