### PR TITLE
FIXED: spine-csharp.csproj - Added missing files to project.

### DIFF
--- a/spine-csharp/spine-csharp.csproj
+++ b/spine-csharp/spine-csharp.csproj
@@ -61,7 +61,9 @@
     <Compile Include="src\Attachments\Attachment.cs" />
     <Compile Include="src\Attachments\AttachmentType.cs" />
     <Compile Include="src\Attachments\BoundingBoxAttachment.cs" />
+    <Compile Include="src\Attachments\MeshAttachment.cs" />
     <Compile Include="src\Attachments\RegionAttachment.cs" />
+    <Compile Include="src\Attachments\SkinnedMeshAttachment.cs" />
     <Compile Include="src\Bone.cs" />
     <Compile Include="src\BoneData.cs" />
     <Compile Include="src\AnimationState.cs" />


### PR DESCRIPTION
Hi Nathan,

I was building the current Spine C# solution today to update our runtimes and realized that there are two (probably new) files missing in the project file, so it's not possible to build the solution.

Cheers
Christian
