### PR TITLE
Parsing and passing images path

### DIFF
--- a/spine-c/include/spine/AttachmentLoader.h
+++ b/spine-c/include/spine/AttachmentLoader.h
@@ -57,7 +57,7 @@ void spAttachmentLoader_dispose (spAttachmentLoader* self);
 
 /* Returns 0 to not load an attachment. If 0 is returned and spAttachmentLoader.error1 is set, an error occurred. */
 spAttachment* spAttachmentLoader_newAttachment (spAttachmentLoader* self, spSkin* skin, spAttachmentType type, const char* name,
-		const char* path);
+		const char* path, const char* images);
 
 #ifdef SPINE_SHORT_NAMES
 typedef spAttachmentLoader AttachmentLoader;

--- a/spine-c/include/spine/SkeletonData.h
+++ b/spine-c/include/spine/SkeletonData.h
@@ -46,6 +46,7 @@ extern "C" {
 typedef struct spSkeletonData {
 	const char* version;
 	const char* hash;
+	const char* images;
 	float width, height;
 
 	int bonesCount;

--- a/spine-c/include/spine/extension.h
+++ b/spine-c/include/spine/extension.h
@@ -149,7 +149,7 @@ void _spTrackEntry_dispose (spTrackEntry* self);
 void _spAttachmentLoader_init (spAttachmentLoader* self, /**/
 void (*dispose) (spAttachmentLoader* self), /**/
 		spAttachment* (*newAttachment) (spAttachmentLoader* self, spSkin* skin, spAttachmentType type, const char* name,
-				const char* path));
+				const char* path, const char* images));
 void _spAttachmentLoader_deinit (spAttachmentLoader* self);
 void _spAttachmentLoader_setError (spAttachmentLoader* self, const char* error1, const char* error2);
 void _spAttachmentLoader_setUnknownTypeError (spAttachmentLoader* self, spAttachmentType type);

--- a/spine-c/src/spine/AttachmentLoader.c
+++ b/spine-c/src/spine/AttachmentLoader.c
@@ -35,14 +35,14 @@
 
 typedef struct _spAttachmentLoaderVtable {
 	spAttachment* (*newAttachment) (spAttachmentLoader* self, spSkin* skin, spAttachmentType type, const char* name,
-			const char* path);
+			const char* path, const char* images);
 	void (*dispose) (spAttachmentLoader* self);
 } _spAttachmentLoaderVtable;
 
 void _spAttachmentLoader_init (spAttachmentLoader* self, /**/
 void (*dispose) (spAttachmentLoader* self), /**/
 		spAttachment* (*newAttachment) (spAttachmentLoader* self, spSkin* skin, spAttachmentType type, const char* name,
-				const char* path)) {
+				const char* path, const char* images)) {
 	CONST_CAST(_spAttachmentLoaderVtable*, self->vtable) = NEW(_spAttachmentLoaderVtable);
 	VTABLE(spAttachmentLoader, self)->dispose = dispose;
 	VTABLE(spAttachmentLoader, self)->newAttachment = newAttachment;
@@ -60,12 +60,12 @@ void spAttachmentLoader_dispose (spAttachmentLoader* self) {
 }
 
 spAttachment* spAttachmentLoader_newAttachment (spAttachmentLoader* self, spSkin* skin, spAttachmentType type, const char* name,
-		const char* path) {
+		const char* path, const char* images) {
 	FREE(self->error1);
 	FREE(self->error2);
 	self->error1 = 0;
 	self->error2 = 0;
-	return VTABLE(spAttachmentLoader, self)->newAttachment(self, skin, type, name, path);
+	return VTABLE(spAttachmentLoader, self)->newAttachment(self, skin, type, name, path, images);
 }
 
 void _spAttachmentLoader_setError (spAttachmentLoader* self, const char* error1, const char* error2) {

--- a/spine-c/src/spine/SkeletonData.c
+++ b/spine-c/src/spine/SkeletonData.c
@@ -65,6 +65,7 @@ void spSkeletonData_dispose (spSkeletonData* self) {
 
 	FREE(self->hash);
 	FREE(self->version);
+	FREE(self->images);
 
 	FREE(self);
 }

--- a/spine-c/src/spine/SkeletonJson.c
+++ b/spine-c/src/spine/SkeletonJson.c
@@ -437,6 +437,7 @@ spSkeletonData* spSkeletonJson_readSkeletonData (spSkeletonJson* self, const cha
 	if (skeleton) {
 		MALLOC_STR(skeletonData->hash, Json_getString(skeleton, "hash", 0));
 		MALLOC_STR(skeletonData->version,  Json_getString(skeleton, "spine", 0));
+		MALLOC_STR(skeletonData->images, Json_getString(skeleton, "images", 0));
 		skeletonData->width = Json_getFloat(skeleton, "width", 0);
 		skeletonData->height = Json_getFloat(skeleton, "height", 0);
 	}
@@ -599,7 +600,7 @@ spSkeletonData* spSkeletonJson_readSkeletonData (spSkeletonJson* self, const cha
 						return 0;
 					}
 
-					attachment = spAttachmentLoader_newAttachment(self->attachmentLoader, skin, type, attachmentName, path);
+					attachment = spAttachmentLoader_newAttachment(self->attachmentLoader, skin, type, attachmentName, path, skeleton ? skeletonData->images : NULL);
 					if (!attachment) {
 						if (self->attachmentLoader->error1) {
 							spSkeletonData_dispose(skeletonData);


### PR DESCRIPTION
In some cases we need to have images path stored and passed to attachment loader. What is your opinion on it @NathanSweet ? Should it be implemented for all other runtimes as well ?