### PR TITLE
return the proper local for the module

### DIFF
--- a/spine-lua/SkinnedMeshAttachment.lua
+++ b/spine-lua/SkinnedMeshAttachment.lua
@@ -128,4 +128,4 @@ function SkinnedMeshAttachment.new (name)
 
 	return self
 end
-return MeshAttachment
+return SkinnedMeshAttachment


### PR DESCRIPTION
The SkinnedMeshAttachment.lua returns "MeshAttachment" instead of SkinnedMeshAttachement which results in silently returning a nil value