### PR TITLE
[Cocos2dx 2] Schedule update calls when entering the scene.

### DIFF
--- a/spine-cocos2dx/2/src/spine/SkeletonRenderer.cpp
+++ b/spine-cocos2dx/2/src/spine/SkeletonRenderer.cpp
@@ -76,7 +76,6 @@ void SkeletonRenderer::initialize () {
 	setOpacityModifyRGB(true);
 
 	setShaderProgram(CCShaderCache::sharedShaderCache()->programForKey(kCCShader_PositionTextureColor));
-	scheduleUpdate();
 }
 
 void SkeletonRenderer::setSkeletonData (spSkeletonData *skeletonData, bool ownsSkeletonData) {
@@ -128,6 +127,11 @@ SkeletonRenderer::~SkeletonRenderer () {
 	spSkeleton_dispose(skeleton);
 	FREE(worldVertices);
 	batch->release();
+}
+
+void SkeletonRenderer::onEnter () {
+	cocos2d::CCNodeRGBA::onEnter();  
+	scheduleUpdate();
 }
 
 void SkeletonRenderer::update (float deltaTime) {

--- a/spine-cocos2dx/2/src/spine/SkeletonRenderer.h
+++ b/spine-cocos2dx/2/src/spine/SkeletonRenderer.h
@@ -58,6 +58,7 @@ public:
 
 	virtual ~SkeletonRenderer ();
 
+	virtual void onEnter ();
 	virtual void update (float deltaTime);
 	virtual void draw ();
 	virtual cocos2d::CCRect boundingBox ();


### PR DESCRIPTION
If a node is removed from the scene, then Cocos2d-x will unschedule its
selectors. In order to have the animation still playing if the node is
inserted again in the scene, the call to scheduleUpdate() in SkeletonRenderer
must then be done in SkeletonRenderer::onEnter() instead of at initialization
time.

This commit applies this change, making the following code to work:

    void testAnimatedWhenReinserted( SkeletonRenderer& skeleton )
    {
        skeleton.retain();
        cocos2d::CCNode* const parent{ skeleton.getParent() };
        skeleton.removeFromParent();
        parent->addChild( &skeleton );
        skeleton.release();
    }