### PR TITLE
Keyable draw order for C# (pre-Events support)

### DIFF
--- a/spine-csharp/src/Animation.cs
+++ b/spine-csharp/src/Animation.cs
@@ -412,4 +412,43 @@ namespace Spine {
 				 attachmentName == null ? null : skeleton.GetAttachment(SlotIndex, attachmentName);
 		}
 	}
+	
+	public class DrawOrderTimeline : Timeline {
+		public float[] Frames { get; private set; } // time, ...
+		public int[][] DrawOrders { get; private set; }
+		public int FrameCount {
+			get {
+				return Frames.Length;
+			}
+		}
+
+		public DrawOrderTimeline (int frameCount) {
+			Frames = new float[frameCount];
+			DrawOrders = new int[frameCount][];
+		}
+
+		// Sets the time of the specified keyframe.
+		public void setFrame (int frameIndex, float time, int[] drawOrder) {
+			Frames[frameIndex] = time;
+			DrawOrders[frameIndex] = drawOrder;
+		}
+
+		public void Apply (Skeleton skeleton, float time, float alpha) {
+			float[] frames = Frames;
+			if (time < frames[0]) return; // Time is before first frame.
+
+			int frameIndex;
+			if (time >= frames[frames.Length - 1]) // Time is after last frame.
+				frameIndex = frames.Length - 1;
+			else
+				frameIndex = Animation.binarySearch(frames, time, 1) - 1;
+
+			List<Slot> drawOrder = skeleton.DrawOrder;
+			List<Slot> slots = skeleton.Slots;
+			int[] drawOrderToSetupIndex = DrawOrders[frameIndex];
+			for (int i = 0, n = drawOrderToSetupIndex.Length; i < n; i++)
+				drawOrder[i] = slots[  drawOrderToSetupIndex[i]  ];
+		}
+	}
+	
 }

--- a/spine-csharp/src/Skeleton.cs
+++ b/spine-csharp/src/Skeleton.cs
@@ -94,7 +94,10 @@ namespace Spine {
 				bones[i].SetToSetupPose();
 		}
 
-		public void SetSlotsToSetupPose () {
+		public void SetSlotsToSetupPose () {			
+			DrawOrder.Clear();
+			DrawOrder.AddRange(this.Slots);
+			
 			List<Slot> slots = this.Slots;
 			for (int i = 0, n = slots.Count; i < n; i++)
 				slots[i].SetToSetupPose(i);


### PR DESCRIPTION
Notes:
The JSON data loader needs review. This code hasn't caused any problems from my testing though.
Also note that the Apply method in the draw order timeline follows the pre-Events number of parameters. That needs to be changed when Events is implemented.

I'm on the fence about the SetSlotsToSetupPose bug being an actual bug. It's more like a design thing regarding the AnimationState convenience class and the behavior of the Spine objects in each specific runtime using AnimationState.
