### PR TITLE
Update README.md

### DIFF
--- a/spine-unity/README.md
+++ b/spine-unity/README.md
@@ -17,3 +17,4 @@ The Spine runtime for Unity comes with an example project which has "spineboy" w
 
 - Atlas images should use premultiplied alpha.
 - Unity scales large images down by default if they exceed 1024x1024, which causes the atlas coordinates to be incorrect. To fix this, override the import settings in the Inspector for any large atlas image you have so Unity does not scale it down.
+- Unity 4.3+'s 2D Project defaults causes (atlas) images added to the project to be imported with the Texture Type "Sprite", which may cause artifacts when using Spine's Skeleton shader. To avoid these artifacts, make sure the Texture Type is set to "Texture".


### PR DESCRIPTION
Warning about possible artifacts when using Unity 4.3's default 2D Project import settings (new "Sprite" texture type) and recommended fix.
