### PR TITLE
[as3] Fix strange behaviour of listeners

### DIFF
--- a/spine-as3/spine-as3/src/spine/animation/Listeners.as
+++ b/spine-as3/spine-as3/src/spine/animation/Listeners.as
@@ -39,13 +39,17 @@ package spine.animation {
 		public function add (listener:Function) : void {
 			if (listener == null)
 				throw new ArgumentError("listener cannot be null.");
-			_listeners[_listeners.length] = listener;
+			var indexOf:int = _listeners.indexOf(listener);
+			if (indexOf == -1)
+				_listeners[_listeners.length] = listener;
 		}
 
 		public function remove (listener:Function) : void {
 			if (listener == null)
 				throw new ArgumentError("listener cannot be null.");
-			_listeners.splice(_listeners.indexOf(listener), 1);
+			var indexOf:int = _listeners.indexOf(listener);
+			if (indexOf != -1)
+				_listeners.splice(_listeners.indexOf(listener), 1);
 		}
 
 		public function invoke (... args:*) : void {


### PR DESCRIPTION
Hello,

Just a couple of changes.
The change in add() will make sure a callback is never registered twice (slight change of behavior, consistent with the signals library, seems harmless to me).
The change in remove() will make sure that a listener is in the list before removing it (this one fix a bug, if indexOf == -1 then splice will remove the wrong listener).

Thanks for the hardwork !