### PR TITLE
Added Xamarin iOS MonoGame example/demo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ spine-csharp/obj
 spine-monogame/xamarinstudio-ios/src/bin
 spine-monogame/xamarinstudio-ios/src/obj
 
+spine-monogame/xamarinstudio-ios/example/bin
+spine-monogame/xamarinstudio-ios/example/obj
+
 spine-monogame/windows8-store/src/bin
 spine-monogame/windows8-store/src/obj
 

--- a/spine-monogame/xamarinstudio-ios/example/AppDelegate.cs
+++ b/spine-monogame/xamarinstudio-ios/example/AppDelegate.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Spine;
+
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+
+namespace spinemonogameexample
+{
+	// The UIApplicationDelegate for the application. This class is responsible for launching the
+	// User Interface of the application, as well as listening (and optionally responding) to
+	// application events from iOS.
+	[Register ("AppDelegate")]
+	public partial class AppDelegate : UIApplicationDelegate
+	{
+		// class-level declarations
+		UIWindow window;
+
+		//
+		// This method is invoked when the application has loaded and is ready to run. In this
+		// method you should instantiate the window, load the UI into it and then make the window
+		// visible.
+		//
+		// You have 17 seconds to return from this method, or iOS will terminate your application.
+		//
+		public override bool FinishedLaunching (UIApplication app, NSDictionary options)
+		{
+			// create a new window instance based on the screen size
+			window = new UIWindow (UIScreen.MainScreen.Bounds);
+			
+			var animationDemo = new Example ();
+			animationDemo.Run ();
+
+			return true;
+		}
+	}
+}
+

--- a/spine-monogame/xamarinstudio-ios/example/Entitlements.plist
+++ b/spine-monogame/xamarinstudio-ios/example/Entitlements.plist
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/spine-monogame/xamarinstudio-ios/example/Info.plist
+++ b/spine-monogame/xamarinstudio-ios/example/Info.plist
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>spine-monogame-example</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.your-company.spinemonogameexample</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>MinimumOSVersion</key>
+	<string>7.0</string>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>2</integer>
+	</array>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/spine-monogame/xamarinstudio-ios/example/Main.cs
+++ b/spine-monogame/xamarinstudio-ios/example/Main.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+
+namespace spinemonogameexample
+{
+	public class Application
+	{
+		// This is the main entry point of the application.
+		static void Main (string[] args)
+		{
+			// if you want to use a different Application Delegate class from "AppDelegate"
+			// you can specify it here.
+			UIApplication.Main (args, null, "AppDelegate");
+		}
+	}
+}

