### PR TITLE
Readme fixes

### DIFF
--- a/spine-cocos2d-iphone/3/README.md
+++ b/spine-cocos2d-iphone/3/README.md
@@ -5,15 +5,15 @@ The spine-cocos2d-iphone runtime provides functionality to load, manipulate and 
 ## Setup
 
 1. Download the Spine Runtimes source using [git](https://help.github.com/articles/set-up-git) or by downloading it [as a zip](https://github.com/EsotericSoftware/spine-runtimes/archive/master.zip).
-1. Place the contents of a cocos2d version 3.0.x distribution into the `spine-cocos2d-iphone/3.0/cocos2d` directory.
-1. Open the XCode project file for iOS or Mac from the `spine-cocos2d-iphone/3.0` directory.
+1. Place the contents of a cocos2d version 3.1 (or higher) distribution into the `spine-cocos2d-iphone/3/cocos2d` directory.
+1. Open the Xcode project file for iOS or Mac from the `spine-cocos2d-iphone/3` directory.
 
-Alternatively, the contents of the `spine-c/src`, `spine-c/include` and `spine-cocos2d-iphone/3.0/src` directories can be copied into your project. Be sure your header search path will find the contents of the `spine-c/include` and `spine-cocos2d-iphone/3.0/src` directories. Note that the includes use `spine/Xxx.h`, so the `spine` directory cannot be omitted when copying the files.
+Alternatively, the contents of the `spine-c/src`, `spine-c/include` and `spine-cocos2d-iphone/3/src` directories can be copied into your project. Be sure your header search path will find the contents of the `spine-c/include` and `spine-cocos2d-iphone/3/src` directories. Note that the includes use `spine/Xxx.h`, so the `spine` directory cannot be omitted when copying the files.
 
 ## Examples
 
-[Spineboy](https://github.com/EsotericSoftware/spine-runtimes/blob/master/spine-cocos2d-iphone/3.0/example/SpineboyExample.cpp)
-[Golbins](https://github.com/EsotericSoftware/spine-runtimes/blob/master/spine-cocos2d-iphone/3.0/example/GoblinsExample.cpp)
+[Spineboy](https://github.com/EsotericSoftware/spine-runtimes/blob/master/spine-cocos2d-iphone/3/example/SpineboyExample.m)
+[Golbins](https://github.com/EsotericSoftware/spine-runtimes/blob/master/spine-cocos2d-iphone/3/example/GoblinsExample.m)
 
 ## Links
 


### PR DESCRIPTION
- directory has been changed from 3.0 to just 3
- the example objective-c files end in .m not .cpp
- the runtime requires CCRenderer, which I believe is only available in 3.1+