### PR TITLE
[LUA] Added missing require

### DIFF
--- a/spine-lua/AttachmentLoader.lua
+++ b/spine-lua/AttachmentLoader.lua
@@ -30,6 +30,7 @@
 
 local AttachmentType = require "spine-lua.AttachmentType"
 local RegionAttachment = require "spine-lua.RegionAttachment"
+local MeshAttachment = require "spine-lua.MeshAttachment"
 local BoundingBoxAttachment = require "spine-lua.BoundingBoxAttachment"
 
 local AttachmentLoader = {}


### PR DESCRIPTION
Corona SDK was throwing the following error:
File: spine-lua/AttachmentLoader.lua
Line: 46
Attempt to index global 'MeshAttachment' (a nil value)