### PR TITLE
[Spine-Unity] Fix for Frame Jump Bug when mix time resolves to zero

### DIFF
--- a/spine-unity/Assets/spine-unity/SkeletonAnimator.cs
+++ b/spine-unity/Assets/spine-unity/SkeletonAnimator.cs
@@ -108,6 +108,7 @@ public class SkeletonAnimator : SkeletonRenderer, ISkeletonAnimation {
 						continue;
 
 					float time = stateInfo.normalizedTime * info.clip.length;
+					if (time == 0) continue;
 					animationTable[GetAnimationClipNameHashCode(info.clip)].Mix(skeleton, Mathf.Max(0, time - deltaTime), time, stateInfo.loop, null, weight);
 				}
 
@@ -117,6 +118,7 @@ public class SkeletonAnimator : SkeletonRenderer, ISkeletonAnimation {
 						continue;
 
 					float time = nextStateInfo.normalizedTime * info.clip.length;
+					if (time == 0) continue;
 					animationTable[GetAnimationClipNameHashCode(info.clip)].Mix(skeleton, Mathf.Max(0, time - deltaTime), time, nextStateInfo.loop, null, weight);
 				}
 			} else if (mode >= MixMode.MixNext) {
@@ -130,6 +132,7 @@ public class SkeletonAnimator : SkeletonRenderer, ISkeletonAnimation {
 						continue;
 
 					float time = stateInfo.normalizedTime * info.clip.length;
+					if (time == 0) continue;
 					animationTable[GetAnimationClipNameHashCode(info.clip)].Apply(skeleton, Mathf.Max(0, time - deltaTime), time, stateInfo.loop, null);
 					break;
 				}
@@ -142,6 +145,7 @@ public class SkeletonAnimator : SkeletonRenderer, ISkeletonAnimation {
 						continue;
 
 					float time = stateInfo.normalizedTime * info.clip.length;
+					if (time == 0) continue;
 					animationTable[GetAnimationClipNameHashCode(info.clip)].Mix(skeleton, Mathf.Max(0, time - deltaTime), time, stateInfo.loop, null, weight);
 				}
 
@@ -156,6 +160,7 @@ public class SkeletonAnimator : SkeletonRenderer, ISkeletonAnimation {
 							continue;
 
 						float time = nextStateInfo.normalizedTime * info.clip.length;
+						if (time == 0) continue;
 						animationTable[GetAnimationClipNameHashCode(info.clip)].Apply(skeleton, Mathf.Max(0, time - deltaTime), time, nextStateInfo.loop, null);
 						break;
 					}
@@ -169,6 +174,7 @@ public class SkeletonAnimator : SkeletonRenderer, ISkeletonAnimation {
 						continue;
 
 					float time = nextStateInfo.normalizedTime * info.clip.length;
+					if (time == 0) continue;
 					animationTable[GetAnimationClipNameHashCode(info.clip)].Mix(skeleton, Mathf.Max(0, time - deltaTime), time, nextStateInfo.loop, null, weight);
 				}
 			}


### PR DESCRIPTION
Originally reported [here on the forums](http://esotericsoftware.com/forum/Unity-One-frame-of-wrong-animation-4719), couldn't find a Github Issue open for the problem.

The graphical bug is this; for the very last frame of a mix between animations, the mix `time` will resolve to zero, and the renderer will display the first frame of the animation. It's a very obvious bug. Imagine half way through an animation, suddenly rendering the first frame. Simply skipping that update, the solution I'm proposing here, cleans the problem up for me.

My first contribution to this repository, very happy to rework things if not up to scratch.