### PR TITLE
[Unity] lastMaterial != null hotspot.

### DIFF
--- a/spine-unity/Assets/spine-unity/SkeletonRenderer.cs
+++ b/spine-unity/Assets/spine-unity/SkeletonRenderer.cs
@@ -258,7 +258,7 @@ public class SkeletonRenderer : MonoBehaviour {
 			#endif
 
 			// Populate submesh when material changes. (or when forced to separate by a submeshSeparator)
-			if ((lastMaterial != null && lastMaterial.GetInstanceID() != material.GetInstanceID()) ||
+			if ((vertexCount > 0 && lastMaterial.GetInstanceID() != material.GetInstanceID()) ||
 				(submeshSeparatorSlotsCount > 0 && submeshSeparatorSlots.Contains(slot))) {
 
 				workingSubmeshArguments.Add(


### PR DESCRIPTION
I was profiling a variant of this SkeletonRenderer code and this seemed to be a hotspot.
`UnityEngine.Object != null` is overloaded behind the scenes and has a pretty deep call stack and does a bunch of things. This scales badly as the number of attachments increases.

See this UnityEngine code for the details:
https://github.com/MattRix/UnityDecompiled/blob/master/UnityEngine/UnityEngine/Object.cs#L180-L183
https://github.com/MattRix/UnityDecompiled/blob/master/UnityEngine/UnityEngine/Object.cs#L100-L117
https://github.com/MattRix/UnityDecompiled/blob/master/UnityEngine/UnityEngine/Object.cs#L118-L121

`vertexCount > 0` effectively serves the same purpose (gate the operation until the first renderable attachment gets processed).