### PR TITLE
[Unity] Fixed event syntax cause JIT compiling on iOS devices

### DIFF
--- a/spine-unity/Assets/spine-unity/SkeletonAnimation.cs
+++ b/spine-unity/Assets/spine-unity/SkeletonAnimation.cs
@@ -58,9 +58,9 @@ public class SkeletonAnimation : SkeletonRenderer, ISkeletonAnimation {
 		remove { _UpdateComplete -= value; }
 	}
 
-	protected event UpdateBonesDelegate _UpdateLocal;
-	protected event UpdateBonesDelegate _UpdateWorld;
-	protected event UpdateBonesDelegate _UpdateComplete;
+	protected UpdateBonesDelegate _UpdateLocal;
+	protected UpdateBonesDelegate _UpdateWorld;
+	protected UpdateBonesDelegate _UpdateComplete;
 
 	[SerializeField]
 	private String

--- a/spine-unity/Assets/spine-unity/SkeletonAnimator.cs
+++ b/spine-unity/Assets/spine-unity/SkeletonAnimator.cs
@@ -58,9 +58,9 @@ public class SkeletonAnimator : SkeletonRenderer, ISkeletonAnimation {
 		remove { _UpdateComplete -= value; }
 	}
 
-	protected event UpdateBonesDelegate _UpdateLocal;
-	protected event UpdateBonesDelegate _UpdateWorld;
-	protected event UpdateBonesDelegate _UpdateComplete;
+	protected UpdateBonesDelegate _UpdateLocal;
+	protected UpdateBonesDelegate _UpdateWorld;
+	protected UpdateBonesDelegate _UpdateComplete;
 
 	Dictionary<string, Spine.Animation> animationTable = new Dictionary<string, Spine.Animation>();
 	Animator animator;

--- a/spine-unity/Assets/spine-unity/SkeletonUtility/SkeletonUtility.cs
+++ b/spine-unity/Assets/spine-unity/SkeletonUtility/SkeletonUtility.cs
@@ -36,6 +36,7 @@
 using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Spine;
 
 [RequireComponent(typeof(ISkeletonAnimation))]
@@ -104,7 +105,15 @@ public class SkeletonUtility : MonoBehaviour {
 
 	public delegate void SkeletonUtilityDelegate ();
 
-	public event SkeletonUtilityDelegate OnReset;
+	private SkeletonUtilityDelegate _OnReset;
+	public event SkeletonUtilityDelegate OnReset
+	{
+		[MethodImpl(MethodImplOptions.Synchronized)]
+		add { _OnReset += value; } 
+
+		[MethodImpl(MethodImplOptions.Synchronized)]
+		remove { _OnReset -= value; }
+	}
 
 	public Transform boneRoot;
 
@@ -174,8 +183,8 @@ public class SkeletonUtility : MonoBehaviour {
 	}
 	
 	void HandleRendererReset (SkeletonRenderer r) {
-		if (OnReset != null)
-			OnReset();
+		if (_OnReset != null)
+			_OnReset();
 
 		CollectBones();
 	}


### PR DESCRIPTION
Hello,

We use spine runtime as shared DLL in several Unity projects,
but event syntax cause JIT Compile Exception on iOS.
http://ja.esotericsoftware.com/forum/viewtopic.php?f=7&t=4204

Thanks.