### PR TITLE
Fixes for the cocos2d-x v3.2 API

### DIFF
--- a/spine-cocos2dx/3.2/src/spine/SkeletonAnimation.cpp
+++ b/spine-cocos2dx/3.2/src/spine/SkeletonAnimation.cpp
@@ -89,7 +89,7 @@ SkeletonAnimation* SkeletonAnimation::createWithFile (const std::string& skeleto
 }
 
 void SkeletonAnimation::initialize () {
-	ownsAnimationStateData = true;
+	_ownsAnimationStateData = true;
 	_state = spAnimationState_create(spAnimationStateData_create(_skeleton->data));
 	_state->rendererObject = this;
 	_state->listener = animationCallback;
@@ -114,7 +114,7 @@ SkeletonAnimation::SkeletonAnimation (const std::string& skeletonDataFile, const
 }
 
 SkeletonAnimation::~SkeletonAnimation () {
-	if (ownsAnimationStateData) spAnimationStateData_dispose(_state->data);
+	if (_ownsAnimationStateData) spAnimationStateData_dispose(_state->data);
 	spAnimationState_dispose(_state);
 }
 
@@ -130,10 +130,10 @@ void SkeletonAnimation::update (float deltaTime) {
 void SkeletonAnimation::setAnimationStateData (spAnimationStateData* stateData) {
 	CCASSERT(stateData, "stateData cannot be null.");
 
-	if (ownsAnimationStateData) spAnimationStateData_dispose(_state->data);
+	if (_ownsAnimationStateData) spAnimationStateData_dispose(_state->data);
 	spAnimationState_dispose(_state);
 
-	ownsAnimationStateData = false;
+	_ownsAnimationStateData = false;
 	_state = spAnimationState_create(stateData);
 	_state->rendererObject = this;
 	_state->listener = animationCallback;
@@ -176,16 +176,16 @@ void SkeletonAnimation::clearTrack (int trackIndex) {
 void SkeletonAnimation::onAnimationStateEvent (int trackIndex, spEventType type, spEvent* event, int loopCount) {
 	switch (type) {
 	case SP_ANIMATION_START:
-		if (startListener) startListener(trackIndex);
+		if (_startListener) _startListener(trackIndex);
 		break;
 	case SP_ANIMATION_END:
-		if (endListener) endListener(trackIndex);
+		if (_endListener) _endListener(trackIndex);
 		break;
 	case SP_ANIMATION_COMPLETE:
-		if (completeListener) completeListener(trackIndex, loopCount);
+		if (_completeListener) _completeListener(trackIndex, loopCount);
 		break;
 	case SP_ANIMATION_EVENT:
-		if (eventListener) eventListener(trackIndex, event);
+		if (_eventListener) _eventListener(trackIndex, event);
 		break;
 	}
 }
@@ -210,19 +210,35 @@ void SkeletonAnimation::onTrackEntryEvent (int trackIndex, spEventType type, spE
 	}
 }
 
-void SkeletonAnimation::setStartListener (spTrackEntry* entry, StartListener listener) {
+void SkeletonAnimation::setStartListener (const StartListener& listener) {
+	_startListener = listener;
+}
+
+void SkeletonAnimation::setEndListener (const EndListener& listener) {
+	_endListener = listener;
+}
+
+void SkeletonAnimation::setCompleteListener (const CompleteListener& listener) {
+	_completeListener = listener;
+}
+
+void SkeletonAnimation::setEventListener (const EventListener& listener) {
+	_eventListener = listener;
+}
+
+void SkeletonAnimation::setTrackStartListener (spTrackEntry* entry, const StartListener& listener) {
 	getListeners(entry)->startListener = listener;
 }
 
-void SkeletonAnimation::setEndListener (spTrackEntry* entry, EndListener listener) {
+void SkeletonAnimation::setTrackEndListener (spTrackEntry* entry, const EndListener& listener) {
 	getListeners(entry)->endListener = listener;
 }
 
-void SkeletonAnimation::setCompleteListener (spTrackEntry* entry, CompleteListener listener) {
+void SkeletonAnimation::setTrackCompleteListener (spTrackEntry* entry, const CompleteListener& listener) {
 	getListeners(entry)->completeListener = listener;
 }
 
-void SkeletonAnimation::setEventListener (spTrackEntry* entry, spine::EventListener listener) {
+void SkeletonAnimation::setTrackEventListener (spTrackEntry* entry, const EventListener& listener) {
 	getListeners(entry)->eventListener = listener;
 }
 

--- a/spine-cocos2dx/3.2/src/spine/SkeletonAnimation.h
+++ b/spine-cocos2dx/3.2/src/spine/SkeletonAnimation.h
@@ -61,20 +61,30 @@ public:
 	void clearTracks ();
 	void clearTrack (int trackIndex = 0);
 
-	void setStartListener (spTrackEntry* entry, StartListener listener);
-	void setEndListener (spTrackEntry* entry, EndListener listener);
-	void setCompleteListener (spTrackEntry* entry, CompleteListener listener);
-	void setEventListener (spTrackEntry* entry, EventListener listener);
+	void setStartListener (const StartListener& listener);
+	void setEndListener (const EndListener& listener);
+	void setCompleteListener (const CompleteListener& listener);
+	void setEventListener (const EventListener& listener);
+
+	void setTrackStartListener (spTrackEntry* entry, const StartListener& listener);
+	void setTrackEndListener (spTrackEntry* entry, const EndListener& listener);
+	void setTrackCompleteListener (spTrackEntry* entry, const CompleteListener& listener);
+	void setTrackEventListener (spTrackEntry* entry, const EventListener& listener);
+
+	void setStartListener (spTrackEntry* entry, const StartListener& listener) CC_DEPRECATED_ATTRIBUTE
+	{ setTrackStartListener(entry, listener); }
+	void setEndListener (spTrackEntry* entry, const EndListener& listener) CC_DEPRECATED_ATTRIBUTE
+	{ setTrackEndListener(entry, listener); }
+	void setCompleteListener (spTrackEntry* entry, const CompleteListener& listener) CC_DEPRECATED_ATTRIBUTE
+	{ setTrackCompleteListener(entry, listener); }
+	void setEventListener (spTrackEntry* entry, const EventListener& listener) CC_DEPRECATED_ATTRIBUTE
+	{ setTrackEventListener(entry, listener); }
+
 
 	virtual void onAnimationStateEvent (int trackIndex, spEventType type, spEvent* event, int loopCount);
 	virtual void onTrackEntryEvent (int trackIndex, spEventType type, spEvent* event, int loopCount);
 
 	spAnimationState* getState() const;
-
-	StartListener startListener;
-	EndListener endListener;
-	CompleteListener completeListener;
-	EventListener eventListener;
 
 protected:
 	SkeletonAnimation ();
@@ -86,7 +96,12 @@ protected:
 
 	spAnimationState* _state;
 
-	bool ownsAnimationStateData;
+	bool _ownsAnimationStateData;
+
+	StartListener _startListener;
+	EndListener _endListener;
+	CompleteListener _completeListener;
+	EventListener _eventListener;
 
 private:
 	typedef SkeletonRenderer super;

--- a/spine-cocos2dx/3.2/src/spine/SkeletonRenderer.cpp
+++ b/spine-cocos2dx/3.2/src/spine/SkeletonRenderer.cpp
@@ -347,6 +347,35 @@ bool SkeletonRenderer::setAttachment (const std::string& slotName, const std::st
 	return spSkeleton_setAttachment(_skeleton, slotName.c_str(), attachmentName.c_str()) ? true : false;
 }
 
+void SkeletonRenderer::setTimeScale(float scale)
+{
+	_timeScale = scale;
+}
+
+float SkeletonRenderer::getTimeScale() const
+{
+	return _timeScale;
+}
+
+void SkeletonRenderer::setDebugSlotsEnabled(bool enabled)
+{
+	_debugSlots = enabled;
+}
+bool SkeletonRenderer::getDebugSlotsEnabled() const
+{
+	return _debugSlots;
+}
+
+void SkeletonRenderer::setDebugBonesEnabled(bool enabled)
+{
+	_debugBones = enabled;
+}
+bool SkeletonRenderer::getDebugBonesEnabled() const
+{
+	return _debugBones;
+}
+
+
 // --- CCBlendProtocol
 
 const BlendFunc& SkeletonRenderer::getBlendFunc () const {

--- a/spine-cocos2dx/3.2/src/spine/SkeletonRenderer.h
+++ b/spine-cocos2dx/3.2/src/spine/SkeletonRenderer.h
@@ -57,6 +57,16 @@ public:
 	void setBonesToSetupPose ();
 	void setSlotsToSetupPose ();
 
+	void setTimeScale(float scale);
+	float getTimeScale() const;
+
+	void setDebugSlotsEnabled(bool enabled);
+	bool getDebugSlotsEnabled() const;
+
+	void setDebugBonesEnabled(bool enabled);
+	bool getDebugBonesEnabled() const;
+
+
 	/* Returns 0 if the bone was not found. */
 	spBone* findBone (const std::string& boneName) const;
 	/* Returns 0 if the slot was not found. */


### PR DESCRIPTION
Adds setters for `timeScale`, `debugBones`, `debugSlots`, and the event listeners.
