### PR TITLE
[Unity] SkeletonRenderer modification for color overbrightening

### DIFF
--- a/spine-unity/Assets/spine-unity/Editor/SkeletonRendererInspector.cs
+++ b/spine-unity/Assets/spine-unity/Editor/SkeletonRendererInspector.cs
@@ -34,7 +34,7 @@ using UnityEngine;
 
 [CustomEditor(typeof(SkeletonRenderer))]
 public class SkeletonRendererInspector : Editor {
-	protected SerializedProperty skeletonDataAsset, initialSkinName, normals, tangents, meshes, immutableTriangles;
+	protected SerializedProperty skeletonDataAsset, initialSkinName, normals, tangents, meshes, immutableTriangles, overbright;
 
 	protected virtual void OnEnable () {
 		skeletonDataAsset = serializedObject.FindProperty("skeletonDataAsset");
@@ -43,6 +43,7 @@ public class SkeletonRendererInspector : Editor {
 		tangents = serializedObject.FindProperty("calculateTangents");
 		meshes = serializedObject.FindProperty("renderMeshes");
 		immutableTriangles = serializedObject.FindProperty("immutableTriangles");
+		overbright = serializedObject.FindProperty("overbright");
 	}
 
 	protected virtual void gui () {
@@ -92,6 +93,7 @@ public class SkeletonRendererInspector : Editor {
 			new GUIContent("Immutable Triangles", "Enable to optimize rendering for skeletons that never change attachment visbility"));
 		EditorGUILayout.PropertyField(normals);
 		EditorGUILayout.PropertyField(tangents);
+		EditorGUILayout.PropertyField(overbright);
 	}
 
 	override public void OnInspectorGUI () {

--- a/spine-unity/Assets/spine-unity/Shaders/SkeletonOverbright.shader
+++ b/spine-unity/Assets/spine-unity/Shaders/SkeletonOverbright.shader
@@ -1,0 +1,53 @@
+Shader "Spine/SkeletonOverbright" {
+	Properties {
+		_Cutoff ("Shadow alpha cutoff", Range(0,1)) = 0.1
+		_MainTex ("Texture to blend", 2D) = "black" {}
+		_Color ("Tint", Color) = (1,1,1,1)
+	}
+	// 2 texture stage GPUs
+	SubShader {
+		Tags { "Queue"="Transparent" "IgnoreProjector"="True" "RenderType"="Transparent" "SpineShader"="Overbright"}
+		LOD 100
+
+		Cull Off
+		ZWrite Off
+		Blend One OneMinusSrcAlpha
+		Lighting Off
+
+		Pass {
+			CGPROGRAM
+			#pragma vertex vert
+			#pragma fragment frag
+			#pragma target 3.0
+
+			#include "UnityCG.cginc"
+		
+			struct appdata {
+				float4 vertex : POSITION;
+				float4 texcoord : TEXCOORD0;
+				float4 color : COLOR;
+			};
+		
+			struct v2f {
+				float4 pos : SV_POSITION;
+				half2 uv : TEXCOORD0;
+				float4 color : COLOR;
+			};
+		
+			v2f vert (appdata v) {
+				v2f o;
+				o.pos =  mul (UNITY_MATRIX_MVP, v.vertex);
+				o.uv = v.texcoord.xy;
+				o.color = v.color;
+				return o;
+			}
+		
+			uniform sampler2D _MainTex;
+		
+			float4 frag(v2f i) : COLOR {
+				return tex2D(_MainTex, i.uv) * i.color * float4(4.0f, 4.0f, 4.0f, 1.0f);
+			}
+			ENDCG
+		}
+	}
+}

--- a/spine-unity/Assets/spine-unity/SkeletonRenderer.cs
+++ b/spine-unity/Assets/spine-unity/SkeletonRenderer.cs
@@ -52,7 +52,9 @@ public class SkeletonRenderer : MonoBehaviour {
 	public float zSpacing;
 	public bool renderMeshes = true, immutableTriangles;
 	public bool logErrors = false;
-	
+	public bool overbright = false;
+
+	private float brightMod = 1f;
 	private MeshFilter meshFilter;
 	private Mesh mesh, mesh1, mesh2;
 	private bool useMesh1;
@@ -80,6 +82,7 @@ public class SkeletonRenderer : MonoBehaviour {
 		submeshMaterials.Clear();
 		submeshes.Clear();
 		skeleton = null;
+		brightMod = overbright ? 0.25f : 1f;
 
 		valid = false;
 		if (!skeletonDataAsset) {
@@ -214,9 +217,9 @@ public class SkeletonRenderer : MonoBehaviour {
 				vertices[vertexIndex + 3] = new Vector3(tempVertices[RegionAttachment.X3], tempVertices[RegionAttachment.Y3], z);
 				
 				color.a = (byte)(a * slot.a * regionAttachment.a);
-				color.r = (byte)(r * slot.r * regionAttachment.r * color.a);
-				color.g = (byte)(g * slot.g * regionAttachment.g * color.a);
-				color.b = (byte)(b * slot.b * regionAttachment.b * color.a);
+				color.r = (byte)(r * slot.r * regionAttachment.r * color.a * brightMod);
+				color.g = (byte)(g * slot.g * regionAttachment.g * color.a * brightMod);
+				color.b = (byte)(b * slot.b * regionAttachment.b * color.a * brightMod);
 				if (slot.data.additiveBlending) color.a = 0;
 				colors[vertexIndex] = color;
 				colors[vertexIndex + 1] = color;
@@ -239,9 +242,9 @@ public class SkeletonRenderer : MonoBehaviour {
 					meshAttachment.ComputeWorldVertices(slot, tempVertices);
 					
 					color.a = (byte)(a * slot.a * meshAttachment.a);
-					color.r = (byte)(r * slot.r * meshAttachment.r * color.a);
-					color.g = (byte)(g * slot.g * meshAttachment.g * color.a);
-					color.b = (byte)(b * slot.b * meshAttachment.b * color.a);
+					color.r = (byte)(r * slot.r * meshAttachment.r * color.a * brightMod);
+					color.g = (byte)(g * slot.g * meshAttachment.g * color.a * brightMod);
+					color.b = (byte)(b * slot.b * meshAttachment.b * color.a * brightMod);
 					if (slot.data.additiveBlending) color.a = 0;
 					
 					float[] meshUVs = meshAttachment.uvs;
@@ -258,9 +261,9 @@ public class SkeletonRenderer : MonoBehaviour {
 					meshAttachment.ComputeWorldVertices(slot, tempVertices);
 					
 					color.a = (byte)(a * slot.a * meshAttachment.a);
-					color.r = (byte)(r * slot.r * meshAttachment.r * color.a);
-					color.g = (byte)(g * slot.g * meshAttachment.g * color.a);
-					color.b = (byte)(b * slot.b * meshAttachment.b * color.a);
+					color.r = (byte)(r * slot.r * meshAttachment.r * color.a * brightMod);
+					color.g = (byte)(g * slot.g * meshAttachment.g * color.a * brightMod);
+					color.b = (byte)(b * slot.b * meshAttachment.b * color.a * brightMod);
 					if (slot.data.additiveBlending) color.a = 0;
 					
 					float[] meshUVs = meshAttachment.uvs;


### PR DESCRIPTION
A modification to SkeletonRenderer to allow for a limited glowing/flashing effect, with the shader for doing the effect. Setting a color with a color component > 1 activates the effect.

![spine-overbright-demo](https://cloud.githubusercontent.com/assets/2573643/4275111/86ed185c-3cf9-11e4-8f95-e9ed47967039.gif)
