### PR TITLE
[c] Allow to create slots and bones on fly

### DIFF
--- a/spine-c/include/spine/Skeleton.h
+++ b/spine-c/include/spine/Skeleton.h
@@ -72,11 +72,13 @@ void spSkeleton_setToSetupPose (const spSkeleton* self);
 void spSkeleton_setBonesToSetupPose (const spSkeleton* self);
 void spSkeleton_setSlotsToSetupPose (const spSkeleton* self);
 
+void spSkeleton_addBone (spSkeleton* self, spBone *bone);
 /* Returns 0 if the bone was not found. */
 spBone* spSkeleton_findBone (const spSkeleton* self, const char* boneName);
 /* Returns -1 if the bone was not found. */
 int spSkeleton_findBoneIndex (const spSkeleton* self, const char* boneName);
 
+void spSkeleton_addSlot (spSkeleton* self, spSlot *slot);
 /* Returns 0 if the slot was not found. */
 spSlot* spSkeleton_findSlot (const spSkeleton* self, const char* slotName);
 /* Returns -1 if the slot was not found. */
@@ -96,7 +98,14 @@ spAttachment* spSkeleton_getAttachmentForSlotName (const spSkeleton* self, const
 /* Returns 0 if the slot or attachment was not found. */
 spAttachment* spSkeleton_getAttachmentForSlotIndex (const spSkeleton* self, int slotIndex, const char* attachmentName);
 /* Returns 0 if the slot or attachment was not found. */
+
+spAttachment* spSkeleton_getAttachmentByName (const spSkeleton* self, const char* attachmentName);
+
 int spSkeleton_setAttachment (spSkeleton* self, const char* slotName, const char* attachmentName);
+
+int spSkeleton_setAttachment2 (spSkeleton* self, const char* slotName, const char* attachmentName);
+
+int spSkeleton_setAttachmentFromSkin (spSkeleton* self, const char* slotName, const char * skinName, const char* attachmentName);
 
 /* Returns 0 if the IK constraint was not found. */
 spIkConstraint* spSkeleton_findIkConstraint (const spSkeleton* self, const char* ikConstraintName);
@@ -105,22 +114,27 @@ void spSkeleton_update (spSkeleton* self, float deltaTime);
 
 #ifdef SPINE_SHORT_NAMES
 typedef spSkeleton Skeleton;
-#define Skeleton_create(...) spSkeleton_create(__VA_ARGS__)
-#define Skeleton_dispose(...) spSkeleton_dispose(__VA_ARGS__)
-#define Skeleton_updateWorldTransform(...) spSkeleton_updateWorldTransform(__VA_ARGS__)
-#define Skeleton_setToSetupPose(...) spSkeleton_setToSetupPose(__VA_ARGS__)
-#define Skeleton_setBonesToSetupPose(...) spSkeleton_setBonesToSetupPose(__VA_ARGS__)
-#define Skeleton_setSlotsToSetupPose(...) spSkeleton_setSlotsToSetupPose(__VA_ARGS__)
-#define Skeleton_findBone(...) spSkeleton_findBone(__VA_ARGS__)
-#define Skeleton_findBoneIndex(...) spSkeleton_findBoneIndex(__VA_ARGS__)
-#define Skeleton_findSlot(...) spSkeleton_findSlot(__VA_ARGS__)
-#define Skeleton_findSlotIndex(...) spSkeleton_findSlotIndex(__VA_ARGS__)
-#define Skeleton_setSkin(...) spSkeleton_setSkin(__VA_ARGS__)
-#define Skeleton_setSkinByName(...) spSkeleton_setSkinByName(__VA_ARGS__)
-#define Skeleton_getAttachmentForSlotName(...) spSkeleton_getAttachmentForSlotName(__VA_ARGS__)
+#define Skeleton_create(...)					spSkeleton_create(__VA_ARGS__)
+#define Skeleton_dispose(...)					spSkeleton_dispose(__VA_ARGS__)
+#define Skeleton_updateWorldTransform(...)		spSkeleton_updateWorldTransform(__VA_ARGS__)
+#define Skeleton_setToSetupPose(...)			spSkeleton_setToSetupPose(__VA_ARGS__)
+#define Skeleton_setBonesToSetupPose(...)		spSkeleton_setBonesToSetupPose(__VA_ARGS__)
+#define Skeleton_setSlotsToSetupPose(...)		spSkeleton_setSlotsToSetupPose(__VA_ARGS__)
+#define Skeleton_addBone(...)					spSkeleton_addBone(__VA_ARGS__)
+#define Skeleton_findBone(...)					spSkeleton_findBone(__VA_ARGS__)
+#define Skeleton_findBoneIndex(...)				spSkeleton_findBoneIndex(__VA_ARGS__)
+#define Skeleton_addSlot(...)					spSkeleton_addSlot(__VA_ARGS__)
+#define Skeleton_findSlot(...)					spSkeleton_findSlot(__VA_ARGS__)
+#define Skeleton_findSlotIndex(...)				spSkeleton_findSlotIndex(__VA_ARGS__)
+#define Skeleton_setSkin(...)					spSkeleton_setSkin(__VA_ARGS__)
+#define Skeleton_setSkinByName(...)				spSkeleton_setSkinByName(__VA_ARGS__)
+#define Skeleton_getAttachmentForSlotName(...)	spSkeleton_getAttachmentForSlotName(__VA_ARGS__)
 #define Skeleton_getAttachmentForSlotIndex(...) spSkeleton_getAttachmentForSlotIndex(__VA_ARGS__)
-#define Skeleton_setAttachment(...) spSkeleton_setAttachment(__VA_ARGS__)
-#define Skeleton_update(...) spSkeleton_update(__VA_ARGS__)
+#define Skeleton_getAttachmentByName(...)		spSkeleton_getAttachmentByName(__VA_ARGS__)
+#define Skeleton_setAttachment(...)				spSkeleton_setAttachment(__VA_ARGS__)
+#define Skeleton_setAttachment2(...)			spSkeleton_setAttachment2(__VA_ARGS__)
+#define Skeleton_setAttachmentFromSkin(...)		spSkeleton_setAttachmentFromSkin(__VA_ARGS__)
+#define Skeleton_update(...)					spSkeleton_update(__VA_ARGS__)
 #endif
 
 #ifdef __cplusplus

--- a/spine-c/include/spine/Skin.h
+++ b/spine-c/include/spine/Skin.h
@@ -51,6 +51,9 @@ void spSkin_addAttachment (spSkin* self, int slotIndex, const char* name, spAtta
 /* Returns 0 if the attachment was not found. */
 spAttachment* spSkin_getAttachment (const spSkin* self, int slotIndex, const char* name);
 
+/* Returns 0 if the attachment was not found. */
+spAttachment* spSkin_getAttachment2 (const spSkin* self, const char* name);
+
 /* Returns 0 if the slot or attachment was not found. */
 const char* spSkin_getAttachmentName (const spSkin* self, int slotIndex, int attachmentIndex);
 
@@ -63,6 +66,7 @@ typedef spSkin Skin;
 #define Skin_dispose(...) spSkin_dispose(__VA_ARGS__)
 #define Skin_addAttachment(...) spSkin_addAttachment(__VA_ARGS__)
 #define Skin_getAttachment(...) spSkin_getAttachment(__VA_ARGS__)
+#define Skin_getAttachment2(...) spSkin_getAttachment2(__VA_ARGS__)
 #define Skin_getAttachmentName(...) spSkin_getAttachmentName(__VA_ARGS__)
 #define Skin_attachAll(...) spSkin_attachAll(__VA_ARGS__)
 #endif

--- a/spine-c/src/spine/Skeleton.c
+++ b/spine-c/src/spine/Skeleton.c
@@ -234,6 +234,19 @@ void spSkeleton_setSlotsToSetupPose (const spSkeleton* self) {
 		spSlot_setToSetupPose(self->slots[i]);
 }
 
+void spSkeleton_addBone (spSkeleton* self, spBone *bone) {
+	self->bones = (spBone **) realloc(self->bones, sizeof(spBone *) * (self->bonesCount + 1));
+	self->bones[self->bonesCount] = bone;
+
+	self->data->bones = (spBoneData **) realloc(self->data->bones, sizeof(spBoneData *) * (self->bonesCount + 1));
+	self->data->bones[self->bonesCount] = bone->data;
+
+	++self->bonesCount;
+	++self->data->bonesCount;
+
+	spSkeleton_updateCache(self);
+}
+
 spBone* spSkeleton_findBone (const spSkeleton* self, const char* boneName) {
 	int i;
 	for (i = 0; i < self->bonesCount; ++i)
@@ -246,6 +259,54 @@ int spSkeleton_findBoneIndex (const spSkeleton* self, const char* boneName) {
 	for (i = 0; i < self->bonesCount; ++i)
 		if (strcmp(self->data->bones[i]->name, boneName) == 0) return i;
 	return -1;
+}
+
+void _spSkeleton_addLastSlotToAnimations(spSkeleton* self)
+{
+	spAnimation *anim;
+	spTimeline *timeline;
+	spDrawOrderTimeline *drawOrderTL;
+	int	a, numAnims, t, numTL, f, numFrames;
+
+	numAnims = self->data->animationsCount;
+	for(a=0; a<numAnims; ++a)
+	{
+		anim = self->data->animations[a];
+
+		numTL = anim->timelinesCount;
+		for(t=0; t<numTL; ++t)
+		{
+			timeline = anim->timelines[t];
+			if(timeline->type == SP_TIMELINE_DRAWORDER)
+			{
+				drawOrderTL = SUB_CAST(spDrawOrderTimeline, timeline);
+				++CONST_CAST(int, drawOrderTL->slotsCount);
+
+				numFrames = drawOrderTL->framesCount;
+				for(f=0; f<numFrames; ++f)
+				{
+					drawOrderTL->drawOrders[f] = (int *) realloc(CONST_CAST(int*, drawOrderTL->drawOrders[f]), sizeof(int) * self->slotsCount);
+					CONST_CAST(int*, drawOrderTL->drawOrders[f])[self->slotsCount-1] = self->slotsCount-1;
+				}
+			}
+		}
+	}
+}
+
+void spSkeleton_addSlot (spSkeleton* self, spSlot *slot) {
+	self->slots = (spSlot **) realloc(self->slots, sizeof(spSlot *) * (self->slotsCount + 1));
+	self->slots[self->slotsCount] = slot;
+
+	self->drawOrder = (spSlot **) realloc(self->drawOrder, sizeof(spSlot *) * (self->slotsCount + 1));
+	self->drawOrder[self->slotsCount] = slot;
+
+	self->data->slots = (spSlotData **) realloc(self->data->slots, sizeof(spSlotData *) * (self->slotsCount + 1));
+	self->data->slots[self->slotsCount] = slot->data;
+
+	++self->slotsCount;
+	++self->data->slotsCount;
+
+	_spSkeleton_addLastSlotToAnimations(self);
 }
 
 spSlot* spSkeleton_findSlot (const spSkeleton* self, const char* slotName) {
@@ -311,6 +372,28 @@ spAttachment* spSkeleton_getAttachmentForSlotIndex (const spSkeleton* self, int 
 	return 0;
 }
 
+spAttachment* spSkeleton_getAttachmentByName (const spSkeleton* self, const char* attachmentName) 
+{
+	if (self->skin) {
+		spAttachment *attachment = spSkin_getAttachment2(self->skin, attachmentName);
+		if (attachment) return attachment;
+	}
+	if (self->data->defaultSkin) {
+		spAttachment *attachment = spSkin_getAttachment2(self->data->defaultSkin, attachmentName);
+		if (attachment) return attachment;
+	}
+	return 0;
+}
+
+spAttachment* spSkeleton_getAttachmentFromSkin (const spSkeleton* self, const spSkin *skin, const char* attachmentName) 
+{
+	if (skin) {
+		spAttachment *attachment = spSkin_getAttachment2(skin, attachmentName);
+		if (attachment) return attachment;
+	}
+	return 0;
+}
+
 int spSkeleton_setAttachment (spSkeleton* self, const char* slotName, const char* attachmentName) {
 	int i;
 	for (i = 0; i < self->slotsCount; ++i) {
@@ -320,6 +403,50 @@ int spSkeleton_setAttachment (spSkeleton* self, const char* slotName, const char
 				spSlot_setAttachment(slot, 0);
 			else {
 				spAttachment* attachment = spSkeleton_getAttachmentForSlotIndex(self, i, attachmentName);
+				if (!attachment) return 0;
+				spSlot_setAttachment(slot, attachment);
+			}
+			return 1;
+		}
+	}
+	return 0;
+}
+
+int spSkeleton_setAttachment2 (spSkeleton* self, const char* slotName, const char* attachmentName) {
+	int i;
+	for (i = 0; i < self->slotsCount; ++i) {
+		spSlot *slot = self->slots[i];
+		if (strcmp(slot->data->name, slotName) == 0) {
+			if (!attachmentName)
+				spSlot_setAttachment(slot, 0);
+			else {
+				spAttachment* attachment = spSkeleton_getAttachmentByName(self, attachmentName);
+				if (!attachment) return 0;
+				spSlot_setAttachment(slot, attachment);
+			}
+			return 1;
+		}
+	}
+	return 0;
+}
+
+int spSkeleton_setAttachmentFromSkin (spSkeleton* self, const char* slotName, const char * skinName, const char* attachmentName) {
+	int i;
+	spSkin	*skin = 0;
+	for (i = 0; i < self->data->skinsCount; ++i) {
+		if (strcmp(self->data->skins[i]->name, skinName) == 0) {
+			skin = self->data->skins[i];
+		}
+	}
+	if(skin == 0) return 0;
+
+	for (i = 0; i < self->slotsCount; ++i) {
+		spSlot *slot = self->slots[i];
+		if (strcmp(slot->data->name, slotName) == 0) {
+			if (!attachmentName)
+				spSlot_setAttachment(slot, 0);
+			else {
+				spAttachment* attachment = spSkeleton_getAttachmentFromSkin (self, skin, attachmentName);
 				if (!attachment) return 0;
 				spSlot_setAttachment(slot, attachment);
 			}

--- a/spine-c/src/spine/Skin.c
+++ b/spine-c/src/spine/Skin.c
@@ -93,6 +93,15 @@ spAttachment* spSkin_getAttachment (const spSkin* self, int slotIndex, const cha
 	return 0;
 }
 
+spAttachment* spSkin_getAttachment2 (const spSkin* self, const char* name) {
+	const _Entry* entry = SUB_CAST(_spSkin, self)->entries;
+	while (entry) {
+		if (strcmp(entry->name, name) == 0) return entry->attachment;
+		entry = entry->next;
+	}
+	return 0;
+}
+
 const char* spSkin_getAttachmentName (const spSkin* self, int slotIndex, int attachmentIndex) {
 	const _Entry* entry = SUB_CAST(_spSkin, self)->entries;
 	int i = 0;


### PR DESCRIPTION
Allow to create slots and bones on fly, get attachments by name, and set attachments from other skins

Added functions:
- Skeleton: spSkeleton_addBone, spSkeleton_addSlot, spSkeleton_getAttachmentByName, spSkeleton_setAttachment2, spSkeleton_setAttachmentFromSkin
- Skin: spSkin_getAttachment2
