### PR TITLE
Combined two similar ifs to one with xor

### DIFF
--- a/spine-csharp/src/Bone.cs
+++ b/spine-csharp/src/Bone.cs
@@ -87,11 +87,7 @@ namespace Spine {
 				M00 = -M00;
 				M01 = -M01;
 			}
-			if (flipY) {
-				M10 = -M10;
-				M11 = -M11;
-			}
-			if (yDown) {
+			if (flipY ^ yDown) {
 				M10 = -M10;
 				M11 = -M11;
 			}


### PR DESCRIPTION
There is no need for the two ifs to exist. If both `flipY` and `yDown` are `true` then there will be no effect because of the double negation. This way with XOR the if will execute only if one of the two is true, but not both.
