### PR TITLE
fix first event not firing and flagging second event as fired

### DIFF
--- a/spine-c/src/spine/Animation.c
+++ b/spine-c/src/spine/Animation.c
@@ -532,16 +532,19 @@ void _EventTimeline_apply (const Timeline* timeline, Skeleton* skeleton, float l
 		frameIndex = 0;
 	else {
 		float frame;
-		frameIndex = binarySearch(self->frames, self->framesLength, lastTime, 1);
+		frameIndex = binarySearch(self->frames, self->framesLength, lastTime, 1)-1;
 		frame = self->frames[frameIndex];
 		while (frameIndex > 0) {
-			float lastFrame = self->frames[frameIndex - 1];
+			float lastFrame = self->frames[frameIndex];
 			/* Fire multiple events with the same frame and events that occurred at lastTime. */
 			if (lastFrame != frame && lastFrame != lastTime) break;
 			frameIndex--;
 		}
 	}
 	for (; frameIndex < self->framesLength && time > self->frames[frameIndex]; frameIndex++) {
+        if(self->frames[frameIndex] < lastTime) // exclude events that were fired previously.
+            continue;
+        
 		firedEvents[*eventCount] = self->events[frameIndex];
 		(*eventCount)++;
 	}


### PR DESCRIPTION
I've been playing with events in cocos2d-iphone runtime, and found a bug when an animation has more than one event in the timeline, the first event firing was flagging the second event as fired, causing it not to fire at all.

Just noticed you might have been working on fixing something similar today.

Maybe something useful here is still merge-able without too much hassle though.  Not sure.

Notes: 
1. When there are 2 events, the binarySearch method was returning 1 which was not the correct frameIndex for the first event.   Fixed by making frameIndex a zero based index.
2. upon fixing that, firedEvents was being populated with _all_ previous events every time it was applied to the timeline, so I added something to skip over the stuff that had already been fired... this could probably be done more optimally by just starting the loop in the right place to begin with.  I didn't try to optimize this.
3. I don't really understand what the loop in the middle is doing, so I tried to modify it as little as possible.

Tested with 1, 2, and 3 events in various animations.
