### PR TITLE
Project added for building MonoGame apps for the Windows8 Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ forums
 spine-csharp/bin
 spine-csharp/obj
 
+spine-monogame-windows8-store/src/bin
+spine-monogame-windows8-store/src/obj
+
 spine-xna/bin
 spine-xna/obj
 spine-xna/example/bin

--- a/spine-monogame-windows8-store/src/Properties/AssemblyInfo.cs
+++ b/spine-monogame-windows8-store/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,29 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SpineMonogameWindows8Store")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SpineMonogameWindows8Store")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: ComVisible(false)]

--- a/spine-monogame-windows8-store/src/SpineMonogameWindows8Store.csproj
+++ b/spine-monogame-windows8-store/src/SpineMonogameWindows8Store.csproj
@@ -1,0 +1,208 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{8E5BAEE2-8CCC-4A32-8BCF-5FF438056C0E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SpineMonogameWindows8Store</RootNamespace>
+    <AssemblyName>SpineMonogameWindows8Store</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{BC8A1FFA-BEE3-4634-8014-F334798102B3};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;NETFX_CORE;WINDOWS_STOREAPP</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ARM\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+    <OutputPath>bin\ARM\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>ARM</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NETFX_CORE</DefineConstants>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE;NETFX_CORE</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoWarn>;2008</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
+    <Reference Include="MonoGame.Framework">
+      <HintPath>$(MSBuildExtensionsPath)\..\MonoGame\v3.0\Assemblies\Windows8\MonoGame.Framework.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX">
+      <HintPath>$(MSBuildExtensionsPath)\..\MonoGame\v3.0\Assemblies\Windows8\SharpDX.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX.XInput">
+      <HintPath>$(MSBuildExtensionsPath)\..\MonoGame\v3.0\Assemblies\Windows8\SharpDX.XInput.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX.Direct2D1">
+      <HintPath>$(MSBuildExtensionsPath)\..\MonoGame\v3.0\Assemblies\Windows8\SharpDX.Direct2D1.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX.Direct3D11">
+      <HintPath>$(MSBuildExtensionsPath)\..\MonoGame\v3.0\Assemblies\Windows8\SharpDX.Direct3D11.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX.DXGI">
+      <HintPath>$(MSBuildExtensionsPath)\..\MonoGame\v3.0\Assemblies\Windows8\SharpDX.DXGI.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX.MediaFoundation">
+      <HintPath>$(MSBuildExtensionsPath)\..\MonoGame\v3.0\Assemblies\Windows8\SharpDX.MediaFoundation.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpDX.XAudio2">
+      <HintPath>$(MSBuildExtensionsPath)\..\MonoGame\v3.0\Assemblies\Windows8\SharpDX.XAudio2.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\spine-csharp\src\Animation.cs">
+      <Link>spine-csharp\Animation.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\AnimationState.cs">
+      <Link>spine-csharp\AnimationState.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\AnimationStateData.cs">
+      <Link>spine-csharp\AnimationStateData.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\Atlas.cs">
+      <Link>spine-csharp\Atlas.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\Attachments\AtlasAttachmentLoader.cs">
+      <Link>spine-csharp\Attachments\AtlasAttachmentLoader.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\Attachments\Attachment.cs">
+      <Link>spine-csharp\Attachments\Attachment.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\Attachments\AttachmentLoader.cs">
+      <Link>spine-csharp\Attachments\AttachmentLoader.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\Attachments\AttachmentType.cs">
+      <Link>spine-csharp\Attachments\AttachmentType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\Attachments\RegionAttachment.cs">
+      <Link>spine-csharp\Attachments\RegionAttachment.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\Bone.cs">
+      <Link>spine-csharp\Bone.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\BoneData.cs">
+      <Link>spine-csharp\BoneData.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\Json.cs">
+      <Link>spine-csharp\Json.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\Skeleton.cs">
+      <Link>spine-csharp\Skeleton.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\SkeletonData.cs">
+      <Link>spine-csharp\SkeletonData.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\SkeletonJson.cs">
+      <Link>spine-csharp\SkeletonJson.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\Skin.cs">
+      <Link>spine-csharp\Skin.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\Slot.cs">
+      <Link>spine-csharp\Slot.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-csharp\src\SlotData.cs">
+      <Link>spine-csharp\SlotData.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-xna\src\SkeletonRenderer.cs">
+      <Link>spine-xna\SkeletonRenderer.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-xna\src\SpriteBatcher.cs">
+      <Link>spine-xna\SpriteBatcher.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-xna\src\Util.cs">
+      <Link>spine-xna\Util.cs</Link>
+    </Compile>
+    <Compile Include="..\..\spine-xna\src\XnaTextureLoader.cs">
+      <Link>spine-xna\XnaTextureLoader.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '11.0' ">
+    <VisualStudioVersion>11.0</VisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
I have created a (VS2012) project for a Windows Store Library for use with MonoGame.  There are no new code files because the project will simply link to all the source files in the spine-csharp and spine-xna folders.  Therefore any changes to these source files will be automatically picked up by this project.  Any new source files for future runtime features will have to be added to the project however this can be done as and when required via a pull request.

I thought this would be useful for MonoGame developers as they won't have to create the project files themselves.  

If you are happy with this approach then I'll also send a PR for a XamarinStudio project file for iOS MonoGame developers.
