### PR TITLE
Fixed error reported by address sanitizer 

### DIFF
--- a/spine-c/src/spine/Skeleton.c
+++ b/spine-c/src/spine/Skeleton.c
@@ -65,7 +65,7 @@ spSkeleton* spSkeleton_create (spSkeletonData* data) {
 		}
 		self->bones[i] = spBone_create(boneData, self, parent);
 	}
-	CONST_CAST(spBone*, self->root) = self->bones[0];
+	CONST_CAST(spBone*, self->root) = (self->bonesCount > 0 ? self->bones[0] : NULL);
 
 	self->slotsCount = data->slotsCount;
 	self->slots = MALLOC(spSlot*, self->slotsCount);


### PR DESCRIPTION
```==13599==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60200000d770 at pc 0x605362 bp 0x7ffec4ab41b0 sp 0x7ffec4ab41a0
READ of size 8 at 0x60200000d770 thread T0
    #0 0x605361 in spSkeleton_create thirdparty/spine-c/source/common/Skeleton.c:67```