### PR TITLE
[Cocos2d-x] Add `gotoAndPlay` `gotoAndStop` `pauseAnimation` and `resumeAnimation` for SkeletonAnimation.

### DIFF
--- a/spine-cocos2dx/3/src/spine/SkeletonAnimation.cpp
+++ b/spine-cocos2dx/3/src/spine/SkeletonAnimation.cpp
@@ -91,6 +91,7 @@ SkeletonAnimation* SkeletonAnimation::createWithFile (const std::string& skeleto
 
 void SkeletonAnimation::initialize () {
 	_ownsAnimationStateData = true;
+    _isAnimationPaused = false;
 	_state = spAnimationState_create(spAnimationStateData_create(_skeleton->data));
 	_state->rendererObject = this;
 	_state->listener = animationCallback;
@@ -127,6 +128,11 @@ void SkeletonAnimation::update (float deltaTime) {
 	super::update(deltaTime);
 
 	deltaTime *= _timeScale;
+    
+    if (_isAnimationPaused) {
+        deltaTime = 0;
+    }
+    
 	spAnimationState_update(_state, deltaTime);
 	spAnimationState_apply(_state, _skeleton);
 	spSkeleton_updateWorldTransform(_skeleton);
@@ -249,6 +255,32 @@ void SkeletonAnimation::setTrackEventListener (spTrackEntry* entry, const EventL
 
 spAnimationState* SkeletonAnimation::getState() const {
 	return _state;
+}
+    
+void SkeletonAnimation::gotoAndPlay(int frame) {
+    spTrackEntry* entry = getCurrent();
+    if (!entry) {
+        return;
+    }
+    entry->time = (float)frame / 30.0;
+    resumeAnimation();
+}
+
+void SkeletonAnimation::gotoAndStop(int frame) {
+    spTrackEntry* entry = getCurrent();
+    if (!entry) {
+        return;
+    }
+    entry->time = (float)frame / 30.0;
+    pauseAnimation();
+}
+
+void SkeletonAnimation::pauseAnimation() {
+    _isAnimationPaused = true;
+}
+
+void SkeletonAnimation::resumeAnimation() {
+    _isAnimationPaused = false;
 }
 
 }

--- a/spine-cocos2dx/3/src/spine/SkeletonAnimation.h
+++ b/spine-cocos2dx/3/src/spine/SkeletonAnimation.h
@@ -76,6 +76,11 @@ public:
 	virtual void onTrackEntryEvent (int trackIndex, spEventType type, spEvent* event, int loopCount);
 
 	spAnimationState* getState() const;
+    
+    void gotoAndPlay(int frame);
+    void gotoAndStop(int frame);
+    void pauseAnimation();
+    void resumeAnimation();
 
 CC_CONSTRUCTOR_ACCESS:
 	SkeletonAnimation ();
@@ -94,6 +99,8 @@ protected:
 	EndListener _endListener;
 	CompleteListener _completeListener;
 	EventListener _eventListener;
+    
+    bool _isAnimationPaused = false;
 
 private:
 	typedef SkeletonRenderer super;


### PR DESCRIPTION
Add some common used APIs for `SkeletonAnimation` used in Cocos2d-x.

* `void SkeletonAnimation::gotoAndPlay(int frame)`: jump to frame and continue play animation.
* `void SkeletonAnimation::gotoAndStop(int frame)`: jump to frame and pause animation.
* `void SkeletonAnimation::pauseAnimation`: pause animation.
* `void SkeletonAnimation::resumeAnimation`: resume animation.