### PR TITLE
[JAVASCRIPT] Atlas attachment loader fix.

### DIFF
--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -2425,7 +2425,7 @@ spine.AtlasAttachmentLoader = function (atlas) {
 };
 spine.AtlasAttachmentLoader.prototype = {
 	newRegionAttachment: function (skin, name, path) {
-		var region = this.atlas.findRegion(name);
+		var region = this.atlas.findRegion(path);
 		if (!region) throw "Region not found in atlas: " + path + " (region attachment: " + name + ")";
 		var attachment = new spine.RegionAttachment(name);
 		attachment.rendererObject = region;
@@ -2439,7 +2439,7 @@ spine.AtlasAttachmentLoader.prototype = {
 		return attachment;
 	},
 	newMeshAttachment: function (skin, name, path) {
-		var region = this.atlas.findRegion(name);
+		var region = this.atlas.findRegion(path);
 		if (!region) throw "Region not found in atlas: " + path + " (mesh attachment: " + name + ")";
 		var attachment = new spine.MeshAttachment(name);
 		attachment.rendererObject = region;
@@ -2457,7 +2457,7 @@ spine.AtlasAttachmentLoader.prototype = {
 		return attachment;
 	},
 	newSkinnedMeshAttachment: function (skin, name, path) {
-		var region = this.atlas.findRegion(name);
+		var region = this.atlas.findRegion(path);
 		if (!region) throw "Region not found in atlas: " + path + " (skinned mesh attachment: " + name + ")";
 		var attachment = new spine.SkinnedMeshAttachment(name);
 		attachment.rendererObject = region;


### PR DESCRIPTION
Atlas attachment loader was using the name as the path to the images in the atlas instead of the path argument passed to it. It would throw an exception using the path argument to report the error, making it extremely confusing. It now properly uses the path argument to look for the image.

This bug made it a requirement to have images and attachments that held them have the same name, not very visible bug in spine because the editor names things properly most of the time but with a more strict naming convention this bug is very evident.

I believe that this bug is present in other runtimes, further investigation is needed.