### PR TITLE
spine.js FFD and flipX/flipY rotation fixes

### DIFF
--- a/spine-c/src/spine/Bone.c
+++ b/spine-c/src/spine/Bone.c
@@ -66,10 +66,17 @@ void spBone_updateWorldTransform (spBone* self) {
 			CONST_CAST(float, self->worldScaleX) = self->scaleX;
 			CONST_CAST(float, self->worldScaleY) = self->scaleY;
 		}
-		CONST_CAST(float, self->worldRotation) =
-				self->data->inheritRotation ? self->parent->worldRotation + self->rotationIK : self->rotationIK;
 		CONST_CAST(int, self->worldFlipX) = self->parent->worldFlipX ^ self->flipX;
 		CONST_CAST(int, self->worldFlipY) = self->parent->worldFlipY ^ self->flipY;
+		if ( self->data->inheritRotation )
+		{
+			if ( self->worldFlipX || self->worldFlipY )
+				CONST_CAST(float, self->worldRotation) = (360.f-self->parent->worldRotation) + self->rotationIK;
+			else
+				CONST_CAST(float, self->worldRotation) = self->parent->worldRotation + self->rotationIK;
+		}
+		else
+			CONST_CAST(float, self->worldRotation) = self->rotationIK;
 	} else {
 		int skeletonFlipX = self->skeleton->flipX, skeletonFlipY = self->skeleton->flipY;
 		CONST_CAST(float, self->worldX) = self->skeleton->flipX ? -self->x : self->x;

--- a/spine-c/src/spine/Bone.c
+++ b/spine-c/src/spine/Bone.c
@@ -66,6 +66,7 @@ void spBone_updateWorldTransform (spBone* self) {
 			CONST_CAST(float, self->worldScaleX) = self->scaleX;
 			CONST_CAST(float, self->worldScaleY) = self->scaleY;
 		}
+
 		CONST_CAST(int, self->worldFlipX) = self->parent->worldFlipX ^ self->flipX;
 		CONST_CAST(int, self->worldFlipY) = self->parent->worldFlipY ^ self->flipY;
 		if ( self->data->inheritRotation )
@@ -75,6 +76,8 @@ void spBone_updateWorldTransform (spBone* self) {
 			else
 				CONST_CAST(float, self->worldRotation) = self->parent->worldRotation + self->rotationIK;
 		}
+		else if ( self->worldFlipX ^ self->worldFlipY )
+			CONST_CAST(float, self->worldRotation) = -self->rotationIK;
 		else
 			CONST_CAST(float, self->worldRotation) = self->rotationIK;
 	} else {
@@ -83,10 +86,14 @@ void spBone_updateWorldTransform (spBone* self) {
 		CONST_CAST(float, self->worldY) = self->skeleton->flipY != yDown ? -self->y : self->y;
 		CONST_CAST(float, self->worldScaleX) = self->scaleX;
 		CONST_CAST(float, self->worldScaleY) = self->scaleY;
-		CONST_CAST(float, self->worldRotation) = self->rotationIK;
 		CONST_CAST(int, self->worldFlipX) = skeletonFlipX ^ self->flipX;
 		CONST_CAST(int, self->worldFlipY) = skeletonFlipY ^ self->flipY;
+		if ( self->worldFlipX ^ self->worldFlipY )
+			CONST_CAST(float, self->worldRotation) = -self->rotationIK;
+		else
+			CONST_CAST(float, self->worldRotation) = self->rotationIK;
 	}
+		
 	radians = self->worldRotation * DEG_RAD;
 	cosine = COS(radians);
 	sine = SIN(radians);

--- a/spine-c/src/spine/Bone.c
+++ b/spine-c/src/spine/Bone.c
@@ -70,7 +70,7 @@ void spBone_updateWorldTransform (spBone* self) {
 		CONST_CAST(int, self->worldFlipY) = self->parent->worldFlipY ^ self->flipY;
 		if ( self->data->inheritRotation )
 		{
-			if ( self->worldFlipX || self->worldFlipY )
+			if ( self->worldFlipX ^ self->worldFlipY )
 				CONST_CAST(float, self->worldRotation) = (360.f-self->parent->worldRotation) + self->rotationIK;
 			else
 				CONST_CAST(float, self->worldRotation) = self->parent->worldRotation + self->rotationIK;

--- a/spine-csharp/src/Bone.cs
+++ b/spine-csharp/src/Bone.cs
@@ -96,9 +96,17 @@ namespace Spine {
 					worldScaleX = scaleX;
 					worldScaleY = scaleY;
 				}
-				worldRotation = data.inheritRotation ? parent.worldRotation + rotationIK : rotationIK;
 				worldFlipX = parent.worldFlipX != flipX;
 				worldFlipY = parent.worldFlipY != flipY;
+				if (data.inheritRotation) {
+					if ( worldFlipX ^ worldFlipY ) {
+							worldRotation = (360-parent.worldRotation) + rotationIK;
+					} else {
+						worldRotation = parent.worldRotation + rotationIK;
+					}
+				} else {
+					worldRotation = rotationIK;
+				}
 			} else {
 				Skeleton skeleton = this.skeleton;
 				bool skeletonFlipX = skeleton.flipX, skeletonFlipY = skeleton.flipY;

--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -162,7 +162,7 @@ spine.Bone.prototype = {
 spine.Slot = function (slotData, bone) {
 	this.data = slotData;
 	this.bone = bone;
-	this.attachmentVertices: [],
+	this.attachmentVertices: [];
 	this.setToSetupPose();
 };
 spine.Slot.prototype = {

--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -897,7 +897,7 @@ spine.FlipXTimeline.prototype = {
 			lastTime = -1;
 		var frameIndex = (time >= frames[frames.length - 2] ? frames.length : spine.Animation.binarySearch(frames, time, 2)) - 2;
 		if (frames[frameIndex] < lastTime) return;
-		skeleton.bones[boneIndex].flipX = frames[frameIndex + 1] != 0;
+		skeleton.bones[this.boneIndex].flipX = frames[frameIndex + 1] != 0;
 	}
 };
 
@@ -2514,6 +2514,7 @@ spine.SkeletonBounds.prototype = {
 		for (var i = 0; i < slotCount; i++) {
 			var slot = slots[i];
 			var boundingBox = slot.attachment;
+			if (!boundingBox) continue;
 			if (boundingBox.type != spine.AttachmentType.boundingbox) continue;
 			boundingBoxes.push(boundingBox);
 

--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -2089,15 +2089,15 @@ spine.SkeletonJson.prototype = {
 							var nn = verticesValue.length;
 							if (this.scale == 1) {
 								for (var ii = 0; ii < nn; ii++)
-									vertices[ii + start] = verticesValue[ii];
+									vertices[ii + start] = (verticesValue[ii] || 0);
 							} else {
 								for (var ii = 0; ii < nn; ii++)
-									vertices[ii + start] = verticesValue[ii] * this.scale;
+									vertices[ii + start] = (verticesValue[ii] || 0) * this.scale;
 							}
 							if (isMesh) {
 								var meshVertices = attachment.vertices;
 								for (var ii = 0, nn = vertices.length; ii < nn; ii++)
-									vertices[ii] += meshVertices[ii];
+									vertices[ii] = (vertices[ii]||0) + (meshVertices[ii]||0);
 							}
 						}
 						

--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -162,13 +162,13 @@ spine.Bone.prototype = {
 spine.Slot = function (slotData, bone) {
 	this.data = slotData;
 	this.bone = bone;
+	this.attachmentVertices: [],
 	this.setToSetupPose();
 };
 spine.Slot.prototype = {
 	r: 1, g: 1, b: 1, a: 1,
 	_attachmentTime: 0,
 	attachment: null,
-	attachmentVertices: [],
 	setAttachment: function (attachment) {
 		this.attachment = attachment;
 		this._attachmentTime = this.bone.skeleton.time;

--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -2053,7 +2053,7 @@ spine.SkeletonJson.prototype = {
 				frameIndex++;
 			}
 			timelines.push(timeline);
-			duration = Math.max(duration, timeline.frames[timeline.frameCount * 3 - 3]);
+			duration = Math.max(duration, timeline.frames[timeline.getFrameCount() * 3 - 3]);
 		}
 
 		var ffd = map["ffd"];
@@ -2114,7 +2114,7 @@ spine.SkeletonJson.prototype = {
 						frameIndex++;
 					}
 					timelines[timelines.length] = timeline;
-					duration = Math.max(duration, timeline.frames[timeline.frameCount - 1]);
+					duration = Math.max(duration, timeline.frames[timeline.getFrameCount() - 1]);
 				}
 			}
 		}

--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -99,9 +99,17 @@ spine.Bone.prototype = {
 				this.worldScaleX = this.scaleX;
 				this.worldScaleY = this.scaleY;
 			}
-			this.worldRotation = this.data.inheritRotation ? (parent.worldRotation + this.rotationIK) : this.rotationIK;
 			this.worldFlipX = parent.worldFlipX != this.flipX;
 			this.worldFlipY = parent.worldFlipY != this.flipY;
+			if (this.data.inheritRotation) {
+				if ((this.worldFlipX || this.worldFlipY) && (this.worldFlipX != this.worldFlipY)) {	// xor
+					this.worldRotation = (360-parent.worldRotation) + this.rotationIK;
+				} else {
+					this.worldRotation = parent.worldRotation + this.rotationIK;
+				}
+			} else {
+				this.worldRotation = this.rotationIK;
+			}
 		} else {
 			var skeletonFlipX = this.skeleton.flipX, skeletonFlipY = this.skeleton.flipY;
 			this.worldX = skeletonFlipX ? -this.x : this.x;

--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -162,7 +162,7 @@ spine.Bone.prototype = {
 spine.Slot = function (slotData, bone) {
 	this.data = slotData;
 	this.bone = bone;
-	this.attachmentVertices: [];
+	this.attachmentVertices = [];
 	this.setToSetupPose();
 };
 spine.Slot.prototype = {

--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -810,13 +810,15 @@ spine.FfdTimeline.prototype = {
 
 		if (alpha < 1) {
 			for (var i = 0; i < vertexCount; i++) {
-				var prev = prevVertices[i];
-				vertices[i] += (prev + (nextVertices[i] - prev) * percent - vertices[i]) * alpha;
+				var prev = prevVertices[i]||0;
+				var next = nextVertices[i]||0;
+				vertices[i] += (prev + (next - prev) * percent - vertices[i]) * alpha;
 			}
 		} else {
 			for (var i = 0; i < vertexCount; i++) {
-				var prev = prevVertices[i];
-				vertices[i] = prev + (nextVertices[i] - prev) * percent;
+				var prev = prevVertices[i]||0;
+				var next = nextVertices[i]||0;
+				vertices[i] = prev + (next - prev) * percent;
 			}
 		}
 	}

--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -1730,6 +1730,8 @@ spine.SkeletonJson.prototype = {
 			boneData.rotation = (boneMap["rotation"] || 0);
 			boneData.scaleX = boneMap.hasOwnProperty("scaleX") ? boneMap["scaleX"] : 1;
 			boneData.scaleY = boneMap.hasOwnProperty("scaleY") ? boneMap["scaleY"] : 1;
+			boneData.flipX = boneMap["flipX"] || false;
+			boneData.flipY = boneMap["flipY"] || false;
 			boneData.inheritScale = boneMap.hasOwnProperty("inheritScale") ? boneMap["inheritScale"] : true;
 			boneData.inheritRotation = boneMap.hasOwnProperty("inheritRotation") ? boneMap["inheritRotation"] : true;
 			skeletonData.bones.push(boneData);


### PR DESCRIPTION
Animations with multiple mesh attachments appeared corrupt when using spine-js. Looks like the attachmentVertices array was being shared amongst all spine.Slot instances. I have moved the declaration out of the prototype function and into the constructor function.