### PR TITLE
[js] Fixed js-canvas renderer to account for scaleX and scaleY properties of attachments

### DIFF
--- a/spine-js/spine-canvas.js
+++ b/spine-js/spine-canvas.js
@@ -86,12 +86,14 @@ spine.SkeletonRenderer.prototype = {
 
 			var x = bone.worldX + attachment.x * bone.m00 + attachment.y * bone.m01;
 			var y = bone.worldY + attachment.x * bone.m10 + attachment.y * bone.m11;
-			var rotation = -(bone.worldRotation + attachment.rotation) * Math.PI / 180;
+			var rotation = - (attachment.scaleX * attachment.scaleY) * (bone.worldRotation + attachment.rotation) * Math.PI / 180;
 			var w = attachment.width, h = attachment.height;
 			context.translate(x, y);
+			context.scale(attachment.scaleX, attachment.scaleY);
 			context.rotate(rotation);
 			context.drawImage(attachment.rendererObject, -w / 2, -h / 2, w, h);
 			context.rotate(-rotation);
+			context.scale(attachment.scaleX, attachment.scaleY);
 			context.translate(-x, -y);
 		}
 


### PR DESCRIPTION
Previously a slot attachment's image with a modified Scale `x` or `y` transform value within Spine would not be reflected in the canvas renderer.

| Without Fix | With Fix |
|-----------------|------------|
| ![screen shot 2015-07-18 at 12 40 12 pm](https://cloud.githubusercontent.com/assets/1178121/8762537/2b3f8318-2d4a-11e5-8546-41c1540c7200.png) | ![screen shot 2015-07-18 at 12 40 06 pm](https://cloud.githubusercontent.com/assets/1178121/8762536/26956954-2d4a-11e5-8ff1-0e1a05c77fdf.png)  | 