### PR TITLE
Wrong type for rgba

### DIFF
--- a/spine-as3/spine-as3/src/spine/Skeleton.as
+++ b/spine-as3/spine-as3/src/spine/Skeleton.as
@@ -35,10 +35,10 @@ public class Skeleton {
 	internal var _slots:Vector.<Slot>;
 	internal var _drawOrder:Vector.<Slot>;
 	internal var _skin:Skin;
-	public var r:int = 1;
-	public var g:int = 1;
-	public var b:int = 1;
-	public var a:int = 1;
+	public var r:Number = 1;
+	public var g:Number = 1;
+	public var b:Number = 1;
+	public var a:Number = 1;
 	public var time:Number;
 	public var flipX:Boolean;
 	public var flipY:Boolean;


### PR DESCRIPTION
Hi,

I think you did a typo. From my understanding of the code, the RGBA value should be numbers, not it (as they are in the RegionAttachement class).

Thanks for the tool.
