### PR TITLE
Update Example: Positioning of Skeleton

### DIFF
--- a/spine-xna/example/src/ExampleGame.cs
+++ b/spine-xna/example/src/ExampleGame.cs
@@ -78,8 +78,8 @@ namespace Spine {
 			state.AddAnimation("jump", false);
 			state.AddAnimation("walk", true);
 
-			skeleton.RootBone.X = 320;
-			skeleton.RootBone.Y = 440;
+			skeleton.X = 320;
+			skeleton.Y = 440;
 			skeleton.UpdateWorldTransform();
 		}
 


### PR DESCRIPTION
Hey Nathan, you recently wrote:

If you apply an animation that keys the root bone position, the root bone will be set to the value from the animation. You can move the root bone after you apply the animation. Ideally though, you don't use the root bone to position the skeleton. The new and better way to position a skeleton is by setting the x and y fields on the skeleton.

So I figured it would be nice to adapt the example accordingly.

Best regards, Marvin
