### PR TITLE
Changed Batch to SpriteBatch

### DIFF
--- a/spine-libgdx/src/com/esotericsoftware/spine/SkeletonRenderer.java
+++ b/spine-libgdx/src/com/esotericsoftware/spine/SkeletonRenderer.java
@@ -38,7 +38,7 @@ import com.esotericsoftware.spine.attachments.RegionAttachment;
 
 import com.badlogic.gdx.graphics.GL11;
 import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.PolygonSpriteBatch;
 import com.badlogic.gdx.utils.Array;
 
@@ -82,7 +82,7 @@ public class SkeletonRenderer {
 		}
 	}
 
-	public void draw (Batch batch, Skeleton skeleton) {
+	public void draw (SpriteBatch batch, Skeleton skeleton) {
 		boolean premultipliedAlpha = this.premultipliedAlpha;
 		int srcFunc = premultipliedAlpha ? GL11.GL_ONE : GL11.GL_SRC_ALPHA;
 		batch.setBlendFunction(srcFunc, GL11.GL_ONE_MINUS_SRC_ALPHA);


### PR DESCRIPTION
I am not sure the issue here and I apologize that I am fairly new to Github. But when trying to compile the Spine libGDX runtime last night I noticed this error.

Very simple fix just change  Batch  to  SpriteBatch  at lines 41 and 85

I think the new libGDX gets rid of the having a public Batch class so you use SpriteBatch. If this is not the case, please let me know! Thanks :)
