### PR TITLE
Fixed bug that prevented the first skin (skin 0) from displaying properly

### DIFF
--- a/spine-tk2d/Assets/Spine/Editor/SkeletonAnimationInspector.cs
+++ b/spine-tk2d/Assets/Spine/Editor/SkeletonAnimationInspector.cs
@@ -60,9 +60,9 @@ public class SkeletonAnimationInspector : Editor {
 		
 		if (component.skeleton != null) {
 			// Initial skin name.
-			String[] skins = new String[component.skeleton.Data.Skins.Count + 1];
+			String[] skins = new String[component.skeleton.Data.Skins.Count];
 			int skinIndex = 0;
-			for (int i = 0; i < skins.Length - 1; i++) {
+			for (int i = 0; i < skins.Length; i++) {
 				String name = component.skeleton.Data.Skins[i].Name;
 				skins[i] = name;
 				if (name == initialSkinName.stringValue)
@@ -76,7 +76,7 @@ public class SkeletonAnimationInspector : Editor {
 			EditorGUIUtility.LookLikeInspector();
 			EditorGUILayout.EndHorizontal();
 		
-			initialSkinName.stringValue = skinIndex == 0 ? null : skins[skinIndex];
+			initialSkinName.stringValue = skins[skinIndex];
 
 			// Animation name.
 			String[] animations = new String[component.skeleton.Data.Animations.Count + 2];

--- a/spine-tk2d/Assets/Spine/Editor/SkeletonComponentInspector.cs
+++ b/spine-tk2d/Assets/Spine/Editor/SkeletonComponentInspector.cs
@@ -56,9 +56,9 @@ public class SkeletonComponentInspector : Editor {
 		
 		if (component.skeleton != null) {
 			// Initial skin name.
-			String[] skins = new String[component.skeleton.Data.Skins.Count + 1];
+			String[] skins = new String[component.skeleton.Data.Skins.Count];
 			int skinIndex = 0;
-			for (int i = 0; i < skins.Length - 1; i++) {
+			for (int i = 0; i < skins.Length; i++) {
 				String name = component.skeleton.Data.Skins[i].Name;
 				skins[i] = name;
 				if (name == initialSkinName.stringValue)
@@ -72,7 +72,7 @@ public class SkeletonComponentInspector : Editor {
 			EditorGUIUtility.LookLikeInspector();
 			EditorGUILayout.EndHorizontal();
 		
-			initialSkinName.stringValue = skinIndex == 0 ? null : skins[skinIndex];
+			initialSkinName.stringValue = skins[skinIndex];
 		}
 
 		EditorGUILayout.PropertyField(timeScale);


### PR DESCRIPTION
Hi,

I think the intention was to display an extra entry in the skins dropdown of the SkeletonComponent and SkeletonAnimation inspectors. However, the extra entry is not at all necessary it seems, so I modified the code to make the skin selection work.

Cheers,

hourglasseye
