### PR TITLE
[LUA] AnimationState trackCount bugfixes

### DIFF
--- a/spine-lua/AnimationState.lua
+++ b/spine-lua/AnimationState.lua
@@ -211,7 +211,7 @@ function AnimationState.new (data)
 			end
 			last.next = entry
 		else
-			self.tracks[trackIndex] = entry
+			setCurrent(trackIndex, entry)
 		end
 
 		delay = delay or 0

--- a/spine-lua/AnimationState.lua
+++ b/spine-lua/AnimationState.lua
@@ -65,7 +65,7 @@ function AnimationState.new (data)
 		end
 
 		self.tracks[index] = entry
-		self.trackCount = math.max(self.trackCount, index)
+		self.trackCount = math.max(self.trackCount, index + 1)
 
 		if entry.onStart then entry.onStart(index) end
 		if self.onStart then self.onStart(index) end
@@ -73,7 +73,7 @@ function AnimationState.new (data)
 
 	function self:update (delta)
 		delta = delta * self.timeScale
-		for i = 0, self.trackCount do
+		for i = 0, self.trackCount - 1 do
 			local current = self.tracks[i]
 			if current then
 				current.time = current.time + delta * current.timeScale
@@ -96,7 +96,7 @@ function AnimationState.new (data)
 	end
 
 	function self:apply(skeleton)
-		for i = 0, self.trackCount do
+		for i = 0, self.trackCount - 1 do
 			local current = self.tracks[i]
 			if current then
 				local time = current.time


### PR DESCRIPTION
Fixes what I believe to be two bugs in the lua runtime AnimationState.

1) Adding an animation on an empty track will now play the animation. This is Line 214

2) The rest of the updates make trackCount hold count and not max track index as it previously did. This fixes an error where animations on the highest track index would stop if the second highest track index finished its animations and cleared the track.

Tested using modified SpineBoy example in main.lua in spine-love using the above mentioned use cases.