### PR TITLE
Fix 2D Projects breaking PMA atlases.

### DIFF
--- a/spine-unity/Assets/spine-unity/Editor/SpineEditorUtilities.cs
+++ b/spine-unity/Assets/spine-unity/Editor/SpineEditorUtilities.cs
@@ -390,6 +390,7 @@ public class SpineEditorUtilities : AssetPostprocessor {
 			TextureImporter texImporter = (TextureImporter)TextureImporter.GetAtPath(texturePath);
 			texImporter.textureFormat = TextureImporterFormat.AutomaticTruecolor;
 			texImporter.mipmapEnabled = false;
+			texImporter.alphaIsTransparency = false;
 			texImporter.maxTextureSize = 2048;
 
 			EditorUtility.SetDirty(texImporter);


### PR DESCRIPTION
Disable alphaIsTransparency by default.
This will prevent 2D projects from causing PMA atlases to bleed colors into transparent areas.
