### PR TITLE
[Unity] Adds a play button to the SkeletonAnimation inspector

### DIFF
--- a/spine-unity/Assets/spine-unity/Editor/SkeletonAnimationInspector.cs
+++ b/spine-unity/Assets/spine-unity/Editor/SkeletonAnimationInspector.cs
@@ -29,7 +29,6 @@
  *****************************************************************************/
 
 using System;
-using Spine;
 using UnityEditor;
 using UnityEngine;
 


### PR DESCRIPTION
This change adds a play button to Unity SkeletonAnimation inspector. Users can preview the animation in the scene in edit mode.