--- a/spine-monogame/xamarinstudio-ios/example/spine-monogame-example.csproj
+++ b/spine-monogame/xamarinstudio-ios/example/spine-monogame-example.csproj
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>spinemonogameexample</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>spinemonogameexample</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <MtouchLink>None</MtouchLink>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchDebug>true</MtouchDebug>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <MtouchLink>None</MtouchLink>
+    <ConsolePause>false</ConsolePause>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\iPhone\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <MtouchDebug>true</MtouchDebug>
+    <CodesignKey>iPhone Developer</CodesignKey>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <ConsolePause>false</ConsolePause>
+    <CodesignKey>iPhone Developer</CodesignKey>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\Ad-Hoc</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <BuildIpa>true</BuildIpa>
+    <CodesignProvision>Automatic:AdHoc</CodesignProvision>
+    <CodesignKey>iPhone Distribution</CodesignKey>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\iPhone\AppStore</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodesignKey>iPhone Distribution</CodesignKey>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <ConsolePause>false</ConsolePause>
+    <CodesignProvision>Automatic:AppStore</CodesignProvision>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="monotouch" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+    <Folder Include="data\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Info.plist" />
+    <None Include="Entitlements.plist" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs" />
+    <Compile Include="AppDelegate.cs" />
+    <Compile Include="..\..\..\spine-xna\example\src\ExampleGame.cs">
+      <Link>ExampleGame.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\MonoGame\MonoGame.Framework\MonoGame.Framework.iOS.csproj">
+      <Project>{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}</Project>
+      <Name>MonoGame.Framework.iOS</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\src\spine-monogame-xamarinstudio-ios.csproj">
+      <Project>{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}</Project>
+      <Name>spine-monogame-xamarinstudio-ios</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\..\..\spine-xna\example\data\goblins-ffd.atlas">
+      <Link>data\goblins-ffd.atlas</Link>
+    </Content>
+    <Content Include="..\..\..\spine-xna\example\data\goblins-ffd.json">
+      <Link>data\goblins-ffd.json</Link>
+    </Content>
+    <Content Include="..\..\..\spine-xna\example\data\goblins-ffd.png">
+      <Link>data\goblins-ffd.png</Link>
+    </Content>
+    <Content Include="..\..\..\spine-xna\example\data\raptor.atlas">
+      <Link>data\raptor.atlas</Link>
+    </Content>
+    <Content Include="..\..\..\spine-xna\example\data\raptor.json">
+      <Link>data\raptor.json</Link>
+    </Content>
+    <Content Include="..\..\..\spine-xna\example\data\raptor.png">
+      <Link>data\raptor.png</Link>
+    </Content>
+    <Content Include="..\..\..\spine-xna\example\data\spineboy.atlas">
+      <Link>data\spineboy.atlas</Link>
+    </Content>
+    <Content Include="..\..\..\spine-xna\example\data\spineboy.json">
+      <Link>data\spineboy.json</Link>
+    </Content>
+    <Content Include="..\..\..\spine-xna\example\data\spineboy.png">
+      <Link>data\spineboy.png</Link>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/spine-monogame/xamarinstudio-ios/example/spine-monogame-example.sln
+++ b/spine-monogame/xamarinstudio-ios/example/spine-monogame-example.sln
@@ -1,0 +1,74 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "spine-monogame-example", "spine-monogame-example.csproj", "{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lidgren.Network.iOS", "..\..\..\..\MonoGame\ThirdParty\Lidgren.Network\Lidgren.Network.iOS.csproj", "{734EAA48-F1CA-481A-B391-0285BC0E8B40}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Framework.iOS", "..\..\..\..\MonoGame\MonoGame.Framework\MonoGame.Framework.iOS.csproj", "{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "spine-monogame-xamarinstudio-ios", "..\src\spine-monogame-xamarinstudio-ios.csproj", "{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|iPhoneSimulator = Release|iPhoneSimulator
+		Debug|iPhone = Debug|iPhone
+		Release|iPhone = Release|iPhone
+		Ad-Hoc|iPhone = Ad-Hoc|iPhone
+		AppStore|iPhone = AppStore|iPhone
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.Ad-Hoc|iPhone.ActiveCfg = Release|Any CPU
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.Ad-Hoc|iPhone.Build.0 = Release|Any CPU
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.AppStore|iPhone.ActiveCfg = Release|Any CPU
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.AppStore|iPhone.Build.0 = Release|Any CPU
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.Release|iPhone.Build.0 = Release|Any CPU
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}.Ad-Hoc|iPhone.ActiveCfg = Ad-Hoc|iPhone
+		{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}.Ad-Hoc|iPhone.Build.0 = Ad-Hoc|iPhone
+		{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}.AppStore|iPhone.ActiveCfg = AppStore|iPhone
+		{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}.AppStore|iPhone.Build.0 = AppStore|iPhone
+		{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}.Debug|iPhone.Build.0 = Debug|iPhone
+		{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}.Release|iPhone.ActiveCfg = Release|iPhone
+		{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}.Release|iPhone.Build.0 = Release|iPhone
+		{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Ad-Hoc|iPhone.ActiveCfg = Release|Any CPU
+		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Ad-Hoc|iPhone.Build.0 = Release|Any CPU
+		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.AppStore|iPhone.ActiveCfg = Release|Any CPU
+		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.AppStore|iPhone.Build.0 = Release|Any CPU
+		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Release|iPhone.Build.0 = Release|Any CPU
+		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Ad-Hoc|iPhone.ActiveCfg = Release|iPhone
+		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Ad-Hoc|iPhone.Build.0 = Release|iPhone
+		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.AppStore|iPhone.ActiveCfg = Release|iPhone
+		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.AppStore|iPhone.Build.0 = Release|iPhone
+		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Debug|iPhone.Build.0 = Debug|iPhone
+		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Release|iPhone.ActiveCfg = Release|iPhone
+		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Release|iPhone.Build.0 = Release|iPhone
+		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = spine-monogame-example.csproj
+	EndGlobalSection
+EndGlobal

--- a/spine-monogame/xamarinstudio-ios/src/spine-monogame-xamarinstudio-ios.csproj
+++ b/spine-monogame/xamarinstudio-ios/src/spine-monogame-xamarinstudio-ios.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}</ProjectGuid>
     <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>


### PR DESCRIPTION
The repository has an example project for windows MonoGame which simply links to the XNA example project and content, however there was not an example for iOS - therefore I've added one.  
As always I'm happy to keep issuing pull requests for MonoGame related changes every time you make a change.
