### PR TITLE
add C++ constructors to all structs (VS Compiler C++ compatibility)

### DIFF
--- a/spine-c/include/spine/Animation.h
+++ b/spine-c/include/spine/Animation.h
@@ -47,6 +47,15 @@ typedef struct spAnimation {
 
 	int timelinesCount;
 	spTimeline** timelines;
+
+#ifdef __cplusplus
+	spAnimation() :
+		name(0),
+		duration(0),
+		timelinesCount(0),
+		timelines(0) {
+	}
+#endif
 } spAnimation;
 
 spAnimation* spAnimation_create (const char* name, int timelinesCount);
@@ -91,8 +100,14 @@ typedef enum {
 
 struct spTimeline {
 	const spTimelineType type;
-
 	const void* const vtable;
+
+#ifdef __cplusplus
+	spTimeline() :
+		type(SP_TIMELINE_SCALE),
+		vtable(0) {
+	}
+#endif
 };
 
 void spTimeline_dispose (spTimeline* self);
@@ -117,6 +132,13 @@ typedef spTimeline Timeline;
 typedef struct spCurveTimeline {
 	spTimeline super;
 	float* curves; /* type, x, y, ... */
+
+#ifdef __cplusplus
+	spCurveTimeline() :
+		super(),
+		curves(0) {
+	}
+#endif
 } spCurveTimeline;
 
 void spCurveTimeline_setLinear (spCurveTimeline* self, int frameIndex);
@@ -143,6 +165,15 @@ typedef struct spBaseTimeline {
 	int const framesCount;
 	float* const frames; /* time, angle, ... for rotate. time, x, y, ... for translate and scale. */
 	int boneIndex;
+
+#ifdef __cplusplus
+	spBaseTimeline() :
+		super(),
+		framesCount(0),
+		frames(0),
+		boneIndex(0) {
+	}
+#endif
 } spBaseTimeline;
 
 /**/
@@ -194,6 +225,15 @@ typedef struct spColorTimeline {
 	int const framesCount;
 	float* const frames; /* time, r, g, b, a, ... */
 	int slotIndex;
+
+#ifdef __cplusplus
+	spColorTimeline() :
+		super(),
+		framesCount(0),
+		frames(0),
+		slotIndex(0) {
+	}
+#endif
 } spColorTimeline;
 
 spColorTimeline* spColorTimeline_create (int framesCount);
@@ -214,6 +254,16 @@ typedef struct spAttachmentTimeline {
 	float* const frames; /* time, ... */
 	int slotIndex;
 	const char** const attachmentNames;
+
+#ifdef __cplusplus
+	spAttachmentTimeline() :
+		super(),
+		framesCount(0),
+		frames(0),
+		slotIndex(0),
+		attachmentNames(0) {
+	}
+#endif
 } spAttachmentTimeline;
 
 spAttachmentTimeline* spAttachmentTimeline_create (int framesCount);
@@ -234,6 +284,15 @@ typedef struct spEventTimeline {
 	int const framesCount;
 	float* const frames; /* time, ... */
 	spEvent** const events;
+
+#ifdef __cplusplus
+	spEventTimeline() :
+		super(),
+		framesCount(0),
+		frames(0),
+		events(0) {
+	}
+#endif
 } spEventTimeline;
 
 spEventTimeline* spEventTimeline_create (int framesCount);
@@ -254,6 +313,16 @@ typedef struct spDrawOrderTimeline {
 	float* const frames; /* time, ... */
 	const int** const drawOrders;
 	int const slotsCount;
+
+#ifdef __cplusplus
+	spDrawOrderTimeline() :
+		super(),
+		framesCount(0),
+		frames(0),
+		drawOrders(0),
+		slotsCount(0) {
+	}
+#endif
 } spDrawOrderTimeline;
 
 spDrawOrderTimeline* spDrawOrderTimeline_create (int framesCount, int slotsCount);
@@ -276,6 +345,17 @@ typedef struct spFFDTimeline {
 	const float** const frameVertices;
 	int slotIndex;
 	spAttachment* attachment;
+
+#ifdef __cplusplus
+	spFFDTimeline() :
+		super(),
+		framesCount(0),
+		frames(0),
+		frameVerticesCount(0),
+		frameVertices(0),
+		slotIndex(0) {
+	}
+#endif
 } spFFDTimeline;
 
 spFFDTimeline* spFFDTimeline_create (int framesCount, int frameVerticesCount);
@@ -295,6 +375,15 @@ typedef struct spIkConstraintTimeline {
 	int const framesCount;
 	float* const frames; /* time, mix, bendDirection, ... */
 	int ikConstraintIndex;
+
+#ifdef __cplusplus
+	spIkConstraintTimeline() :
+		super(),
+		framesCount(0),
+		frames(0),
+		ikConstraintIndex(0) {
+	}
+#endif
 } spIkConstraintTimeline;
 
 spIkConstraintTimeline* spIkConstraintTimeline_create (int framesCount);
@@ -316,6 +405,16 @@ typedef struct spFlipTimeline {
 	int const framesCount;
 	float* const frames; /* time, flip, ... */
 	int boneIndex;
+
+#ifdef __cplusplus
+	spFlipTimeline() :
+		super(),
+		x(0),
+		framesCount(0),
+		frames(0),
+		boneIndex(0) {
+	}
+#endif
 } spFlipTimeline;
 
 spFlipTimeline* spFlipTimeline_create (int framesCount, int/*bool*/x);

--- a/spine-c/include/spine/AnimationState.h
+++ b/spine-c/include/spine/AnimationState.h
@@ -60,6 +60,20 @@ struct spTrackEntry {
 	float mixTime, mixDuration, mix;
 
 	void* rendererObject;
+
+#ifdef __cplusplus
+	spTrackEntry() :
+		state(0),
+		next(0),
+		previous(0),
+		animation(0),
+		loop(0),
+		delay(0), time(0), lastTime(0), endTime(0), timeScale(0),
+		listener(0),
+		mixTime(0), mixDuration(0), mix(0),
+		rendererObject(0) {
+	}
+#endif
 };
 
 struct spAnimationState {
@@ -71,6 +85,17 @@ struct spAnimationState {
 	spTrackEntry** tracks;
 
 	void* rendererObject;
+
+#ifdef __cplusplus
+	spAnimationState() :
+		data(0),
+		timeScale(0),
+		listener(0),
+		tracksCount(0),
+		tracks(0),
+		rendererObject(0) {
+	}
+#endif
 };
 
 /* @param data May be 0 for no mixing. */

--- a/spine-c/include/spine/AnimationStateData.h
+++ b/spine-c/include/spine/AnimationStateData.h
@@ -42,6 +42,14 @@ typedef struct spAnimationStateData {
 	spSkeletonData* const skeletonData;
 	float defaultMix;
 	const void* const entries;
+
+#ifdef __cplusplus
+	spAnimationStateData() :
+		skeletonData(0),
+		defaultMix(0),
+		entries(0) {
+	}
+#endif
 } spAnimationStateData;
 
 spAnimationStateData* spAnimationStateData_create (spSkeletonData* skeletonData);

--- a/spine-c/include/spine/Attachment.h
+++ b/spine-c/include/spine/Attachment.h
@@ -42,8 +42,15 @@ typedef enum {
 typedef struct spAttachment {
 	const char* const name;
 	const spAttachmentType type;
-
 	const void* const vtable;
+
+#ifdef __cplusplus
+	spAttachment() :
+		name(0),
+		type(SP_ATTACHMENT_REGION),
+		vtable(0) {
+	}
+#endif
 } spAttachment;
 
 void spAttachment_dispose (spAttachment* self);

--- a/spine-c/include/spine/Bone.h
+++ b/spine-c/include/spine/Bone.h
@@ -54,6 +54,24 @@ struct spBone {
 	float const worldRotation;
 	float const worldScaleX, worldScaleY;
 	int/*bool*/const worldFlipX, worldFlipY;
+
+#ifdef __cplusplus
+	spBone() :
+		data(0),
+		skeleton(0),
+		parent(0),
+		x(0), y(0),
+		rotation(0), rotationIK(0),
+		scaleX(0), scaleY(0),
+		flipX(0), flipY(0),
+
+		m00(0), m01(0), worldX(0),
+		m10(0), m11(0), worldY(0),
+		worldRotation(0),
+		worldScaleX(0), worldScaleY(0),
+		worldFlipX(0), worldFlipY(0) {
+	}
+#endif
 };
 
 void spBone_setYDown (int/*bool*/yDown);

--- a/spine-c/include/spine/BoneData.h
+++ b/spine-c/include/spine/BoneData.h
@@ -45,6 +45,19 @@ struct spBoneData {
 	float scaleX, scaleY;
 	int/*bool*/flipX, flipY;
 	int/*bool*/inheritScale, inheritRotation;
+
+#ifdef __cplusplus
+	spBoneData() :
+		name(0),
+		parent(0),
+		length(0),
+		x(0), y(0),
+		rotation(0),
+		scaleX(0), scaleY(0),
+		flipX(0), flipY(0),
+		inheritScale(0), inheritRotation(0) {
+	}
+#endif
 };
 
 spBoneData* spBoneData_create (const char* name, spBoneData* parent);

--- a/spine-c/include/spine/Event.h
+++ b/spine-c/include/spine/Event.h
@@ -42,6 +42,15 @@ typedef struct spEvent {
 	int intValue;
 	float floatValue;
 	const char* stringValue;
+
+#ifdef __cplusplus
+	spEvent() :
+		data(0),
+		intValue(0),
+		floatValue(0),
+		stringValue(0) {
+	}
+#endif
 } spEvent;
 
 spEvent* spEvent_create (spEventData* data);

--- a/spine-c/include/spine/EventData.h
+++ b/spine-c/include/spine/EventData.h
@@ -40,6 +40,15 @@ typedef struct spEventData {
 	int intValue;
 	float floatValue;
 	const char* stringValue;
+
+#ifdef __cplusplus
+	spEventData() :
+		name(0),
+		intValue(0),
+		floatValue(0),
+		stringValue(0) {
+	}
+#endif
 } spEventData;
 
 spEventData* spEventData_create (const char* name);

--- a/spine-c/include/spine/IkConstraint.h
+++ b/spine-c/include/spine/IkConstraint.h
@@ -49,6 +49,17 @@ typedef struct spIkConstraint {
 	spBone* target;
 	int bendDirection;
 	float mix;
+
+#ifdef __cplusplus
+	spIkConstraint() :
+		data(0),
+		bonesCount(0),
+		bones(0),
+		target(0),
+		bendDirection(0),
+		mix(0) {
+	}
+#endif
 } spIkConstraint;
 
 spIkConstraint* spIkConstraint_create (spIkConstraintData* data, const struct spSkeleton* skeleton);

--- a/spine-c/include/spine/IkConstraintData.h
+++ b/spine-c/include/spine/IkConstraintData.h
@@ -46,6 +46,17 @@ typedef struct spIkConstraintData {
 	spBoneData* target;
 	int bendDirection;
 	float mix;
+
+#ifdef __cplusplus
+	spIkConstraintData() :
+		name(0),
+		bonesCount(0),
+		bones(0),
+		target(0),
+		bendDirection(0),
+		mix(0) {
+	}
+#endif
 } spIkConstraintData;
 
 spIkConstraintData* spIkConstraintData_create (const char* name);

--- a/spine-c/include/spine/Skeleton.h
+++ b/spine-c/include/spine/Skeleton.h
@@ -59,6 +59,28 @@ typedef struct spSkeleton {
 	float time;
 	int/*bool*/flipX, flipY;
 	float x, y;
+
+#ifdef __cplusplus
+	spSkeleton() :
+		data(0),
+		bonesCount(0),
+		bones(0),
+		root(0),
+		slotsCount(0),
+		slots(0),
+		drawOrder(0),
+
+		ikConstraintsCount(0),
+		ikConstraints(0),
+
+		skin(0),
+		r(0), g(0), b(0), a(0),
+		time(0),
+		flipX(0),
+		flipY(0),
+		x(0), y(0) {
+	}
+#endif
 } spSkeleton;
 
 spSkeleton* spSkeleton_create (spSkeletonData* data);

--- a/spine-c/include/spine/Skin.h
+++ b/spine-c/include/spine/Skin.h
@@ -41,6 +41,12 @@ struct spSkeleton;
 
 typedef struct spSkin {
 	const char* const name;
+
+#ifdef __cplusplus
+	spSkin() :
+		name(0) {
+	}
+#endif
 } spSkin;
 
 spSkin* spSkin_create (const char* name);

--- a/spine-c/include/spine/Slot.h
+++ b/spine-c/include/spine/Slot.h
@@ -48,6 +48,18 @@ typedef struct spSlot {
 	int attachmentVerticesCapacity;
 	int attachmentVerticesCount;
 	float* attachmentVertices;
+
+#ifdef __cplusplus
+	spSlot() :
+		data(0),
+		bone(0),
+		r(0), b(0), g(0), a(0),
+		attachment(0),
+		attachmentVerticesCapacity(0),
+		attachmentVerticesCount(0),
+		attachmentVertices(0) {
+	}
+#endif
 } spSlot;
 
 spSlot* spSlot_create (spSlotData* data, spBone* bone);

--- a/spine-c/include/spine/SlotData.h
+++ b/spine-c/include/spine/SlotData.h
@@ -43,6 +43,16 @@ typedef struct spSlotData {
 	const char* attachmentName;
 	float r, g, b, a;
 	int/*bool*/additiveBlending;
+
+#ifdef __cplusplus
+	spSlotData() :
+		name(0),
+		boneData(0),
+		attachmentName(0),
+		r(0), g(0), b(0), a(0),
+		additiveBlending(0) {
+	}
+#endif
 } spSlotData;
 
 spSlotData* spSlotData_create (const char* name, spBoneData* boneData);

--- a/spine-c/include/spine/extension.h
+++ b/spine-c/include/spine/extension.h
@@ -130,6 +130,15 @@ typedef struct _spAnimationState {
 
 	spTrackEntry* (*createTrackEntry) (spAnimationState* self);
 	void (*disposeTrackEntry) (spTrackEntry* entry);
+
+#ifdef __cplusplus
+	_spAnimationState() :
+		super(),
+		events(0),
+		createTrackEntry(0),
+		disposeTrackEntry(0) {
+	}
+#endif
 } _spAnimationState;
 
 spTrackEntry* _spTrackEntry_create (spAnimationState* self);


### PR DESCRIPTION
for Visual Studio compiler compatibility where projects are using C++

----------------

spine-c now compiles successfully in VS 2013!

I don't know what I'm doing with regards to what values to use for initialization.  most things are ints, floats, chars or pointers so I set them to 0 and hope that it will all work out somehow. I think they will all be overwritten by your custom OO create methods but I'm not sure how that all works. Maybe take a cursory glance at that? Also the super() inits, did I do those right?