### PR TITLE
Why not link to spine.js?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,5 +90,3 @@ spine-as3/spine-as3-example/bin-release
 spine-starling/spine-starling/bin
 spine-starling/spine-starling-example/bin-debug
 spine-starling/spine-starling-example/bin-release
-
-spine-turbulenz/spine-js/spine.js

--- a/spine-turbulenz/spine-js/spine.js
+++ b/spine-turbulenz/spine-js/spine.js
@@ -1,0 +1,1 @@
+../../spine-js/spine.js


### PR DESCRIPTION
Instead of place-it-here.txt? I know, you could say, it will not work on some systems (windows), but then txt file does not make it work either. Whereas on linux and mac this would work out of the box.