### PR TITLE
Fixed file loading for XNA on Windows Phone 7.

### DIFF
--- a/spine-csharp/src/Atlas.cs
+++ b/spine-csharp/src/Atlas.cs
@@ -34,6 +34,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 
 #if WINDOWS_STOREAPP
 using System.Threading.Tasks;
@@ -64,7 +65,14 @@ namespace Spine {
 		}
 #else
 		public Atlas (String path, TextureLoader textureLoader) {
-			using (StreamReader reader = new StreamReader(path)) {
+
+#if WINDOWS_PHONE
+            Stream stream = Microsoft.Xna.Framework.TitleContainer.OpenStream(path);
+            using (StreamReader reader = new StreamReader(stream))
+            {
+#else
+            using (StreamReader reader = new StreamReader(path)) {
+#endif
 				try {
 					Load(reader, Path.GetDirectoryName(path), textureLoader);
 				} catch (Exception ex) {

--- a/spine-csharp/src/SkeletonJson.cs
+++ b/spine-csharp/src/SkeletonJson.cs
@@ -80,8 +80,14 @@ namespace Spine {
 		}
 #else
 		public SkeletonData ReadSkeletonData (String path) {
-			using (StreamReader reader = new StreamReader(path)) {
-				SkeletonData skeletonData = ReadSkeletonData(reader);
+#if WINDOWS_PHONE
+            Stream stream = Microsoft.Xna.Framework.TitleContainer.OpenStream(path);
+            using (StreamReader reader = new StreamReader(stream))
+            {
+#else
+            using (StreamReader reader = new StreamReader(path)) {
+#endif
+                SkeletonData skeletonData = ReadSkeletonData(reader);
 				skeletonData.name = Path.GetFileNameWithoutExtension(path);
 				return skeletonData;
 			}

--- a/spine-xna/src/Util.cs
+++ b/spine-xna/src/Util.cs
@@ -60,7 +60,14 @@ namespace Spine {
 		}
 #else
 		static public Texture2D LoadTexture (GraphicsDevice device, String path) {
-			using (Stream input = new FileStream(path, FileMode.Open, FileAccess.Read)) {
+
+#if WINDOWS_PHONE
+            Stream stream = Microsoft.Xna.Framework.TitleContainer.OpenStream(path);
+            using (Stream input = stream)
+            {
+#else
+            using (Stream input = new FileStream(path, FileMode.Open, FileAccess.Read)) {
+#endif
 				try {
 					return Util.LoadTexture(device, input);
 				} catch (Exception ex) {


### PR DESCRIPTION
I've fixed the file loading for XNA when using Windows Phone 7 by using TitleContainer. I've also put the code inside a cross platform conditional statement which is used by default by Windows Phone projects. Hope this helps some.
