### PR TITLE
Ensured MonoGame compatibility for Windows 8 Store Apps.

### DIFF
--- a/spine-csharp/src/Atlas.cs
+++ b/spine-csharp/src/Atlas.cs
@@ -26,12 +26,42 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
+#if WINDOWS_STOREAPP
+using System.Threading.Tasks;
+using Windows.Storage;
+#endif
+
 namespace Spine {
-	public class Atlas {
+    public class Atlas {
 		List<AtlasPage> pages = new List<AtlasPage>();
 		List<AtlasRegion> regions = new List<AtlasRegion>();
 		TextureLoader textureLoader;
 
+#if WINDOWS_STOREAPP
+        private async Task ReadFile(string path, TextureLoader textureLoader)
+        {
+            var folder = Windows.ApplicationModel.Package.Current.InstalledLocation;
+
+            var file = await folder.GetFileAsync(path).AsTask().ConfigureAwait(false);
+
+            using (var reader = new StreamReader(await file.OpenStreamForReadAsync().ConfigureAwait(false)))
+            {
+                try
+                {
+                    Load(reader, Path.GetDirectoryName(path), textureLoader);
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception("Error reading atlas file: " + path, ex);
+                }
+            }
+        }
+
+        public Atlas(String path, TextureLoader textureLoader)
+        {
+            this.ReadFile(path, textureLoader).Wait();
+        }
+#else
 		public Atlas (String path, TextureLoader textureLoader) {
 			using (StreamReader reader = new StreamReader(path)) {
 				try {
@@ -41,8 +71,9 @@ namespace Spine {
 				}
 			}
 		}
+#endif
 
-		public Atlas (TextReader reader, String dir, TextureLoader textureLoader) {
+        public Atlas (TextReader reader, String dir, TextureLoader textureLoader) {
 			Load(reader, dir, textureLoader);
 		}
 

--- a/spine-csharp/src/SkeletonJson.cs
+++ b/spine-csharp/src/SkeletonJson.cs
@@ -27,8 +27,13 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 
+#if WINDOWS_STOREAPP
+using System.Threading.Tasks;
+using Windows.Storage;
+#endif
+
 namespace Spine {
-	public class SkeletonJson {
+    public class SkeletonJson {
 		static public String TIMELINE_SCALE = "scale";
 		static public String TIMELINE_ROTATE = "rotate";
 		static public String TIMELINE_TRANSLATE = "translate";
@@ -51,7 +56,26 @@ namespace Spine {
 			this.attachmentLoader = attachmentLoader;
 			Scale = 1;
 		}
+#if WINDOWS_STOREAPP
+        private async Task<SkeletonData> ReadFile(string path)
+        {
+            var folder = Windows.ApplicationModel.Package.Current.InstalledLocation;
 
+            var file = await folder.GetFileAsync(path).AsTask().ConfigureAwait(false);
+
+            using (var reader = new StreamReader(await file.OpenStreamForReadAsync().ConfigureAwait(false)))
+            {
+                SkeletonData skeletonData = ReadSkeletonData(reader);
+                skeletonData.Name = Path.GetFileNameWithoutExtension(path);
+                return skeletonData;
+            }
+        }
+
+		public SkeletonData ReadSkeletonData (String path)
+		{
+		    return this.ReadFile(path).Result;
+		}
+#else
 		public SkeletonData ReadSkeletonData (String path) {
 			using (StreamReader reader = new StreamReader(path)) {
 				SkeletonData skeletonData = ReadSkeletonData(reader);
@@ -60,6 +84,7 @@ namespace Spine {
 			}
 		}
 
+#endif
 		public SkeletonData ReadSkeletonData (TextReader reader) {
 			if (reader == null) throw new ArgumentNullException("reader cannot be null.");
 

--- a/spine-xna/src/Util.cs
+++ b/spine-xna/src/Util.cs
@@ -28,8 +28,36 @@ using System.IO;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
+#if WINDOWS_STOREAPP
+using System.Threading.Tasks;
+using Windows.Storage;
+#endif
+
 namespace Spine {
-	static public class Util {
+
+    static public class Util {
+#if WINDOWS_STOREAPP
+		private static async Task<Texture2D> LoadFile(GraphicsDevice device, String path)
+        {
+            var folder = Windows.ApplicationModel.Package.Current.InstalledLocation;
+
+            var file = await folder.GetFileAsync(path).AsTask().ConfigureAwait(false);
+
+            try
+            {
+                return Util.LoadTexture(device, await file.OpenStreamForReadAsync().ConfigureAwait(false));
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Error reading texture file: " + path, ex);
+            }
+        }
+
+        static public Texture2D LoadTexture (GraphicsDevice device, String path)
+        {
+            return LoadFile(device, path).Result;
+		}
+#else
 		static public Texture2D LoadTexture (GraphicsDevice device, String path) {
 			using (Stream input = new FileStream(path, FileMode.Open, FileAccess.Read)) {
 				try {
@@ -40,6 +68,7 @@ namespace Spine {
 			}
 		}
 
+#endif
 		static public Texture2D LoadTexture (GraphicsDevice device, Stream input) {
 			Texture2D file = Texture2D.FromStream(device, input);
 


### PR DESCRIPTION
The security is such that you cannot load from a stream in the 'normal .net way' - you must instead use specific Windows.Storage methods.
