### PR TITLE
update convenience constructors for CCSkeleton, CCSkeletonAnimation

### DIFF
--- a/spine-cocos2d-iphone/src/spine/CCSkeleton.m
+++ b/spine-cocos2d-iphone/src/spine/CCSkeleton.m
@@ -47,15 +47,15 @@
 @synthesize debugBones = _debugBones;
 
 + (id) skeletonWithData:(SkeletonData*)skeletonData ownsSkeletonData:(bool)ownsSkeletonData {
-	return [[[CCSkeleton alloc] initWithData:skeletonData ownsSkeletonData:ownsSkeletonData] autorelease];
+	return [[[self alloc] initWithData:skeletonData ownsSkeletonData:ownsSkeletonData] autorelease];
 }
 
 + (id) skeletonWithFile:(NSString*)skeletonDataFile atlas:(Atlas*)atlas scale:(float)scale {
-	return [[[CCSkeleton alloc] initWithFile:skeletonDataFile atlas:atlas scale:scale] autorelease];
+	return [[[self alloc] initWithFile:skeletonDataFile atlas:atlas scale:scale] autorelease];
 }
 
 + (id) skeletonWithFile:(NSString*)skeletonDataFile atlasFile:(NSString*)atlasFile scale:(float)scale {
-	return [[[CCSkeleton alloc] initWithFile:skeletonDataFile atlasFile:atlasFile scale:scale] autorelease];
+	return [[[self alloc] initWithFile:skeletonDataFile atlasFile:atlasFile scale:scale] autorelease];
 }
 
 - (void) initialize:(SkeletonData*)skeletonData ownsSkeletonData:(bool)ownsSkeletonData {

--- a/spine-cocos2d-iphone/src/spine/CCSkeletonAnimation.m
+++ b/spine-cocos2d-iphone/src/spine/CCSkeletonAnimation.m
@@ -43,15 +43,15 @@
 @synthesize states = _states;
 
 + (id) skeletonWithData:(SkeletonData*)skeletonData ownsSkeletonData:(bool)ownsSkeletonData {
-	return [[[CCSkeletonAnimation alloc] initWithData:skeletonData ownsSkeletonData:ownsSkeletonData] autorelease];
+	return [[[self alloc] initWithData:skeletonData ownsSkeletonData:ownsSkeletonData] autorelease];
 }
 
 + (id) skeletonWithFile:(NSString*)skeletonDataFile atlas:(Atlas*)atlas scale:(float)scale {
-	return [[[CCSkeletonAnimation alloc] initWithFile:skeletonDataFile atlas:atlas scale:scale] autorelease];
+	return [[[self alloc] initWithFile:skeletonDataFile atlas:atlas scale:scale] autorelease];
 }
 
 + (id) skeletonWithFile:(NSString*)skeletonDataFile atlasFile:(NSString*)atlasFile scale:(float)scale {
-	return [[[CCSkeletonAnimation alloc] initWithFile:skeletonDataFile atlasFile:atlasFile scale:scale] autorelease];
+	return [[[self alloc] initWithFile:skeletonDataFile atlasFile:atlasFile scale:scale] autorelease];
 }
 
 - (void) initialize {


### PR DESCRIPTION
We should use "self" instead of CCSkeleton._, because the are lot situations, when we want to implement child of CCSkeleton._. And we want to init childOfCCCkeleton.\* using given convenience constructors.

I mean, when we creating childOfCCCkeleton, we want it to be childOfCCCkeleton, not CCCkeleton. 

P. S. sorry for my english. 
