### PR TITLE
FIXED: spine-unity - Reverted meta file of SkeletonAnimation.cs to avoid...

### DIFF
--- a/spine-unity/Assets/Spine/SkeletonAnimation.cs.meta
+++ b/spine-unity/Assets/Spine/SkeletonAnimation.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 77556b6aeacded74798bf9b33de3ae5a
+guid: d247ba06193faa74d9335f5481b2b56c
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []


### PR DESCRIPTION
... loosing references in prefabs.

Hi Nathan,

During the update I realized that the meta GUID of the SkeletonAnimation script in Unity changed. Was there a reason to this? Because of the change, all references to the script within scenes and prefabs get lost. So everybody updating their project will have a hard time fixing those missing references. I would recommend to revert the GUID if the change was just made by accident.

Cheers
Christian
