### PR TITLE
CHANGED: spine-csharp - If animation loops the last key frame should be ...

### DIFF
--- a/spine-csharp/src/Animation.cs
+++ b/spine-csharp/src/Animation.cs
@@ -423,14 +423,16 @@ namespace Spine {
 		}
 
 		public void Apply (Skeleton skeleton, float lastTime, float time, List<Event> firedEvents, float alpha) {
-			float[] frames = this.frames;
-			if (time < frames[0]) return; // Time is before first frame.
+            float[] frames = this.frames;
 
-			int frameIndex;
-			if (time >= frames[frames.Length - 1]) // Time is after last frame.
-				frameIndex = frames.Length - 1;
-			else
-				frameIndex = Animation.binarySearch(frames, time, 1) - 1;
+            int frameIndex;
+            bool looped = lastTime > time;
+            if (looped && time < frames[0] || time >= frames[frames.Length - 1]) // Time is after last frame.
+                frameIndex = frames.Length - 1;
+            else if (time >= frames[0])
+                frameIndex = Animation.binarySearch(frames, time, 1) - 1;
+            else
+                return; // Time is before first frame and not looped.
 
 			String attachmentName = attachmentNames[frameIndex];
 			skeleton.slots[slotIndex].Attachment =


### PR DESCRIPTION
...taken for an attachment timeline if there is no key frame at the start of the timeline.

Hi Nathan,

This is a thing our artists were complaining about and I made a pull request to open a discussion about it.

We have some very simple looped character animations in our project. They just let the character blink, therefore the eyes are exchanged and the pupils are shown/hidden.

``` YAML
    "idle_neutral": {
        "slots": {
            "eyes": {
                "attachment": [
                    { "time": 2.2666, "name": "eyeblink" },
                    { "time": 2.4, "name": "eyes" }
                ]
            },
            "pupil_left": {
                "attachment": [
                    { "time": 2.2666, "name": null },
                    { "time": 2.4, "name": "pupil_left" }
                ]
            },
            "pupil_right": {
                "attachment": [
                    { "time": 2.2666, "name": null },
                    { "time": 2.4, "name": "pupil_right" }
                ]
            }
        }
    }
```

They are happy with the result in their editor. But what happens in Unity (and I guess C# in general) is: The character blinks once and keeps its eyes closed afterwards.

The reason for this behavior is the line `if (time < frames[0]) return; // Time is before first frame.`. If no key frame is set at the beginning of the animation after the timeline was looped, nothing happens. The last key frame isn't used at all because it also defines the duration of the animation, so the time is clamped before the Apply methods of the timelines are called.

I see three solutions for this issue:
1. Always define a key frame at time 0. This works, but is a bit dirty as the artists define the same key frame twice. No code changes are necessary though.
2. The solution I suggested with the pull request. I guess a similar change has to be made for other Timeline types as well (e.g. color, scale,...)
3. The animation applies the last key frames of its timelines before starting the next loop. This would be the cleanest solution in my opinion, but I have not enough insights into the whole system, yet, to see which consequences this would have.

I'm very curious about your opinion, maybe there is already a clean solution which I haven't found.

Cheers
Christian
