### PR TITLE
Fixed toColor function returning NaN

### DIFF
--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -1,4 +1,3 @@
-
 var spine = {};
 
 spine.BoneData = function (name, parent) {
@@ -1078,7 +1077,7 @@ spine.SkeletonJson.readCurve = function (timeline, frameIndex, valueMap) {
 };
 spine.SkeletonJson.toColor = function (hexString, colorIndex) {
 	if (hexString.length != 8) throw "Color hexidecimal length must be 8, recieved: " + hexString;
-	return parseInt(hexString.substring(colorIndex * 2, 2), 16) / 255;
+	return parseInt(hexString.substring(colorIndex * 2, (colorIndex * 2)+2), 16) / 255;
 };
 
 spine.Atlas = function (atlasText, textureLoader) {


### PR DESCRIPTION
I've tested the 'toColor' function with the rgba hex 'FFFFFF00'.
The returned result (in r,g,b,a) was 1,NaN,1,257.
The correct result should obviously be 1,1,1,0.
The hex substring was being done incorrectly.
