### PR TITLE
Fix to avoid excessive flushing of polygon batch.

### DIFF
--- a/spine-starling/spine-starling/src/spine/starling/PolygonBatch.as
+++ b/spine-starling/spine-starling/src/spine/starling/PolygonBatch.as
@@ -125,7 +125,7 @@ internal class PolygonBatch {
 			_support.applyBlendMode(true);
 		}
 
-		if (texture != _texture) {
+		if (!_texture || texture.base != _texture.base) {
 			flush();
 			_texture = texture;
 		}


### PR DESCRIPTION
It seems that when we use a starling SubTexture instead of an Spine texture, this line will trigger a lot of flushing instead of batching the polygons.
This fix avoid that.
Btw, you are using Animation.binarySearch1() in AnimationTimeline wich does not exists yet :-p
