### PR TITLE
Clamp lastTime to endTime

### DIFF
--- a/spine-c/src/spine/AnimationState.c
+++ b/spine-c/src/spine/AnimationState.c
@@ -119,7 +119,7 @@ void spAnimationState_apply (spAnimationState* self, spSkeleton* skeleton) {
 	int i, ii;
 	int eventsCount;
 	int entryChanged;
-	float time;
+	float time, lastTime;
 	spTrackEntry* previous;
 	for (i = 0; i < self->tracksCount; ++i) {
 		spTrackEntry* current = self->tracks[i];
@@ -130,13 +130,16 @@ void spAnimationState_apply (spAnimationState* self, spSkeleton* skeleton) {
 		time = current->time;
 		if (!current->loop && time > current->endTime) time = current->endTime;
 
+		lastTime = current->lastTime;
+		if (!current->loop && lastTime > current->endTime) lastTime = current->endTime;
+
 		previous = current->previous;
 		if (!previous) {
 			if (current->mix == 1) {
-				spAnimation_apply(current->animation, skeleton, current->lastTime, time,
+				spAnimation_apply(current->animation, skeleton, lastTime, time,
 					current->loop, internal->events, &eventsCount);
 			} else {
-				spAnimation_mix(current->animation, skeleton, current->lastTime, time,
+				spAnimation_mix(current->animation, skeleton, lastTime, time,
 					current->loop, internal->events, &eventsCount, current->mix);
 			}
 		} else {
@@ -151,7 +154,7 @@ void spAnimationState_apply (spAnimationState* self, spSkeleton* skeleton) {
 				internal->disposeTrackEntry(current->previous);
 				current->previous = 0;
 			}
-			spAnimation_mix(current->animation, skeleton, current->lastTime, time,
+			spAnimation_mix(current->animation, skeleton, lastTime, time,
 				current->loop, internal->events, &eventsCount, alpha);
 		}
 
@@ -176,8 +179,8 @@ void spAnimationState_apply (spAnimationState* self, spSkeleton* skeleton) {
 		if (entryChanged) continue;
 
 		/* Check if completed the animation or a loop iteration. */
-		if (current->loop ? (FMOD(current->lastTime, current->endTime) > FMOD(time, current->endTime))
-				: (current->lastTime < current->endTime && time >= current->endTime)) {
+		if (current->loop ? (FMOD(lastTime, current->endTime) > FMOD(time, current->endTime))
+				: (lastTime < current->endTime && time >= current->endTime)) {
 			int count = (int)(time / current->endTime);
 			if (current->listener) {
 				current->listener(self, i, SP_ANIMATION_COMPLETE, 0, count);


### PR DESCRIPTION
Currently, for a non-looping animation, lastTime is not clamped to the length of the animation but time is.  This means then when applying an animation, time could be less than lastTime and this in turn can lead
to all events in the animation being fired every frame, when the animation has reached the end.

This commit clamps the lastTime in a similar manner to the time, when applying animations.

This is only fixed in the spine-c runtime, as I'm not in a position to test the others.  I did notice that the same issue will occur in other runtimes however.