### PR TITLE
Compiles on win32.

### DIFF
--- a/spine-cocos2dx/3.2/example/proj.win32/spine-cocos2dx.sln
+++ b/spine-cocos2dx/3.2/example/proj.win32/spine-cocos2dx.sln
@@ -6,7 +6,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "spine-cocos2dx", "spine-coc
 		{98A51BA8-FC3A-415B-AC8F-8C7BD464E93E} = {98A51BA8-FC3A-415B-AC8F-8C7BD464E93E}
 	EndProjectSection
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcocos2d", "..\..\cocos2dx\cocos\2d\cocos2d.vcxproj", "{98A51BA8-FC3A-415B-AC8F-8C7BD464E93E}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcocos2d", "..\..\cocos2dx\cocos\2d\libcocos2d.vcxproj", "{98A51BA8-FC3A-415B-AC8F-8C7BD464E93E}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libchipmunk", "..\..\cocos2dx\external\chipmunk\proj.win32\chipmunk.vcxproj", "{207BC7A9-CCF1-4F2F-A04D-45F72242AE25}"
 EndProject

--- a/spine-cocos2dx/3.2/example/proj.win32/spine-cocos2dx.vcxproj
+++ b/spine-cocos2dx/3.2/example/proj.win32/spine-cocos2dx.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -24,6 +24,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '10.0'">v100</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0'">v110</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v110_xp</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -31,6 +32,7 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '10.0'">v100</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0'">v110</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '11.0' and exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v7.1A')">v110_xp</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -153,13 +155,8 @@
     <ProjectReference Include="..\..\..\..\spine-c\spine-c.vcxproj">
       <Project>{5d74934a-7512-45ee-8402-7b95d3642e85}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\cocos2dx\cocos\2d\cocos2d.vcxproj">
+    <ProjectReference Include="..\..\cocos2dx\cocos\2d\libcocos2d.vcxproj">
       <Project>{98a51ba8-fc3a-415b-ac8f-8c7bd464e93e}</Project>
-      <Private>false</Private>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <CopyLocalSatelliteAssemblies>false</CopyLocalSatelliteAssemblies>
-      <LinkLibraryDependencies>true</LinkLibraryDependencies>
-      <UseLibraryDependencyInputs>false</UseLibraryDependencyInputs>
     </ProjectReference>
     <ProjectReference Include="..\..\cocos2dx\external\chipmunk\proj.win32\chipmunk.vcxproj">
       <Project>{207bc7a9-ccf1-4f2f-a04d-45f72242ae25}</Project>

--- a/spine-cocos2dx/3.2/src/spine/SkeletonAnimation.h
+++ b/spine-cocos2dx/3.2/src/spine/SkeletonAnimation.h
@@ -71,13 +71,13 @@ public:
 	void setTrackCompleteListener (spTrackEntry* entry, const CompleteListener& listener);
 	void setTrackEventListener (spTrackEntry* entry, const EventListener& listener);
 
-	void setStartListener (spTrackEntry* entry, const StartListener& listener) CC_DEPRECATED_ATTRIBUTE
+	CC_DEPRECATED_ATTRIBUTE void setStartListener(spTrackEntry* entry, const StartListener& listener)
 	{ setTrackStartListener(entry, listener); }
-	void setEndListener (spTrackEntry* entry, const EndListener& listener) CC_DEPRECATED_ATTRIBUTE
+	CC_DEPRECATED_ATTRIBUTE void setEndListener(spTrackEntry* entry, const EndListener& listener)
 	{ setTrackEndListener(entry, listener); }
-	void setCompleteListener (spTrackEntry* entry, const CompleteListener& listener) CC_DEPRECATED_ATTRIBUTE
+	CC_DEPRECATED_ATTRIBUTE void setCompleteListener(spTrackEntry* entry, const CompleteListener& listener)
 	{ setTrackCompleteListener(entry, listener); }
-	void setEventListener (spTrackEntry* entry, const EventListener& listener) CC_DEPRECATED_ATTRIBUTE
+	CC_DEPRECATED_ATTRIBUTE void setEventListener(spTrackEntry* entry, const EventListener& listener)
 	{ setTrackEventListener(entry, listener); }
 
 


### PR DESCRIPTION
- Compiles on win32. `CC_DEPRECATED_ATTRIBUTE` is at the beginning, not end.
- Visual Studio project file fixed for cocos2d-x v3.2
