### PR TITLE
AnimationState C# events subscription

### DIFF
--- a/spine-csharp/src/AnimationState.cs
+++ b/spine-csharp/src/AnimationState.cs
@@ -41,14 +41,14 @@ namespace Spine {
 		public float TimeScale { get { return timeScale; } set { timeScale = value; } }
 
 		public delegate void StartEndDelegate(AnimationState state, int trackIndex);
-	    public StartEndDelegate Start;
-	    public StartEndDelegate End;
+	    public event StartEndDelegate Start;
+	    public event StartEndDelegate End;
 
 		public delegate void EventDelegate(AnimationState state, int trackIndex, Event e);
-		public EventDelegate Event;
+		public event EventDelegate Event;
 		
 		public delegate void CompleteDelegate(AnimationState state, int trackIndex, int loopCount);
-		public CompleteDelegate Complete;
+		public event CompleteDelegate Complete;
 
 		public AnimationState (AnimationStateData data) {
 			if (data == null) throw new ArgumentNullException("data cannot be null.");
@@ -262,10 +262,10 @@ namespace Spine {
 		public float TimeScale { get { return timeScale; } set { timeScale = value; } }
 		public bool Loop { get { return loop; } set { loop = value; } }
 		
-	    public AnimationState.StartEndDelegate Start;
-	    public AnimationState.StartEndDelegate End;
-		public AnimationState.EventDelegate Event;
-		public AnimationState.CompleteDelegate Complete;
+	    public event AnimationState.StartEndDelegate Start;
+	    public event AnimationState.StartEndDelegate End;
+		public event AnimationState.EventDelegate Event;
+		public event AnimationState.CompleteDelegate Complete;
 
 		internal void OnStart (AnimationState state, int index) {
 			if (Start != null) Start(state, index);


### PR DESCRIPTION
Using the "event" keyword DOESN'T require the use of EventArgs derived classes as part of the method signature.

Events provide a (standard) layer of safety by preventing the nulling or complete reassignment.
It restricts external class interaction with the event to subscription with the += operator and unsubscription with the -= operator. This prevents bugs caused by unrelated objects accidentally unsubscribing other objects from the event.

The null check is still required though.

For people who followed the examples, worked with the original events and only used += to subscribe to events, this change shouldn't affect client code at all.
