### PR TITLE
[Unity] Disallow multiple SkeletonRenderers.

### DIFF
--- a/spine-unity/Assets/spine-unity/SkeletonRenderer.cs
+++ b/spine-unity/Assets/spine-unity/SkeletonRenderer.cs
@@ -35,6 +35,7 @@ using UnityEngine;
 using Spine;
 
 /// <summary>Renders a skeleton.</summary>
+[DisallowMultipleComponent]
 [ExecuteInEditMode, RequireComponent(typeof(MeshFilter), typeof(MeshRenderer))]
 public class SkeletonRenderer : MonoBehaviour {
 


### PR DESCRIPTION
Disallow multiple SkeletonRenderers on one GameObject. This is unsupported, makes no sense, and also causes Unity to go nuts.