### PR TITLE
Fixed Spine-c for multithread environment.

### DIFF
--- a/spine-c/include/spine/extension.h
+++ b/spine-c/include/spine/extension.h
@@ -77,6 +77,26 @@
 #define ACOS(A) (float)acos(A)
 #endif
 
+// http://stackoverflow.com/questions/18298280/how-to-declare-a-variable-as-thread-local-portably
+#ifndef thread_local
+# if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
+#  define thread_local _Thread_local
+# elif defined _WIN32 && ( \
+       defined _MSC_VER || \
+       defined __ICL || \
+       defined __DMC__ || \
+       defined __BORLANDC__ )
+#  define thread_local __declspec(thread) 
+/* note that ICC (linux) and Clang are covered by __GNUC__ */
+# elif defined __GNUC__ || \
+       defined __SUNPRO_C || \
+       defined __xlC__
+#  define thread_local __thread
+# else
+#  error "Cannot define thread_local"
+# endif
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>

--- a/spine-c/src/spine/Atlas.c
+++ b/spine-c/src/spine/Atlas.c
@@ -78,7 +78,7 @@ static void trim (Str* str) {
 
 /* Tokenize string without modification. Returns 0 on failure. */
 static int readLine (const char* begin, const char* end, Str* str) {
-	static const char* nextStart;
+	static thread_local const char* nextStart;
 	if (begin) {
 		nextStart = begin;
 		return 1;

--- a/spine-c/src/spine/Bone.c
+++ b/spine-c/src/spine/Bone.c
@@ -32,7 +32,7 @@
 #include <spine/Bone.h>
 #include <spine/extension.h>
 
-static int yDown;
+static thread_local int yDown;
 
 void spBone_setYDown (int value) {
 	yDown = value;

--- a/spine-c/src/spine/Json.c
+++ b/spine-c/src/spine/Json.c
@@ -46,7 +46,7 @@
 #define SPINE_JSON_DEBUG 0
 #endif
 
-static const char* ep;
+static thread_local const char* ep;
 
 const char* Json_getError (void) {
 	return ep;


### PR DESCRIPTION
Spine-c runtime uses static variables which prevent it from using in multithread environment. This request convert the such variables to be thread local^ which seems to fix the problem. 