### PR TITLE
Break a looping animation when a new animation is added after it.

### DIFF
--- a/spine-c/src/spine/AnimationState.c
+++ b/spine-c/src/spine/AnimationState.c
@@ -82,6 +82,7 @@ void AnimationState_addAnimation (AnimationState* self, Animation* animation, in
 		while (existingEntry->next)
 			existingEntry = existingEntry->next;
 		existingEntry->next = entry;
+        existingEntry->loop = 0;
 		previousAnimation = existingEntry->animation;
 	} else {
 		internal->queue = entry;


### PR DESCRIPTION
If a looping animation is set then any following animation added will never get played unless the loop property of the last animation is set to false.

This change explicitly sets the loop property of the last entry to false when adding an animation.
