### PR TITLE
[LUA] AnimationState trackCount fix

### DIFF
--- a/spine-lua/AnimationState.lua
+++ b/spine-lua/AnimationState.lua
@@ -211,7 +211,7 @@ function AnimationState.new (data)
 			last.next = entry
 		else
 			self.tracks[trackIndex] = entry
-			self.trackCount = math.max(self.trackCount, index)
+			self.trackCount = math.max(self.trackCount, trackIndex)
 		end
 
 		delay = delay or 0


### PR DESCRIPTION
As is the addAnimation function does not update the trackCount when adding an animation to a previously empty track. This fix updates the trackCount when adding an animation to an empty track, which I assume is the wanted behavior.
