### PR TITLE
Add ExposedList.cs to C# csproj.

### DIFF
--- a/spine-csharp/spine-csharp.csproj
+++ b/spine-csharp/spine-csharp.csproj
@@ -70,6 +70,7 @@
     <Compile Include="src\AnimationState.cs" />
     <Compile Include="src\Event.cs" />
     <Compile Include="src\EventData.cs" />
+    <Compile Include="src\ExposedList.cs" />
     <Compile Include="src\IkConstraint.cs" />
     <Compile Include="src\IkConstraintData.cs" />
     <Compile Include="src\Json.cs" />


### PR DESCRIPTION
Not sure why github's text editor changed that bottom part. But it did. Must be a line endings thing.