### PR TITLE
[c] Add dynamic skin composition.

### DIFF
--- a/spine-c/include/spine/Attachment.h
+++ b/spine-c/include/spine/Attachment.h
@@ -55,6 +55,7 @@ typedef struct spAttachment {
 } spAttachment;
 
 void spAttachment_dispose (spAttachment* self);
+spAttachment* spAttachment_clone (const spAttachment* self);
 
 #ifdef SPINE_SHORT_NAMES
 typedef spAttachmentType AttachmentType;
@@ -64,6 +65,7 @@ typedef spAttachmentType AttachmentType;
 #define ATTACHMENT_SKINNED_MESH SP_ATTACHMENT_SKINNED_MESH
 typedef spAttachment Attachment;
 #define Attachment_dispose(...) spAttachment_dispose(__VA_ARGS__)
+#define Attachment_clone(...) spAttachment_clone(__VA_ARGS__)
 #endif
 
 #ifdef __cplusplus

--- a/spine-c/include/spine/Skin.h
+++ b/spine-c/include/spine/Skin.h
@@ -53,10 +53,15 @@ typedef struct spSkin {
 spSkin* spSkin_create (const char* name);
 void spSkin_dispose (spSkin* self);
 
+spSkin* spSkin_createComposed (const char* name, struct spSkin** parts, int count);
+    
 /* The Skin owns the attachment. */
 void spSkin_addAttachment (spSkin* self, int slotIndex, const char* name, spAttachment* attachment);
 /* Returns 0 if the attachment was not found. */
 spAttachment* spSkin_getAttachment (const spSkin* self, int slotIndex, const char* name);
+
+int spSkin_getAttachmentCount(const spSkin* self);
+void spSkin_getAttachmentAt(const spSkin* self, int i, int* slotIndex, const char** name, spAttachment** attachment);
 
 /* Returns 0 if the slot or attachment was not found. */
 const char* spSkin_getAttachmentName (const spSkin* self, int slotIndex, int attachmentIndex);
@@ -68,6 +73,7 @@ void spSkin_attachAll (const spSkin* self, struct spSkeleton* skeleton, const sp
 typedef spSkin Skin;
 #define Skin_create(...) spSkin_create(__VA_ARGS__)
 #define Skin_dispose(...) spSkin_dispose(__VA_ARGS__)
+#define Skin_createComposed(...) spSkin_createComposed(__VA_ARGS__)
 #define Skin_addAttachment(...) spSkin_addAttachment(__VA_ARGS__)
 #define Skin_getAttachment(...) spSkin_getAttachment(__VA_ARGS__)
 #define Skin_getAttachmentName(...) spSkin_getAttachmentName(__VA_ARGS__)

--- a/spine-c/include/spine/extension.h
+++ b/spine-c/include/spine/extension.h
@@ -57,6 +57,8 @@
 /* Allocates a new char[], assigns it to TO, and copies FROM to it. Can be used on const types. */
 #define MALLOC_STR(TO,FROM) strcpy(CONST_CAST(char*, TO) = (char*)MALLOC(char, strlen(FROM) + 1), FROM)
 
+#define MALLOC_COPY(TO,FROM,TYPE,COUNT) memcpy(TO = MALLOC(TYPE, COUNT), FROM, sizeof(TYPE) * (COUNT))
+
 #define PI 3.1415926535897932385f
 #define DEG_RAD (PI / 180)
 #define RAD_DEG (180 / PI)
@@ -164,7 +166,8 @@ void _spAttachmentLoader_setUnknownTypeError (spAttachmentLoader* self, spAttach
 /**/
 
 void _spAttachment_init (spAttachment* self, const char* name, spAttachmentType type, /**/
-void (*dispose) (spAttachment* self));
+void (*dispose) (spAttachment* self),
+spAttachment* (*clone) (const spAttachment* self));
 void _spAttachment_deinit (spAttachment* self);
 
 #ifdef SPINE_SHORT_NAMES

--- a/spine-c/src/spine/Attachment.c
+++ b/spine-c/src/spine/Attachment.c
@@ -35,13 +35,16 @@
 
 typedef struct _spAttachmentVtable {
 	void (*dispose) (spAttachment* self);
+	spAttachment* (*clone) (const spAttachment* self);
 } _spAttachmentVtable;
 
 void _spAttachment_init (spAttachment* self, const char* name, spAttachmentType type, /**/
-		void (*dispose) (spAttachment* self)) {
+		void (*dispose) (spAttachment* self),
+		spAttachment* (*clone) (const spAttachment* self) ) {
 
 	CONST_CAST(_spAttachmentVtable*, self->vtable) = NEW(_spAttachmentVtable);
 	VTABLE(spAttachment, self) ->dispose = dispose;
+	VTABLE(spAttachment, self) ->clone = clone;
 
 	MALLOC_STR(self->name, name);
 	CONST_CAST(spAttachmentType, self->type) = type;
@@ -54,4 +57,8 @@ void _spAttachment_deinit (spAttachment* self) {
 
 void spAttachment_dispose (spAttachment* self) {
 	VTABLE(spAttachment, self) ->dispose(self);
+}
+
+spAttachment* spAttachment_clone (const spAttachment* self) {
+	return VTABLE(spAttachment, self) ->clone(self);
 }

--- a/spine-c/src/spine/BoundingBoxAttachment.c
+++ b/spine-c/src/spine/BoundingBoxAttachment.c
@@ -41,9 +41,21 @@ void _spBoundingBoxAttachment_dispose (spAttachment* attachment) {
 	FREE(self);
 }
 
+spAttachment* _spBoundingBoxAttachment_clone (const spAttachment* attachment) {
+	const spBoundingBoxAttachment* const self = SUB_CAST(spBoundingBoxAttachment, attachment);
+	spBoundingBoxAttachment* const result = NEW(spBoundingBoxAttachment);
+	_spAttachment_init(SUPER(result), SUPER(self)->name, SP_ATTACHMENT_BOUNDING_BOX, _spBoundingBoxAttachment_dispose, _spBoundingBoxAttachment_clone);
+
+        const int vertexCount = self->verticesCount;
+        result->verticesCount = vertexCount;
+        MALLOC_COPY(result->vertices, self->vertices, float, vertexCount);
+
+        return SUPER_CAST(spAttachment, result);
+}
+
 spBoundingBoxAttachment* spBoundingBoxAttachment_create (const char* name) {
 	spBoundingBoxAttachment* self = NEW(spBoundingBoxAttachment);
-	_spAttachment_init(SUPER(self), name, SP_ATTACHMENT_BOUNDING_BOX, _spBoundingBoxAttachment_dispose);
+	_spAttachment_init(SUPER(self), name, SP_ATTACHMENT_BOUNDING_BOX, _spBoundingBoxAttachment_dispose, _spBoundingBoxAttachment_clone);
 	return self;
 }
 

--- a/spine-c/src/spine/MeshAttachment.c
+++ b/spine-c/src/spine/MeshAttachment.c
@@ -44,13 +44,59 @@ void _spMeshAttachment_dispose (spAttachment* attachment) {
 	FREE(self);
 }
 
+spAttachment* _spMeshAttachment_clone (const spAttachment* attachment) {
+	const spMeshAttachment* const self = SUB_CAST(spMeshAttachment, attachment);
+	spMeshAttachment* const result = NEW(spMeshAttachment);
+	_spAttachment_init(SUPER(result), SUPER(self)->name, SP_ATTACHMENT_MESH, _spMeshAttachment_dispose, _spMeshAttachment_clone);
+        MALLOC_STR(result->path, self->path);
+
+        const int vertexCount = self->verticesCount;
+        result->verticesCount = vertexCount;
+        MALLOC_COPY(result->vertices, self->vertices, float, vertexCount);
+        
+        result->hullLength = self->hullLength;
+        
+        MALLOC_COPY(result->regionUVs, self->uvs, float, vertexCount);
+        MALLOC_COPY(result->uvs, self->uvs, float, vertexCount);
+
+        const int triangleCount = self->trianglesCount;
+        result->trianglesCount = triangleCount;
+        MALLOC_COPY(result->triangles, self->triangles, int, triangleCount);
+
+        result->r = self->r;
+        result->g = self->g;
+        result->b = self->b;
+        result->a = self->a;
+        result->rendererObject = self->rendererObject;
+        result->regionOffsetX = self->regionOffsetX;
+        result->regionOffsetY = self->regionOffsetY;
+        result->regionWidth = self->regionWidth;
+        result->regionHeight = self->regionHeight;
+        result->regionOriginalWidth = self->regionOriginalWidth;
+        result->regionOriginalHeight = self->regionOriginalHeight;
+        result->regionU = self->regionU;
+        result->regionV = self->regionV;
+        result->regionU2 = self->regionU2;
+        result->regionV2 = self->regionV2;
+        result->regionRotate = self->regionRotate;
+
+        const int edgeCount = self->edgesCount;
+        result->edgesCount = edgeCount;
+        MALLOC_COPY(result->edges, self->edges, int, edgeCount);
+        
+        result->width = self->width;
+        result->height = self->height;
+
+        return SUPER_CAST(spAttachment, result);
+}
+
 spMeshAttachment* spMeshAttachment_create (const char* name) {
 	spMeshAttachment* self = NEW(spMeshAttachment);
 	self->r = 1;
 	self->g = 1;
 	self->b = 1;
 	self->a = 1;
-	_spAttachment_init(SUPER(self), name, SP_ATTACHMENT_MESH, _spMeshAttachment_dispose);
+	_spAttachment_init(SUPER(self), name, SP_ATTACHMENT_MESH, _spMeshAttachment_dispose, _spMeshAttachment_clone);
 	return self;
 }
 

--- a/spine-c/src/spine/RegionAttachment.c
+++ b/spine-c/src/spine/RegionAttachment.c
@@ -39,6 +39,35 @@ void _spRegionAttachment_dispose (spAttachment* attachment) {
 	FREE(self);
 }
 
+spAttachment* _spRegionAttachment_clone (const spAttachment* attachment) {
+	const spRegionAttachment* const self = SUB_CAST(spRegionAttachment, attachment);
+	spRegionAttachment* const result = NEW(spRegionAttachment);
+	_spAttachment_init(SUPER(result), SUPER(self)->name, SP_ATTACHMENT_REGION, _spRegionAttachment_dispose, _spRegionAttachment_clone);
+        MALLOC_STR(result->path, self->path);
+        result->x = self->x;
+        result->y = self->y;
+        result->scaleX = self->scaleX;
+        result->scaleY = self->scaleY;
+        result->rotation = self->rotation;
+        result->width = self->width;
+        result->height = self->height;
+        result->r = self->r;
+        result->g = self->g;
+        result->b = self->b;
+        result->a = self->a;
+        result->rendererObject = self->rendererObject;
+        result->regionOffsetX = self->regionOffsetX;
+        result->regionOffsetY = self->regionOffsetY;
+        result->regionWidth = self->regionWidth;
+        result->regionHeight = self->regionHeight;
+        result->regionOriginalWidth = self->regionOriginalWidth;
+        result->regionOriginalHeight = self->regionOriginalHeight;
+        memcpy( result->offset, self->offset, sizeof( result->offset ) );
+        memcpy( result->uvs, self->uvs, sizeof( result->offset ) );
+
+        return SUPER_CAST(spAttachment, result);
+}
+
 spRegionAttachment* spRegionAttachment_create (const char* name) {
 	spRegionAttachment* self = NEW(spRegionAttachment);
 	self->scaleX = 1;
@@ -47,7 +76,7 @@ spRegionAttachment* spRegionAttachment_create (const char* name) {
 	self->g = 1;
 	self->b = 1;
 	self->a = 1;
-	_spAttachment_init(SUPER(self), name, SP_ATTACHMENT_REGION, _spRegionAttachment_dispose);
+	_spAttachment_init(SUPER(self), name, SP_ATTACHMENT_REGION, _spRegionAttachment_dispose, _spRegionAttachment_clone);
 	return self;
 }
 

--- a/spine-c/src/spine/Skin.c
+++ b/spine-c/src/spine/Skin.c
@@ -79,6 +79,27 @@ void spSkin_dispose (spSkin* self) {
 	FREE(self);
 }
 
+spSkin* spSkin_createComposed (const char* name, struct spSkin** parts, int count) {
+    spSkin* const self = spSkin_create(name);
+    while (count) {
+        --count;
+        spSkin* const part = parts[count];
+        int i = spSkin_getAttachmentCount(part);
+        while (i)
+        {
+            --i;
+            int slot;
+            const char* attachmentName;
+            spAttachment* attachment;
+
+            spSkin_getAttachmentAt(part, i, &slot, &attachmentName, &attachment);
+            spSkin_addAttachment(self, slot, attachmentName, spAttachment_clone(attachment));
+        }
+    }
+
+    return self;
+}
+
 void spSkin_addAttachment (spSkin* self, int slotIndex, const char* name, spAttachment* attachment) {
 	_Entry* newEntry = _Entry_create(slotIndex, name, attachment);
 	newEntry->next = SUB_CAST(_spSkin, self)->entries;
@@ -92,6 +113,34 @@ spAttachment* spSkin_getAttachment (const spSkin* self, int slotIndex, const cha
 		entry = entry->next;
 	}
 	return 0;
+}
+
+int spSkin_getAttachmentCount(const spSkin* self) {
+
+    const _Entry* entry = SUB_CAST(_spSkin, self)->entries;
+    int result = 0;
+    while (entry) {
+        ++result;
+        entry = entry->next;
+    }
+
+    return result;
+}
+
+void spSkin_getAttachmentAt
+( const spSkin* self, int i, int* slotIndex, const char** name,
+  spAttachment** attachment ) {
+    
+    const _Entry* entry = SUB_CAST(_spSkin, self)->entries;
+
+    while ( i != 0 ) {
+        --i;
+        entry = entry->next;
+    }
+
+    *slotIndex = entry->slotIndex;
+    *name = entry->name;
+    *attachment = entry->attachment;
 }
 
 const char* spSkin_getAttachmentName (const spSkin* self, int slotIndex, int attachmentIndex) {

--- a/spine-c/src/spine/SkinnedMeshAttachment.c
+++ b/spine-c/src/spine/SkinnedMeshAttachment.c
@@ -45,13 +45,64 @@ void _spSkinnedMeshAttachment_dispose (spAttachment* attachment) {
 	FREE(self);
 }
 
+spAttachment* _spSkinnedMeshAttachment_clone (const spAttachment* attachment) {
+	const spSkinnedMeshAttachment* const self = SUB_CAST(spSkinnedMeshAttachment, attachment);
+	spSkinnedMeshAttachment* const result = NEW(spSkinnedMeshAttachment);
+	_spAttachment_init(SUPER(result), SUPER(self)->name, SP_ATTACHMENT_SKINNED_MESH, _spSkinnedMeshAttachment_dispose, _spSkinnedMeshAttachment_clone);
+        MALLOC_STR(result->path, self->path);
+
+        const int boneCount = self->bonesCount;
+        result->bonesCount = boneCount;
+        MALLOC_COPY(result->bones, self->bones, int, boneCount);
+
+        const int weightCount = self->weightsCount;
+        result->weightsCount = weightCount;
+        MALLOC_COPY(result->weights, self->weights, float, weightCount);
+
+        const int triangleCount = self->trianglesCount;
+        result->trianglesCount = triangleCount;
+        MALLOC_COPY(result->triangles, self->triangles, int, triangleCount);
+
+        const int uvCount = self->uvsCount;
+        result->uvsCount = uvCount;
+        MALLOC_COPY(result->regionUVs, self->regionUVs, float, uvCount);
+        MALLOC_COPY(result->uvs, self->uvs, float, uvCount);
+        
+        result->hullLength = self->hullLength;
+        result->r = self->r;
+        result->g = self->g;
+        result->b = self->b;
+        result->a = self->a;
+        result->rendererObject = self->rendererObject;
+        result->regionOffsetX = self->regionOffsetX;
+        result->regionOffsetY = self->regionOffsetY;
+        result->regionWidth = self->regionWidth;
+        result->regionHeight = self->regionHeight;
+        result->regionOriginalWidth = self->regionOriginalWidth;
+        result->regionOriginalHeight = self->regionOriginalHeight;
+        result->regionU = self->regionU;
+        result->regionV = self->regionV;
+        result->regionU2 = self->regionU2;
+        result->regionV2 = self->regionV2;
+        result->regionRotate = self->regionRotate;
+
+        const int edgeCount = self->edgesCount;
+        result->edgesCount = edgeCount;
+        MALLOC_COPY(result->edges, self->edges, int, edgeCount);
+        
+        result->width = self->width;
+        result->height = self->height;
+
+        return SUPER_CAST(spAttachment, result);
+}
+
 spSkinnedMeshAttachment* spSkinnedMeshAttachment_create (const char* name) {
 	spSkinnedMeshAttachment* self = NEW(spSkinnedMeshAttachment);
 	self->r = 1;
 	self->g = 1;
 	self->b = 1;
 	self->a = 1;
-	_spAttachment_init(SUPER(self), name, SP_ATTACHMENT_SKINNED_MESH, _spSkinnedMeshAttachment_dispose);
+	_spAttachment_init(SUPER(self), name, SP_ATTACHMENT_SKINNED_MESH, _spSkinnedMeshAttachment_dispose, _spSkinnedMeshAttachment_clone);
 	return self;
 }
 


### PR DESCRIPTION
Please merge this commit which adds a
`pSkin_createComposed(const char* name, struct spSkin** parts, int count)`
function allowing to create a skin by combining several other skins,
thus effectively allowing to build skins at run-time in the core part of
the Spine runtime.

This feature is an answer to requests like these:
- http://fr.esotericsoftware.com/forum/How-to-have-swappable-heads-and-skins-4304?p=20824
- http://fr.esotericsoftware.com/forum/How-do-I-implement-avatar-characters-4446
- http://fr.esotericsoftware.com/forum/mix-and-match-skin-attachments-618?p=17837
