### PR TITLE
Fix for unexpected huge skeleton render scale when using SPINE_TK2D

### DIFF
--- a/spine-unity/Assets/spine-unity/Editor/SkeletonDataAssetInspector.cs
+++ b/spine-unity/Assets/spine-unity/Editor/SkeletonDataAssetInspector.cs
@@ -38,7 +38,7 @@ public class SkeletonDataAssetInspector : Editor {
 	private bool needToSerialize;
 
 	List<string> warnings = new List<string>();
-	
+
 	void OnEnable () {
 
 		SpineEditorUtilities.ConfirmInitialization();
@@ -117,7 +117,7 @@ public class SkeletonDataAssetInspector : Editor {
 			DrawAnimationList();
 			DrawSlotList();
 			DrawUnityTools();
-			
+
 		} else {
 
 			DrawReimportButton();
@@ -131,8 +131,8 @@ public class SkeletonDataAssetInspector : Editor {
 	}
 
 	void DrawMecanim () {
-		
-		EditorGUILayout.PropertyField(controller, new GUIContent("Controller", SpineEditorUtilities.Icons.controllerIcon));		
+
+		EditorGUILayout.PropertyField(controller, new GUIContent("Controller", SpineEditorUtilities.Icons.controllerIcon));
 		if (controller.objectReferenceValue == null) {
 			GUILayout.BeginHorizontal();
 			GUILayout.Space(32);
@@ -142,7 +142,7 @@ public class SkeletonDataAssetInspector : Editor {
 			GUILayout.EndHorizontal();
 			EditorGUILayout.LabelField("Alternative to SkeletonAnimation, not required", EditorStyles.miniLabel);
 		}
-		
+
 	}
 
 	void DrawUnityTools () {
@@ -292,7 +292,7 @@ public class SkeletonDataAssetInspector : Editor {
 			serializedObject.ApplyModifiedProperties();
 			needToSerialize = true;
 		}
-			
+
 	}
 	void DrawAnimationList () {
 		showAnimationList = EditorGUILayout.Foldout(showAnimationList, new GUIContent("Animations", SpineEditorUtilities.Icons.animationRoot));
@@ -648,7 +648,7 @@ public class SkeletonDataAssetInspector : Editor {
 		this.m_previewUtility.m_Camera.orthographicSize = orthoSet;
 
 		float dist = Vector3.Distance(m_previewUtility.m_Camera.transform.position, m_posGoal);
-		if (dist > 60f * ((SkeletonDataAsset)target).scale) {
+		if(dist > 0f) {
 			Vector3 pos = Vector3.Lerp(this.m_previewUtility.m_Camera.transform.position, m_posGoal, 0.1f);
 			pos.x = 0;
 			this.m_previewUtility.m_Camera.transform.position = pos;
@@ -676,7 +676,7 @@ public class SkeletonDataAssetInspector : Editor {
 
 
 
-			if (drawHandles) {			
+			if (drawHandles) {
 				Handles.SetCamera(m_previewUtility.m_Camera);
 				Handles.color = m_originColor;
 
@@ -724,8 +724,8 @@ public class SkeletonDataAssetInspector : Editor {
 
 		Handles.DrawLine(lastVert, firstVert);
 
-		
-		
+
+
 	}
 
 	void Update () {
@@ -857,7 +857,7 @@ public class SkeletonDataAssetInspector : Editor {
 			case EventType.ScrollWheel:
 				if (position.Contains(current.mousePosition)) {
 
-					m_orthoGoal += current.delta.y * ((SkeletonDataAsset)target).scale * 10;
+					m_orthoGoal += current.delta.y;
 					GUIUtility.hotControl = controlID;
 					current.Use();
 				}
@@ -882,7 +882,7 @@ public class SkeletonDataAssetInspector : Editor {
 				EditorGUIUtility.SetWantsMouseJumping(1);
 			}
 			return scrollPosition;
-			
+
 		case EventType.MouseUp:
 			if (GUIUtility.hotControl == controlID)
 			{
@@ -890,10 +890,10 @@ public class SkeletonDataAssetInspector : Editor {
 			}
 			EditorGUIUtility.SetWantsMouseJumping(0);
 			return scrollPosition;
-			
+
 		case EventType.MouseMove:
 			return scrollPosition;
-			
+
 		case EventType.MouseDrag:
 			if (GUIUtility.hotControl == controlID)
 			{

--- a/spine-unity/Assets/spine-unity/SkeletonDataAsset.cs
+++ b/spine-unity/Assets/spine-unity/SkeletonDataAsset.cs
@@ -1,10 +1,10 @@
 /******************************************************************************
  * Spine Runtimes Software License
  * Version 2.3
- * 
+ *
  * Copyright (c) 2013-2015, Esoteric Software
  * All rights reserved.
- * 
+ *
  * You are granted a perpetual, non-exclusive, non-sublicensable and
  * non-transferable license to use, install, execute and perform the Spine
  * Runtimes Software (the "Software") and derivative works solely for personal
@@ -16,7 +16,7 @@
  * or other intellectual property or proprietary rights notices on or in the
  * Software, including any copy thereof. Redistributions in binary or source
  * form must include this license and terms.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY ESOTERIC SOFTWARE "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
@@ -98,7 +98,7 @@ public class SkeletonDataAsset : ScriptableObject {
 
 		if (skeletonData != null)
 			return skeletonData;
-		
+
 		AttachmentLoader attachmentLoader;
 		float skeletonDataScale;
 
@@ -108,7 +108,7 @@ public class SkeletonDataAsset : ScriptableObject {
 #else
 		if (spriteCollection != null) {
 			attachmentLoader = new SpriteCollectionAttachmentLoader(spriteCollection);
-			skeletonDataScale = (1.0f / (spriteCollection.invOrthoSize * spriteCollection.halfTargetHeight) * scale) * 100f;
+			skeletonDataScale = (1.0f / (spriteCollection.invOrthoSize * spriteCollection.halfTargetHeight) * scale);
 		} else {
 			if (atlasArr.Length == 0) {
 				Reset();


### PR DESCRIPTION
I just recently switched from using the old spine-tk2d runtime to using the latest spine-unity runtime. This change caused all my skeletons to render at exactly 100x size. There was an explicit *100f at SkeletonDataAsset.cs:111 which doesn't seem to have a reason to be there (corroborated by [this thread](http://esotericsoftware.com/forum/spine-unity-ignore-tk2d-pixel-per-meter-setting-4233)) so I removed that, which fixed the in-game render size.

After making that change, the Inspector preview window for a SkeletonDataAsset stopped rendering if the **scale** property there was anything higher than about 0.18 (it defaults to 1). This doesn't make a lot of sense to me, but the condition at SkeletonDataAssetInspector.cs:651 did seem to be the culprit, so I changed that and it seems to work properly at all scales now (because... reasons? O_o)

Finally, the mouse wheel response in the Inspector preview got suuuuper touchy as the scale increased. That doesn't actually seem necessary since the renderer bounds don't seem to be changing with the scale (instead, the camera's orthographic size is changing), so I removed the scale multiplier at SkeletonDataAssetInspector.cs:860 and the mouse wheel response is much more consistent now.

I tested these changes against tk2dSpriteCollections using both Explicit and Pixels Per Meter sizing modes, at various sizes, and also against various skeleton scales as set in the SkeletonDataAssetInspector. Everything seems pretty solid, so... here you go!