### PR TITLE
Issue #100 Used the AtlasRegion page RenderObject as the Texture2D to draw the skeleton with

### DIFF
--- a/spine-xna/src/SkeletonRenderer.cs
+++ b/spine-xna/src/SkeletonRenderer.cs
@@ -77,7 +77,8 @@ namespace Spine {
 				RegionAttachment regionAttachment = slot.Attachment as RegionAttachment;
 				if (regionAttachment != null) {
 					SpriteBatchItem item = batcher.CreateBatchItem();
-					item.Texture = (Texture2D)regionAttachment.RendererObject;
+					AtlasRegion region = (AtlasRegion)regionAttachment.RendererObject;
+					item.Texture = (Texture2D)region.page.rendererObject;
 
 					byte r = (byte)(skeleton.R * slot.R * 255);
 					byte g = (byte)(skeleton.G * slot.G * 255);


### PR DESCRIPTION
(Rather than the incorrect RegionAttachment RenderObject.)
