### PR TITLE
Qt conflicts because of variables named "slots"

### DIFF
--- a/spine-c/include/spine/Skeleton.h
+++ b/spine-c/include/spine/Skeleton.h
@@ -49,7 +49,7 @@ typedef struct spSkeleton {
 	spBone* const root;
 
 	int slotsCount;
-	spSlot** slots;
+	spSlot** slots_;
 	spSlot** drawOrder;
 
 	int ikConstraintsCount;
@@ -68,7 +68,7 @@ typedef struct spSkeleton {
 		bones(0),
 		root(0),
 		slotsCount(0),
-		slots(0),
+		slots_(0),
 		drawOrder(0),
 
 		ikConstraintsCount(0),

--- a/spine-c/include/spine/SkeletonData.h
+++ b/spine-c/include/spine/SkeletonData.h
@@ -52,7 +52,7 @@ typedef struct spSkeletonData {
 	spBoneData** bones;
 
 	int slotsCount;
-	spSlotData** slots;
+	spSlotData** slots_;
 
 	int skinsCount;
 	spSkin** skins;

--- a/spine-c/src/spine/Animation.c
+++ b/spine-c/src/spine/Animation.c
@@ -437,7 +437,7 @@ void _spColorTimeline_apply (const spTimeline* timeline, spSkeleton* skeleton, f
 		b = prevFrameB + (self->frames[frameIndex + COLOR_FRAME_B] - prevFrameB) * percent;
 		a = prevFrameA + (self->frames[frameIndex + COLOR_FRAME_A] - prevFrameA) * percent;
 	}
-	slot = skeleton->slots[self->slotIndex];
+	slot = skeleton->slots_[self->slotIndex];
 	if (alpha < 1) {
 		slot->r += (r - slot->r) * alpha;
 		slot->g += (g - slot->g) * alpha;
@@ -483,7 +483,7 @@ void _spAttachmentTimeline_apply (const spTimeline* timeline, spSkeleton* skelet
 	if (self->frames[frameIndex] < lastTime) return;
 
 	attachmentName = self->attachmentNames[frameIndex];
-	spSlot_setAttachment(skeleton->slots[self->slotIndex],
+	spSlot_setAttachment(skeleton->slots_[self->slotIndex],
 			attachmentName ? spSkeleton_getAttachmentForSlotIndex(skeleton, self->slotIndex, attachmentName) : 0);
 }
 
@@ -603,10 +603,10 @@ void _spDrawOrderTimeline_apply (const spTimeline* timeline, spSkeleton* skeleto
 
 	drawOrderToSetupIndex = self->drawOrders[frameIndex];
 	if (!drawOrderToSetupIndex)
-		memcpy(skeleton->drawOrder, skeleton->slots, self->slotsCount * sizeof(spSlot*));
+		memcpy(skeleton->drawOrder, skeleton->slots_, self->slotsCount * sizeof(spSlot*));
 	else {
 		for (i = 0; i < self->slotsCount; ++i)
-			skeleton->drawOrder[i] = skeleton->slots[drawOrderToSetupIndex[i]];
+			skeleton->drawOrder[i] = skeleton->slots_[drawOrderToSetupIndex[i]];
 	}
 }
 
@@ -657,7 +657,7 @@ void _spFFDTimeline_apply (const spTimeline* timeline, spSkeleton* skeleton, flo
 	const float* nextVertices;
 	spFFDTimeline* self = (spFFDTimeline*)timeline;
 
-	spSlot *slot = skeleton->slots[self->slotIndex];
+	spSlot *slot = skeleton->slots_[self->slotIndex];
 	if (slot->attachment != self->attachment) return;
 
 	if (time < self->frames[0]) return; /* Time is before first frame. */

--- a/spine-c/src/spine/Skeleton.c
+++ b/spine-c/src/spine/Skeleton.c
@@ -68,9 +68,9 @@ spSkeleton* spSkeleton_create (spSkeletonData* data) {
 	CONST_CAST(spBone*, self->root) = self->bones[0];
 
 	self->slotsCount = data->slotsCount;
-	self->slots = MALLOC(spSlot*, self->slotsCount);
+	self->slots_ = MALLOC(spSlot*, self->slotsCount);
 	for (i = 0; i < self->slotsCount; ++i) {
-		spSlotData *slotData = data->slots[i];
+		spSlotData *slotData = data->slots_[i];
 
 		/* Find bone for the slotData's boneData. */
 		spBone* bone = 0;
@@ -80,11 +80,11 @@ spSkeleton* spSkeleton_create (spSkeletonData* data) {
 				break;
 			}
 		}
-		self->slots[i] = spSlot_create(slotData, bone);
+		self->slots_[i] = spSlot_create(slotData, bone);
 	}
 
 	self->drawOrder = MALLOC(spSlot*, self->slotsCount);
-	memcpy(self->drawOrder, self->slots, sizeof(spSlot*) * self->slotsCount);
+	memcpy(self->drawOrder, self->slots_, sizeof(spSlot*) * self->slotsCount);
 
 	self->r = 1;
 	self->g = 1;
@@ -115,8 +115,8 @@ void spSkeleton_dispose (spSkeleton* self) {
 	FREE(self->bones);
 
 	for (i = 0; i < self->slotsCount; ++i)
-		spSlot_dispose(self->slots[i]);
-	FREE(self->slots);
+		spSlot_dispose(self->slots_[i]);
+	FREE(self->slots_);
 
 	for (i = 0; i < self->ikConstraintsCount; ++i)
 		spIkConstraint_dispose(self->ikConstraints[i]);
@@ -230,9 +230,9 @@ void spSkeleton_setBonesToSetupPose (const spSkeleton* self) {
 
 void spSkeleton_setSlotsToSetupPose (const spSkeleton* self) {
 	int i;
-	memcpy(self->drawOrder, self->slots, self->slotsCount * sizeof(spSlot*));
+	memcpy(self->drawOrder, self->slots_, self->slotsCount * sizeof(spSlot*));
 	for (i = 0; i < self->slotsCount; ++i)
-		spSlot_setToSetupPose(self->slots[i]);
+		spSlot_setToSetupPose(self->slots_[i]);
 }
 
 spBone* spSkeleton_findBone (const spSkeleton* self, const char* boneName) {
@@ -252,14 +252,14 @@ int spSkeleton_findBoneIndex (const spSkeleton* self, const char* boneName) {
 spSlot* spSkeleton_findSlot (const spSkeleton* self, const char* slotName) {
 	int i;
 	for (i = 0; i < self->slotsCount; ++i)
-		if (strcmp(self->data->slots[i]->name, slotName) == 0) return self->slots[i];
+		if (strcmp(self->data->slots_[i]->name, slotName) == 0) return self->slots_[i];
 	return 0;
 }
 
 int spSkeleton_findSlotIndex (const spSkeleton* self, const char* slotName) {
 	int i;
 	for (i = 0; i < self->slotsCount; ++i)
-		if (strcmp(self->data->slots[i]->name, slotName) == 0) return i;
+		if (strcmp(self->data->slots_[i]->name, slotName) == 0) return i;
 	return -1;
 }
 
@@ -283,7 +283,7 @@ void spSkeleton_setSkin (spSkeleton* self, spSkin* newSkin) {
 			/* No previous skin, attach setup pose attachments. */
 			int i;
 			for (i = 0; i < self->slotsCount; ++i) {
-				spSlot* slot = self->slots[i];
+				spSlot* slot = self->slots_[i];
 				if (slot->data->attachmentName) {
 					spAttachment* attachment = spSkin_getAttachment(newSkin, i, slot->data->attachmentName);
 					if (attachment) spSlot_setAttachment(slot, attachment);
@@ -315,7 +315,7 @@ spAttachment* spSkeleton_getAttachmentForSlotIndex (const spSkeleton* self, int 
 int spSkeleton_setAttachment (spSkeleton* self, const char* slotName, const char* attachmentName) {
 	int i;
 	for (i = 0; i < self->slotsCount; ++i) {
-		spSlot *slot = self->slots[i];
+		spSlot *slot = self->slots_[i];
 		if (strcmp(slot->data->name, slotName) == 0) {
 			if (!attachmentName)
 				spSlot_setAttachment(slot, 0);

--- a/spine-c/src/spine/SkeletonBounds.c
+++ b/spine-c/src/spine/SkeletonBounds.c
@@ -130,7 +130,7 @@ void spSkeletonBounds_update (spSkeletonBounds* self, spSkeleton* skeleton, int/
 		spPolygon* polygon;
 		spBoundingBoxAttachment* boundingBox;
 
-		spSlot* slot = skeleton->slots[i];
+		spSlot* slot = skeleton->slots_[i];
 		spAttachment* attachment = slot->attachment;
 		if (!attachment || attachment->type != SP_ATTACHMENT_BOUNDING_BOX) continue;
 		boundingBox = (spBoundingBoxAttachment*)attachment;

--- a/spine-c/src/spine/SkeletonData.c
+++ b/spine-c/src/spine/SkeletonData.c
@@ -44,8 +44,8 @@ void spSkeletonData_dispose (spSkeletonData* self) {
 	FREE(self->bones);
 
 	for (i = 0; i < self->slotsCount; ++i)
-		spSlotData_dispose(self->slots[i]);
-	FREE(self->slots);
+        spSlotData_dispose(self->slots_[i]);
+    FREE(self->slots_);
 
 	for (i = 0; i < self->skinsCount; ++i)
 		spSkin_dispose(self->skins[i]);
@@ -86,14 +86,14 @@ int spSkeletonData_findBoneIndex (const spSkeletonData* self, const char* boneNa
 spSlotData* spSkeletonData_findSlot (const spSkeletonData* self, const char* slotName) {
 	int i;
 	for (i = 0; i < self->slotsCount; ++i)
-		if (strcmp(self->slots[i]->name, slotName) == 0) return self->slots[i];
+        if (strcmp(self->slots_[i]->name, slotName) == 0) return self->slots_[i];
 	return 0;
 }
 
 int spSkeletonData_findSlotIndex (const spSkeletonData* self, const char* slotName) {
 	int i;
 	for (i = 0; i < self->slotsCount; ++i)
-		if (strcmp(self->slots[i]->name, slotName) == 0) return i;
+        if (strcmp(self->slots_[i]->name, slotName) == 0) return i;
 	return -1;
 }
 

--- a/spine-c/src/spine/SkeletonJson.c
+++ b/spine-c/src/spine/SkeletonJson.c
@@ -110,7 +110,7 @@ static spAnimation* _spSkeletonJson_readAnimation (spSkeletonJson* self, Json* r
 	int timelinesCount = 0;
 
 	Json* bones = Json_getItem(root, "bones");
-	Json* slots = Json_getItem(root, "slots");
+	Json* slots_ = Json_getItem(root, "slots");
 	Json* ik = Json_getItem(root, "ik");
 	Json* ffd = Json_getItem(root, "ffd");
 	Json* drawOrder = Json_getItem(root, "drawOrder");
@@ -122,7 +122,7 @@ static spAnimation* _spSkeletonJson_readAnimation (spSkeletonJson* self, Json* r
 
 	for (boneMap = bones ? bones->child : 0; boneMap; boneMap = boneMap->next)
 		timelinesCount += boneMap->size;
-	for (slotMap = slots ? slots->child : 0; slotMap; slotMap = slotMap->next)
+	for (slotMap = slots_ ? slots_->child : 0; slotMap; slotMap = slotMap->next)
 		timelinesCount += slotMap->size;
 	timelinesCount += ik ? ik->size : 0;
 	for (ffdMap = ffd ? ffd->child : 0; ffdMap; ffdMap = ffdMap->next)
@@ -138,7 +138,7 @@ static spAnimation* _spSkeletonJson_readAnimation (spSkeletonJson* self, Json* r
 	skeletonData->animations[skeletonData->animationsCount++] = animation;
 
 	/* Slot timelines. */
-	for (slotMap = slots ? slots->child : 0; slotMap; slotMap = slotMap->next) {
+	for (slotMap = slots_ ? slots_->child : 0; slotMap; slotMap = slotMap->next) {
 		Json *timelineArray;
 
 		int slotIndex = spSkeletonData_findSlotIndex(skeletonData, slotMap->name);
@@ -420,7 +420,7 @@ spSkeletonData* spSkeletonJson_readSkeletonDataFile (spSkeletonJson* self, const
 spSkeletonData* spSkeletonJson_readSkeletonData (spSkeletonJson* self, const char* json) {
 	int i, ii;
 	spSkeletonData* skeletonData;
-	Json *root, *skeleton, *bones, *boneMap, *ik, *slots, *skins, *animations, *events;
+    Json *root, *skeleton, *bones, *boneMap, *ik, *slots_, *skins, *animations, *events;
 
 	FREE(self->error);
 	CONST_CAST(char*, self->error) = 0;
@@ -512,12 +512,12 @@ spSkeletonData* spSkeletonJson_readSkeletonData (spSkeletonJson* self, const cha
 	}
 
 	/* Slots. */
-	slots = Json_getItem(root, "slots");
-	if (slots) {
+    slots_ = Json_getItem(root, "slots");
+    if (slots_) {
 		Json *slotMap;
-		skeletonData->slotsCount = slots->size;
-		skeletonData->slots = MALLOC(spSlotData*, slots->size);
-		for (slotMap = slots->child, i = 0; slotMap; slotMap = slotMap->next, ++i) {
+        skeletonData->slotsCount = slots_->size;
+        skeletonData->slots_ = MALLOC(spSlotData*, slots_->size);
+        for (slotMap = slots_->child, i = 0; slotMap; slotMap = slotMap->next, ++i) {
 			spSlotData* slotData;
 			const char* color;
 			Json *item;
@@ -553,7 +553,7 @@ spSkeletonData* spSkeletonJson_readSkeletonData (spSkeletonJson* self, const cha
 					slotData->blendMode = SP_BLEND_MODE_SCREEN;
 			}
 
-			skeletonData->slots[i] = slotData;
+            skeletonData->slots_[i] = slotData;
 		}
 	}
 

--- a/spine-c/src/spine/Skin.c
+++ b/spine-c/src/spine/Skin.c
@@ -110,7 +110,7 @@ const char* spSkin_getAttachmentName (const spSkin* self, int slotIndex, int att
 void spSkin_attachAll (const spSkin* self, spSkeleton* skeleton, const spSkin* oldSkin) {
 	const _Entry *entry = SUB_CAST(_spSkin, oldSkin)->entries;
 	while (entry) {
-		spSlot *slot = skeleton->slots[entry->slotIndex];
+		spSlot *slot = skeleton->slots_[entry->slotIndex];
 		if (slot->attachment == entry->attachment) {
 			spAttachment *attachment = spSkin_getAttachment(self, entry->slotIndex, entry->name);
 			if (attachment) spSlot_setAttachment(slot, attachment);

--- a/spine-c/src/spine/Slot.c
+++ b/spine-c/src/spine/Slot.c
@@ -76,7 +76,7 @@ void spSlot_setToSetupPose (spSlot* self) {
 		/* Find slot index. */
 		int i;
 		for (i = 0; i < self->bone->skeleton->data->slotsCount; ++i) {
-			if (self->data == self->bone->skeleton->data->slots[i]) {
+			if (self->data == self->bone->skeleton->data->slots_[i]) {
 				attachment = spSkeleton_getAttachmentForSlotIndex(self->bone->skeleton, i, self->data->attachmentName);
 				break;
 			}

--- a/spine-cocos2dx/3/src/spine/SkeletonRenderer.cpp
+++ b/spine-cocos2dx/3/src/spine/SkeletonRenderer.cpp
@@ -305,7 +305,7 @@ Rect SkeletonRenderer::getBoundingBox () const {
 	float minX = FLT_MAX, minY = FLT_MAX, maxX = FLT_MIN, maxY = FLT_MIN;
 	float scaleX = getScaleX(), scaleY = getScaleY();
 	for (int i = 0; i < _skeleton->slotsCount; ++i) {
-		spSlot* slot = _skeleton->slots[i];
+		spSlot* slot = _skeleton->slots_[i];
 		if (!slot->attachment) continue;
 		int verticesCount;
 		if (slot->attachment->type == SP_ATTACHMENT_REGION) {


### PR DESCRIPTION
This will rename all the variables named "slots" to "slots_". This is because the library had to run in a Qt environment (using cocos2d-x as well). Qt uses a very powerful signal/slot system in its core, and for their projects the word slots is reserved.