### PR TITLE
fix bug may be happened in mix animations

### DIFF
--- a/spine-c/src/spine/Animation.c
+++ b/spine-c/src/spine/Animation.c
@@ -33,6 +33,8 @@
 #include <limits.h>
 #include <spine/extension.h>
 
+#include <float.h>
+
 spAnimation* spAnimation_create (const char* name, int timelinesCount) {
 	spAnimation* self = NEW(spAnimation);
 	MALLOC_STR(self->name, name);
@@ -479,7 +481,7 @@ void _spAttachmentTimeline_apply (const spTimeline* timeline, spSkeleton* skelet
 
 	frameIndex = time >= self->frames[self->framesCount - 1] ?
 		self->framesCount - 1 : binarySearch1(self->frames, self->framesCount, time) - 1;
-	if (self->frames[frameIndex] <= lastTime) return;
+	if (self->frames[frameIndex] <= lastTime && fabs(1 - alpha) <= FLT_EPSILON) return;
 
 	attachmentName = self->attachmentNames[frameIndex];
 	spSlot_setAttachment(skeleton->slots[self->slotIndex],


### PR DESCRIPTION
in mix period, if pervious timeline has attachment change after the current timeline attachment change, the slot attachment may be not correct after mix period.
