### PR TITLE
Fixed ColorTimeline.setFrame bug

### DIFF
--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -389,7 +389,7 @@ spine.ColorTimeline.prototype = {
 	getFrameCount: function () {
 		return this.frames.length / 2;
 	},
-	setFrame: function (frameIndex, time, x, y) {
+	setFrame: function (frameIndex, time, r, g, b, a) {
 		frameIndex *= 5;
 		this.frames[frameIndex] = time;
 		this.frames[frameIndex + 1] = r;


### PR DESCRIPTION
".. x, y)" should be ".. r, g, b, a)"
