### PR TITLE
Restore blend function after drawing a skeleton on LibGDX

### DIFF
--- a/spine-libgdx/spine-libgdx/src/com/esotericsoftware/spine/SkeletonRenderer.java
+++ b/spine-libgdx/spine-libgdx/src/com/esotericsoftware/spine/SkeletonRenderer.java
@@ -48,6 +48,8 @@ public class SkeletonRenderer {
 
 	@SuppressWarnings("null")
 	public void draw (PolygonSpriteBatch batch, Skeleton skeleton) {
+		int oldBlendSrc = batch.getBlendSrcFunc();
+		int oldBlendDst = batch.getBlendDstFunc();
 		boolean premultipliedAlpha = this.premultipliedAlpha;
 		BlendMode blendMode = null;
 
@@ -110,9 +112,13 @@ public class SkeletonRenderer {
 				batch.draw(texture, vertices, 0, vertices.length, triangles, 0, triangles.length);
 			}
 		}
+		
+		batch.setBlendFunction(oldBlendSrc, oldBlendDst);
 	}
 
 	public void draw (Batch batch, Skeleton skeleton) {
+		int oldBlendSrc = batch.getBlendSrcFunc();
+		int oldBlendDst = batch.getBlendDstFunc();
 		boolean premultipliedAlpha = this.premultipliedAlpha;
 		BlendMode blendMode = null;
 
@@ -157,6 +163,8 @@ public class SkeletonRenderer {
 				rootBone.setRotation(oldRotation);
 			}
 		}
+		
+		batch.setBlendFunction(oldBlendSrc, oldBlendDst);
 	}
 
 	public void setPremultipliedAlpha (boolean premultipliedAlpha) {


### PR DESCRIPTION
When rendering slots with different BlendModes, the batch has it's blend functions modified, but they're never restored after the skeleton has been rendered. This commit fixes it by keeping track of it's previous functions and restoring them later.