### PR TITLE
Allow Skin.AddAttachment (C#) to overwrite safely

### DIFF
--- a/spine-csharp/src/Skin.cs
+++ b/spine-csharp/src/Skin.cs
@@ -45,7 +45,7 @@ namespace Spine {
 
 		public void AddAttachment (int slotIndex, String name, Attachment attachment) {
 			if (attachment == null) throw new ArgumentNullException("attachment cannot be null.");
-			attachments.Add(new KeyValuePair<int, String>(slotIndex, name), attachment);
+			attachments[new KeyValuePair<int, String>(slotIndex, name)] = attachment;
 		}
 
 		/// <returns>May be null.</returns>


### PR DESCRIPTION
Allow Skin.AddAttachment to overwrite an existing attachment (overwrite an existing entry in the Dictionary) as intended.

( For more info, see the Remarks section of: http://msdn.microsoft.com/en-us/library/k7z0zy8k%28v=vs.110%29.aspx )
