### PR TITLE
Cocos2d-x: changes for JSB support.

### DIFF
--- a/spine-cocos2dx/3/src/spine/SkeletonAnimation.cpp
+++ b/spine-cocos2dx/3/src/spine/SkeletonAnimation.cpp
@@ -100,7 +100,6 @@ void SkeletonAnimation::initialize () {
 
 SkeletonAnimation::SkeletonAnimation ()
 		: SkeletonRenderer() {
-	initialize();
 }
 
 SkeletonAnimation::SkeletonAnimation (spSkeletonData *skeletonData)

--- a/spine-cocos2dx/3/src/spine/SkeletonAnimation.h
+++ b/spine-cocos2dx/3/src/spine/SkeletonAnimation.h
@@ -76,7 +76,7 @@ public:
 
 	spAnimationState* getState() const;
 
-protected:
+CC_CONSTRUCTOR_ACCESS:
 	SkeletonAnimation ();
 	SkeletonAnimation (spSkeletonData* skeletonData);
 	SkeletonAnimation (const std::string&skeletonDataFile, spAtlas* atlas, float scale = 1);
@@ -84,6 +84,7 @@ protected:
 	virtual ~SkeletonAnimation ();
 	void initialize ();
 
+protected:
 	spAnimationState* _state;
 
 	bool _ownsAnimationStateData;

--- a/spine-cocos2dx/3/src/spine/SkeletonRenderer.cpp
+++ b/spine-cocos2dx/3/src/spine/SkeletonRenderer.cpp
@@ -83,7 +83,6 @@ void SkeletonRenderer::setSkeletonData (spSkeletonData *skeletonData, bool ownsS
 }
 
 SkeletonRenderer::SkeletonRenderer () {
-	initialize();
 }
 
 SkeletonRenderer::SkeletonRenderer (spSkeletonData *skeletonData, bool ownsSkeletonData) {
@@ -106,15 +105,13 @@ SkeletonRenderer::~SkeletonRenderer () {
 	FREE(_worldVertices);
 }
 
-void SkeletonRenderer::initWithData (spSkeletonData* skeletonData, bool ownsSkeletonData = false) {
-	initialize();
-
+void SkeletonRenderer::initWithData (spSkeletonData* skeletonData, bool ownsSkeletonData) {
 	setSkeletonData(skeletonData, ownsSkeletonData);
+
+	initialize();
 }
 
-void SkeletonRenderer::initWithFile (const std::string& skeletonDataFile, spAtlas* atlas, float scale = 1) {
-	initialize();
-
+void SkeletonRenderer::initWithFile (const std::string& skeletonDataFile, spAtlas* atlas, float scale) {
 	spSkeletonJson* json = spSkeletonJson_create(atlas);
 	json->scale = scale;
 	spSkeletonData* skeletonData = spSkeletonJson_readSkeletonDataFile(json, skeletonDataFile.c_str());
@@ -122,11 +119,11 @@ void SkeletonRenderer::initWithFile (const std::string& skeletonDataFile, spAtla
 	spSkeletonJson_dispose(json);
 
 	setSkeletonData(skeletonData, true);
+
+	initialize();
 }
 
-void SkeletonRenderer::initWithFile (const std::string& skeletonDataFile, const std::string& atlasFile, float scale = 1) {
-	initialize();
-
+void SkeletonRenderer::initWithFile (const std::string& skeletonDataFile, const std::string& atlasFile, float scale) {
 	_atlas = spAtlas_createFromFile(atlasFile.c_str(), 0);
 	CCASSERT(_atlas, "Error reading atlas file.");
 
@@ -137,6 +134,8 @@ void SkeletonRenderer::initWithFile (const std::string& skeletonDataFile, const 
 	spSkeletonJson_dispose(json);
 
 	setSkeletonData(skeletonData, true);
+
+	initialize();
 }
 
 

--- a/spine-cocos2dx/3/src/spine/SkeletonRenderer.cpp
+++ b/spine-cocos2dx/3/src/spine/SkeletonRenderer.cpp
@@ -87,12 +87,32 @@ SkeletonRenderer::SkeletonRenderer () {
 }
 
 SkeletonRenderer::SkeletonRenderer (spSkeletonData *skeletonData, bool ownsSkeletonData) {
+	initWithData(skeletonData, ownsSkeletonData);
+}
+
+SkeletonRenderer::SkeletonRenderer (const std::string& skeletonDataFile, spAtlas* atlas, float scale) {
+	initWithFile(skeletonDataFile, atlas, scale);
+}
+
+SkeletonRenderer::SkeletonRenderer (const std::string& skeletonDataFile, const std::string& atlasFile, float scale) {
+	initWithFile(skeletonDataFile, atlasFile, scale);
+}
+
+SkeletonRenderer::~SkeletonRenderer () {
+	if (_ownsSkeletonData) spSkeletonData_dispose(_skeleton->data);
+	if (_atlas) spAtlas_dispose(_atlas);
+	spSkeleton_dispose(_skeleton);
+	_batch->release();
+	FREE(_worldVertices);
+}
+
+void SkeletonRenderer::initWithData (spSkeletonData* skeletonData, bool ownsSkeletonData = false) {
 	initialize();
 
 	setSkeletonData(skeletonData, ownsSkeletonData);
 }
 
-SkeletonRenderer::SkeletonRenderer (const std::string& skeletonDataFile, spAtlas* atlas, float scale) {
+void SkeletonRenderer::initWithFile (const std::string& skeletonDataFile, spAtlas* atlas, float scale = 1) {
 	initialize();
 
 	spSkeletonJson* json = spSkeletonJson_create(atlas);
@@ -104,7 +124,7 @@ SkeletonRenderer::SkeletonRenderer (const std::string& skeletonDataFile, spAtlas
 	setSkeletonData(skeletonData, true);
 }
 
-SkeletonRenderer::SkeletonRenderer (const std::string& skeletonDataFile, const std::string& atlasFile, float scale) {
+void SkeletonRenderer::initWithFile (const std::string& skeletonDataFile, const std::string& atlasFile, float scale = 1) {
 	initialize();
 
 	_atlas = spAtlas_createFromFile(atlasFile.c_str(), 0);
@@ -119,13 +139,6 @@ SkeletonRenderer::SkeletonRenderer (const std::string& skeletonDataFile, const s
 	setSkeletonData(skeletonData, true);
 }
 
-SkeletonRenderer::~SkeletonRenderer () {
-	if (_ownsSkeletonData) spSkeletonData_dispose(_skeleton->data);
-	if (_atlas) spAtlas_dispose(_atlas);
-	spSkeleton_dispose(_skeleton);
-	_batch->release();
-	FREE(_worldVertices);
-}
 
 void SkeletonRenderer::update (float deltaTime) {
 	spSkeleton_update(_skeleton, deltaTime * _timeScale);

--- a/spine-cocos2dx/3/src/spine/SkeletonRenderer.h
+++ b/spine-cocos2dx/3/src/spine/SkeletonRenderer.h
@@ -91,14 +91,21 @@ public:
 	virtual void setOpacityModifyRGB (bool value);
 	virtual bool isOpacityModifyRGB () const;
 
-protected:
+CC_CONSTRUCTOR_ACCESS:
 	SkeletonRenderer ();
 	SkeletonRenderer (spSkeletonData* skeletonData, bool ownsSkeletonData = false);
 	SkeletonRenderer (const std::string& skeletonDataFile, spAtlas* atlas, float scale = 1);
 	SkeletonRenderer (const std::string& skeletonDataFile, const std::string& atlasFile, float scale = 1);
+
 	virtual ~SkeletonRenderer ();
+
+	void initWithData (spSkeletonData* skeletonData, bool ownsSkeletonData = false);
+	void initWithFile (const std::string& skeletonDataFile, spAtlas* atlas, float scale = 1);
+	void initWithFile (const std::string& skeletonDataFile, const std::string& atlasFile, float scale = 1);
+
 	void initialize ();
 
+protected:
 	void setSkeletonData (spSkeletonData* skeletonData, bool ownsSkeletonData);
 	virtual cocos2d::Texture2D* getTexture (spRegionAttachment* attachment) const;
 	virtual cocos2d::Texture2D* getTexture (spMeshAttachment* attachment) const;


### PR DESCRIPTION
Hi.

These changes are needed for supporting **extend** of this classes in [Cocos2d-x Javascript Binding](https://github.com/cocos2d/cocos2d-js):

1. All constructors and init methods must be in ```CC_CONSTRUCTOR_ACCESS``` scope instead of ```protected``` because of **JSB** binding generator`s needs;
2. I'm add init functions for all constructors of ```SkeletonRenderer``` because we need to init the class after calling empty constructor (That is how **JSB** works).

We can't modify sources of **spine-runtimes** according to the license conditions so in  [Cocos2d-x Javascript Binding](https://github.com/cocos2d/cocos2d-js) we very need these changes.

Hope you understand.
Thanks.