### PR TITLE
* Allow memory tracking inside spine

### DIFF
--- a/spine-c/include/spine/extension.h
+++ b/spine-c/include/spine/extension.h
@@ -32,8 +32,8 @@
 #define SPINE_EXTENSION_H_
 
 /* All allocation uses these. */
-#define MALLOC(TYPE,COUNT) ((TYPE*)_malloc(sizeof(TYPE) * COUNT))
-#define CALLOC(TYPE,COUNT) ((TYPE*)_calloc(COUNT, sizeof(TYPE)))
+#define MALLOC(TYPE,COUNT) ((TYPE*)_malloc(sizeof(TYPE) * COUNT, __FILE__, __LINE__))
+#define CALLOC(TYPE,COUNT) ((TYPE*)_calloc(COUNT, sizeof(TYPE), __FILE__, __LINE__))
 #define NEW(TYPE) CALLOC(TYPE,1)
 
 /* Gets the direct super class. Type safe. */
@@ -97,11 +97,12 @@ char* _spUtil_readFile (const char* path, int* length);
  * Internal API available for extension:
  */
 
-void* _malloc (size_t size);
-void* _calloc (size_t num, size_t size);
+void* _malloc (size_t size, const char* file, int line);
+void* _calloc (size_t num, size_t size, const char* file, int line);
 void _free (void* ptr);
 
 void _setMalloc (void* (*_malloc) (size_t size));
+void _setDebugMalloc (void* (*_malloc) (size_t size, const char* file, int line));
 void _setFree (void (*_free) (void* ptr));
 
 char* _readFile (const char* path, int* length);

--- a/spine-c/src/spine/extension.c
+++ b/spine-c/src/spine/extension.c
@@ -32,18 +32,26 @@
 #include <stdio.h>
 
 static void* (*mallocFunc) (size_t size) = malloc;
+static void* (*debugMallocFunc) (size_t size, const char* file, int line) = NULL;
 static void (*freeFunc) (void* ptr) = free;
 
-void* _malloc (size_t size) {
+void* _malloc (size_t size, const char* file, int line) {
+	if(debugMallocFunc)
+		return debugMallocFunc(size, file, line);
+
 	return mallocFunc(size);
 }
-void* _calloc (size_t num, size_t size) {
-	void* ptr = mallocFunc(num * size);
+void* _calloc (size_t num, size_t size, const char* file, int line) {
+	void* ptr = _malloc(num * size, file, line);
 	if (ptr) memset(ptr, 0, num * size);
 	return ptr;
 }
 void _free (void* ptr) {
 	freeFunc(ptr);
+}
+
+void _setDebugMalloc(void* (*malloc) (size_t size, const char* file, int line)) {
+	debugMallocFunc = malloc;
 }
 
 void _setMalloc (void* (*malloc) (size_t size)) {


### PR DESCRIPTION
I had a bit of trouble tracking down a memory leak because the NEW() macro wasn't saving the **FILE** or **LINE**.

This allows the [option] of getting better information on memory allocations for a custom tracker.
