### PR TITLE
[JS] Mesh attachments + syntax fixes + infinite loop fix

### DIFF
--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -2092,7 +2092,7 @@ spine.SkeletonJson.prototype = {
 							}
 							if (isMesh) {
 								var meshVertices = attachment.vertices;
-								for (var ii = 0, nn = vertices.length; ii < nn; i++)
+								for (var ii = 0, nn = vertices.length; ii < nn; ii++)
 									vertices[ii] += meshVertices[ii];
 							}
 						}

--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -772,8 +772,8 @@ spine.FfdTimeline.prototype = {
 		this.frameVertices[frameIndex] = vertices;
 	},
 	apply: function (skeleton, lastTime, time, firedEvents, alpha) {
-		var slot = skeleton.slots[slotIndex];
-		if (slot.attachment != attachment) return;
+		var slot = skeleton.slots[this.slotIndex];
+		if (slot.attachment != this.attachment) return;
 
 		var frames = this.frames;
 		if (time < frames[0]) return; // Time is before first frame.
@@ -1030,7 +1030,7 @@ spine.Skeleton.prototype = {
 		var arrayCount = ikConstraintsCount + 1;
 		var boneCache = this.boneCache;
 		if (boneCache.length > arrayCount) boneCache.length = arrayCount;
-		for (var i = 0, n = boneCache.length; i < n; i++) 
+		for (var i = 0, n = boneCache.length; i < n; i++)
 			boneCache[i].length = 0;
 		while (boneCache.length < arrayCount)
 			boneCache[boneCache.length] = [];
@@ -1821,8 +1821,8 @@ spine.SkeletonJson.prototype = {
 			var region = this.attachmentLoader.newRegionAttachment(skin, name, path);
 			if (!region) return null;
 			region.path = path;
-			region.x = (map["x"] || 0) * this.scale;
-			region.y = (map["y"] || 0) * this.scale;
+			region.x = (map["x"] || 0) * scale;
+			region.y = (map["y"] || 0) * scale;
 			region.scaleX = map.hasOwnProperty("scaleX") ? map["scaleX"] : 1;
 			region.scaleY = map.hasOwnProperty("scaleY") ? map["scaleY"] : 1;
 			region.rotation = map["rotation"] || 0;
@@ -1904,7 +1904,7 @@ spine.SkeletonJson.prototype = {
 			var attachment = this.attachmentLoader.newBoundingBoxAttachment(skin, name);
 			var vertices = map["vertices"];
 			for (var i = 0, n = vertices.length; i < n; i++)
-				attachment.vertices.push(vertices[i] * this.scale);
+				attachment.vertices.push(vertices[i] * scale);
 			return attachment;
 		}
 		throw "Unknown attachment type: " + type;
@@ -2083,12 +2083,12 @@ spine.SkeletonJson.prototype = {
 							vertices.length = vertexCount;
 							var start = valueMap["offset"] || 0;
 							var nn = verticesValue.length;
-							if (scale == 1) {
+							if (this.scale == 1) {
 								for (var ii = 0; ii < nn; ii++)
 									vertices[ii + start] = verticesValue[ii];
 							} else {
 								for (var ii = 0; ii < nn; ii++)
-									vertices[ii + start] = verticesValue[ii] * scale;
+									vertices[ii + start] = verticesValue[ii] * this.scale;
 							}
 							if (isMesh) {
 								var meshVertices = attachment.vertices;

--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -1335,21 +1335,20 @@ spine.MeshAttachment.prototype = {
 	edges: null,
 	width: 0, height: 0,
 	updateUVs: function () {
-		var width = regionU2 - regionU, height = regionV2 - regionV;
-		var n = regionUVs.length;
-		if (!uvs || uvs.length != n) {
-			uvs = [];
-			uvs.length = n;
+		var width = this.regionU2 - this.regionU, height = this.regionV2 - this.regionV;
+		var n = this.regionUVs.length;
+		if (!this.uvs || this.uvs.length != n) {
+            this.uvs = new spine.Float32Array(n);
 		}
-		if (regionRotate) {
+		if (this.regionRotate) {
 			for (var i = 0; i < n; i += 2) {
-				uvs[i] = regionU + regionUVs[i + 1] * width;
-				uvs[i + 1] = regionV + height - regionUVs[i] * height;
+                this.uvs[i] = this.regionU + this.regionUVs[i + 1] * width;
+                this.uvs[i + 1] = this.regionV + height - this.regionUVs[i] * height;
 			}
 		} else {
 			for (var i = 0; i < n; i += 2) {
-				uvs[i] = regionU + regionUVs[i] * width;
-				uvs[i + 1] = regionV + regionUVs[i + 1] * height;
+                this.uvs[i] = this.regionU + this.regionUVs[i] * width;
+                this.uvs[i + 1] = this.regionV + this.regionUVs[i + 1] * height;
 			}
 		}
 	},
@@ -1391,21 +1390,20 @@ spine.SkinnedMeshAttachment.prototype = {
 	edges: null,
 	width: 0, height: 0,
 	updateUVs: function (u, v, u2, v2, rotate) {
-		var width = regionU2 - regionU, height = regionV2 - regionV;
-		var n = regionUVs.length;
-		if (!uvs || uvs.length != n) {
-			uvs = [];
-			uvs.length = n;
+		var width = this.regionU2 - this.regionU, height = this.regionV2 - this.regionV;
+		var n = this.regionUVs.length;
+		if (!this.uvs || this.uvs.length != n) {
+            this.uvs = new spine.Float32Array(n);
 		}
-		if (regionRotate) {
+		if (this.regionRotate) {
 			for (var i = 0; i < n; i += 2) {
-				uvs[i] = regionU + regionUVs[i + 1] * width;
-				uvs[i + 1] = regionV + height - regionUVs[i] * height;
+                this.uvs[i] = this.regionU + this.regionUVs[i + 1] * width;
+                this.uvs[i + 1] = this.regionV + height - this.regionUVs[i] * height;
 			}
 		} else {
 			for (var i = 0; i < n; i += 2) {
-				uvs[i] = regionU + regionUVs[i] * width;
-				uvs[i + 1] = regionV + regionUVs[i + 1] * height;
+                this.uvs[i] = this.regionU + this.regionUVs[i] * width;
+                this.uvs[i + 1] = this.regionV + this.regionUVs[i + 1] * height;
 			}
 		}
 	},
@@ -1869,7 +1867,7 @@ spine.SkeletonJson.prototype = {
 			mesh.path = path;
 
 			var uvs = this.getFloatArray(map, "uvs", 1);
-			vertices = this.getFloatArray(map, "vertices", 1);
+			var vertices = this.getFloatArray(map, "vertices", 1);
 			var weights = [];
 			var bones = [];
 			for (var i = 0, n = vertices.length; i < n; ) {

--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -31,7 +31,9 @@
 var spine = {
 	radDeg: 180 / Math.PI,
 	degRad: Math.PI / 180,
-	temp: []
+	temp: [],
+    Float32Array: (typeof(Float32Array) === 'undefined') ? Array : Float32Array,
+    Uint16Array: (typeof(Uint16Array) === 'undefined') ? Array : Uint16Array
 };
 
 spine.BoneData = function (name, parent) {
@@ -2183,8 +2185,7 @@ spine.SkeletonJson.prototype = {
 	},
 	getFloatArray: function (map, name, scale) {
 		var list = map[name];
-		var values = [];
-		values = list.length;
+		var values = new spine.Float32Array(list.length);
 		var i = 0, n = list.length;
 		if (scale == 1) {
 			for (; i < n; i++)
@@ -2197,8 +2198,7 @@ spine.SkeletonJson.prototype = {
 	},
 	getIntArray: function (map, name) {
 		var list = map[name];
-		var values = [];
-		values = list.length;
+		var values = new spine.Uint16Array(list.length);
 		for (var i = 0, n = list.length; i < n; i++)
 			values[i] = list[i] | 0;
 		return values;


### PR DESCRIPTION
Adds support for typed arrays (float32 and uint16), useful when rendering in WebGL.
Fixes syntax issues in the `updateUVs` functions in MeshAttachment and SkinnedMeshAttachment.

Tested in pixi.js:
![](http://i.giphy.com/5xaOcLtf6Ch5nkkjcic.gif)