### PR TITLE
Fix all Corona examples to run

### DIFF
--- a/spine-corona/examples/dragon.lua
+++ b/spine-corona/examples/dragon.lua
@@ -23,7 +23,7 @@ skeleton:setToSetupPose()
 local stateData = spine.AnimationStateData.new(skeletonData)
 -- AnimationState has a queue of animations and can apply them with crossfading.
 local state = spine.AnimationState.new(stateData)
-state:setAnimation("flying", true)
+state:setAnimationByName(0, "flying", true, 0)
 
 local lastTime = 0
 local animationTime = 0

--- a/spine-corona/examples/goblins.lua
+++ b/spine-corona/examples/goblins.lua
@@ -22,7 +22,7 @@ skeleton:setToSetupPose() -- Required after changing skin to attach attachments 
 -- AnimationState has a queue of animations and can apply them with crossfading.
 local stateData = spine.AnimationStateData.new(skeletonData)
 local state = spine.AnimationState.new(stateData)
-state:setAnimation("walk", true)
+state:setAnimationByName(0, "walk", true, 0)
 
 local lastTime = 0
 local animationTime = 0


### PR DESCRIPTION
I switched so that all Corona examples use setAnimationByName instead of setAnimation. Without this fix, the goblin and dragon examples failed with the following error:

Runtime error
...e-runtimes/spine-corona/spine-lua/AnimationState.lua:171: attempt to index local 'animation' (a boolean value)
stack traceback:
    [C]: ?
    ...e-runtimes/spine-corona/spine-lua/AnimationState.lua:171: in function 'setAnimation'
    ...ona/spine-runtimes/spine-corona/examples/goblins.lua:25: in main chunk
    [C]: in function 'require'
    ?: in function <?:982>
    (tail call): ?
    ...nts/code/corona/spine-runtimes/spine-corona/main.lua:3: in main chunk
