### PR TITLE
Fixed build for spine-csharp

### DIFF
--- a/spine-csharp/spine-csharp.csproj
+++ b/spine-csharp/spine-csharp.csproj
@@ -70,6 +70,7 @@
     <Compile Include="src\AnimationState.cs" />
     <Compile Include="src\Event.cs" />
     <Compile Include="src\EventData.cs" />
+    <Compile Include="src\ExposedList.cs" />
     <Compile Include="src\IkConstraint.cs" />
     <Compile Include="src\IkConstraintData.cs" />
     <Compile Include="src\Json.cs" />


### PR DESCRIPTION
Added reference to ExposedList.cs which is used in the spine-csharp project but is never actually referenced by the csproj file.