### PR TITLE
Fixed a bug in SkeletonComponent with submeshes

### DIFF
--- a/spine-unity/Assets/Spine/SkeletonComponent.cs
+++ b/spine-unity/Assets/Spine/SkeletonComponent.cs
@@ -131,6 +131,7 @@ public class SkeletonComponent : MonoBehaviour {
 		int quadCount = 0, submeshQuadCount = 0;
 		Material lastMaterial = null;
 		submeshMaterials.Clear();
+		submeshes.Clear();
 		List<Slot> drawOrder = skeleton.DrawOrder;
 		for (int i = 0, n = drawOrder.Count; i < n; i++) {
 			RegionAttachment regionAttachment = drawOrder[i].Attachment as RegionAttachment;


### PR DESCRIPTION
Fixed a bug in SkeletonComponent where the submesh count wasn't properly initialized and there were more submeshes than submeshMaterials
