### PR TITLE
[cocos2dx] PolygonBatch::flush crash fix

### DIFF
--- a/spine-cocos2dx/3.0/src/spine/PolygonBatch.cpp
+++ b/spine-cocos2dx/3.0/src/spine/PolygonBatch.cpp
@@ -94,6 +94,7 @@ void PolygonBatch::flush () {
 	if (!verticesCount) return;
 
 	GL::bindTexture2D(texture->getName());
+	GL::bindVAO(0);
 	glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
 	glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
 	glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORDS);

--- a/spine-cocos2dx/3.1/src/spine/PolygonBatch.cpp
+++ b/spine-cocos2dx/3.1/src/spine/PolygonBatch.cpp
@@ -94,6 +94,7 @@ void PolygonBatch::flush () {
 	if (!verticesCount) return;
 
 	GL::bindTexture2D(texture->getName());
+	GL::bindVAO(0);
 	glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
 	glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
 	glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORDS);

--- a/spine-cocos2dx/3.2/src/spine/PolygonBatch.cpp
+++ b/spine-cocos2dx/3.2/src/spine/PolygonBatch.cpp
@@ -94,6 +94,7 @@ void PolygonBatch::flush () {
 	if (!_verticesCount) return;
 
 	GL::bindTexture2D(_texture->getName());
+	GL::bindVAO(0);
 	glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_POSITION);
 	glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_COLOR);
 	glEnableVertexAttribArray(GLProgram::VERTEX_ATTRIB_TEX_COORDS);


### PR DESCRIPTION
Same fix as in https://github.com/EsotericSoftware/spine-runtimes/pull/224/files but for cocos2dx
Referenced here http://forum.cocos2d-swift.org/t/spine-runtime-for-3-0-problems/13504

"bind VAO 0 to clear the current vao context"
