### PR TITLE
[Unity] Submesh triangles may not be set when not rendering Meshes.

### DIFF
--- a/spine-unity/Assets/spine-unity/SkeletonRenderer.cs
+++ b/spine-unity/Assets/spine-unity/SkeletonRenderer.cs
@@ -340,8 +340,8 @@ public class SkeletonRenderer : MonoBehaviour {
 					triangles[i + 4] = firstVertex + 3;
 					triangles[i + 5] = firstVertex + 1;
 				}
+				return;
 			}
-			return;
 		}
 
 		// Store triangles.


### PR DESCRIPTION
Hi Nathan!
One comment to this return: Is it possible that it should be inside the inner "if" block? We have one issue with a character which doesn't use mesh attachments, but shows some strange behaviour when I turn off the renderMeshes option. When I move the return in the inner if block the issue is gone which makes sense because otherwise the triangles for the sub mesh may never be set if the check "submesh.firstVertex != firstVertex || submesh.triangleCount < triangleCount" fails.

Cheers
Christian