### PR TITLE
Prevent mesh from temporary disappearing in Unity Editor

### DIFF
--- a/spine-tk2d/Code/tk2dSpineSkeleton.cs
+++ b/spine-tk2d/Code/tk2dSpineSkeleton.cs
@@ -139,6 +139,9 @@ public class tk2dSpineSkeleton : MonoBehaviour, tk2dRuntime.ISpriteCollectionFor
 			if (attachment is RegionAttachment) quadCount++;
 		}
 		
+#if UNITY_EDITOR
+		if (mesh.subMeshCount == submeshIndices.Count)
+#endif
 		if (quadCount == cachedQuadCount) return;
 		
 		cachedQuadCount = quadCount;


### PR DESCRIPTION
After changing code or assets, skeleton mesh will disappear until game starts.
