### PR TITLE
[Cocos2DX] Fixed render spine as 3D object.

### DIFF
--- a/spine-cocos2dx/3/src/spine/SkeletonRenderer.cpp
+++ b/spine-cocos2dx/3/src/spine/SkeletonRenderer.cpp
@@ -145,7 +145,7 @@ void SkeletonRenderer::update (float deltaTime) {
 }
 
 void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t transformFlags) {
-	_drawCommand.init(_globalZOrder);
+	_drawCommand.init(_globalZOrder, transform, transformFlags);
 	_drawCommand.func = CC_CALLBACK_0(SkeletonRenderer::drawSkeleton, this, transform, transformFlags);
 	renderer->addCommand(&_drawCommand);
 }


### PR DESCRIPTION
Process flag to fix render spine as 3D object.