### PR TITLE
changed texture loaded to pass the current context.

### DIFF
--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -1451,7 +1451,7 @@ spine.Atlas = function (atlasText, textureLoader) {
 			else if (direction == "xy")
 				page.uWrap = page.vWrap = spine.Atlas.TextureWrap.repeat;
 
-			textureLoader.load(page, line);
+			textureLoader.load(page, line, this);
 
 			this.pages.push(page);
 


### PR DESCRIPTION
An issue I was having with the texture loader is that the callback expects there to be an atlas object available, much like in the turbulenz example:

https://github.com/EsotericSoftware/spine-runtimes/blob/master/spine-js/turbulenz/index.html#L49

In the example, the atlas object exists because it is part of an ajax callback, so the rest of the code has had time to run. I've been working on using Spine with MelonJS, a canvas based game framework. The idea with Melon is to typically load all your necessary resources at the loading screen, and simply refer to them when you need it. So I made this change here to just simply pass the atlas object to the loader.
