### PR TITLE
spine-libgdx: Fix: SkeletonJson now sets mesh color if present in json.

### DIFF
--- a/spine-libgdx/src/com/esotericsoftware/spine/SkeletonJson.java
+++ b/spine-libgdx/src/com/esotericsoftware/spine/SkeletonJson.java
@@ -215,6 +215,12 @@ public class SkeletonJson {
 			mesh.setRegionUVs(map.require("uvs").asFloatArray());
 			mesh.updateUVs();
 
+            //Check if color exists
+            JsonValue meshColor = map.get("color");
+            if(meshColor != null) {
+                mesh.getColor().set(Color.valueOf(meshColor.asString()));
+            }
+
 			if (map.has("hull")) mesh.setHullLength(map.require("hull").asInt() * 2);
 			if (map.has("edges")) mesh.setEdges(map.require("edges").asIntArray());
 			mesh.setWidth(map.getFloat("width", 0) * scale);


### PR DESCRIPTION
SkeletonJson didn't read color attribute if color was set on mesh attachment. 
