### PR TITLE
bind VAO 0 to clear the current vao context

### DIFF
--- a/spine-cocos2d-iphone/3.0/src/spine/PolygonBatch.m
+++ b/spine-cocos2d-iphone/3.0/src/spine/PolygonBatch.m
@@ -89,6 +89,7 @@
     if (!_verticesCount) return;
     
 	ccGLBindTexture2D(_texture.name);
+	ccGLBindVAO(0);
 	glEnableVertexAttribArray(kCCVertexAttrib_Position);
 	glEnableVertexAttribArray(kCCVertexAttrib_Color);
 	glEnableVertexAttribArray(kCCVertexAttrib_TexCoords);


### PR DESCRIPTION
reference to post on cocos2d forums: http://forum.cocos2d-iphone.org/t/spine-runtime-for-3-0-problems/13504
