### PR TITLE
Fixes uninitialized variable in flip timelines.

### DIFF
--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -887,7 +887,7 @@ spine.FlipXTimeline.prototype = {
 			lastTime = -1;
 		var frameIndex = (time >= frames[frames.length - 2] ? frames.length : spine.Animation.binarySearch(frames, time, 2)) - 2;
 		if (frames[frameIndex] < lastTime) return;
-		skeleton.bones[boneIndex].flipX = frames[frameIndex + 1] != 0;
+		skeleton.bones[this.boneIndex].flipX = frames[frameIndex + 1] != 0;
 	}
 };
 
@@ -915,7 +915,7 @@ spine.FlipYTimeline.prototype = {
 			lastTime = -1;
 		var frameIndex = (time >= frames[frames.length - 2] ? frames.length : spine.Animation.binarySearch(frames, time, 2)) - 2;
 		if (frames[frameIndex] < lastTime) return;
-		skeleton.bones[boneIndex].flipY = frames[frameIndex + 1] != 0;
+		skeleton.bones[this.boneIndex].flipY = frames[frameIndex + 1] != 0;
 	}
 };
 


### PR DESCRIPTION
Caused an exception when flip timelines were used.