### PR TITLE
Move attachmentVertices[] from the prototype and into the constructor

### DIFF
--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -162,13 +162,13 @@ spine.Bone.prototype = {
 spine.Slot = function (slotData, bone) {
 	this.data = slotData;
 	this.bone = bone;
+	this.attachmentVertices: [],
 	this.setToSetupPose();
 };
 spine.Slot.prototype = {
 	r: 1, g: 1, b: 1, a: 1,
 	_attachmentTime: 0,
 	attachment: null,
-	attachmentVertices: [],
 	setAttachment: function (attachment) {
 		this.attachment = attachment;
 		this._attachmentTime = this.bone.skeleton.time;


### PR DESCRIPTION
Animations with multiple mesh attachments appeared corrupt when using spine-js.  Looks like the attachmentVertices array was being shared amongst all spine.Slot instances.  I have moved the declaration out of the prototype function and into the constructor function.