### PR TITLE
[C#] Optional fix for firing events when mixing

### DIFF
--- a/spine-csharp/src/AnimationState.cs
+++ b/spine-csharp/src/AnimationState.cs
@@ -113,7 +113,8 @@ namespace Spine {
 				} else {
 					float previousTime = previous.time;
 					if (!previous.loop && previousTime > previous.endTime) previousTime = previous.endTime;
-					previous.animation.Apply(skeleton, previousTime, previousTime, previous.loop, null);
+					previous.animation.Apply(skeleton, previous.lastTime, previousTime, previous.loop, events);
+					previous.lastTime = previousTime;
 
 					float alpha = current.mixTime / current.mixDuration * current.mix;
 					if (alpha >= 1) {

--- a/spine-csharp/src/AnimationState.cs
+++ b/spine-csharp/src/AnimationState.cs
@@ -113,7 +113,9 @@ namespace Spine {
 				} else {
 					float previousTime = previous.time;
 					if (!previous.loop && previousTime > previous.endTime) previousTime = previous.endTime;
-					previous.animation.Apply(skeleton, previous.lastTime, previousTime, previous.loop, events);
+					previous.animation.Apply(skeleton, previous.lastTime, previousTime, previous.loop, null);
+					// Remove the line above, and uncomment the line below, to allow previous animations to fire events during mixing.
+					//previous.animation.Apply(skeleton, previous.lastTime, previousTime, previous.loop, events);
 					previous.lastTime = previousTime;
 
 					float alpha = current.mixTime / current.mixDuration * current.mix;


### PR DESCRIPTION
Not sure if the same "fix" needs to be applied to other runtimes, or if this was intended behavior at all. But someone in the forums was looking for this fix.