### PR TITLE
Make Json.Deserialize thread-safe in spine-csharp

### DIFF
--- a/spine-csharp/src/Json.cs
+++ b/spine-csharp/src/Json.cs
@@ -2,15 +2,9 @@ using System.IO;
 
 namespace Spine {
 	public static class Json {
-		
-		static readonly SharpJson.JsonDecoder parser;
-
-		static Json () {
-			parser = new SharpJson.JsonDecoder();
-			parser.parseNumbersAsFloat = true;
-		}
-
 		public static object Deserialize (TextReader text) {
+			var parser = new SharpJson.JsonDecoder();
+			parser.parseNumbersAsFloat = true;
 			return parser.Decode(text.ReadToEnd());
 		}
 	}


### PR DESCRIPTION
There is a problem in turning `JsonDecoder` into a singleton: it uses `lexer` field that is modified by each call to `Decode`, so any already running `Decode` will suffer because its `lexer` will be lost.
Btw there is no big performance gain in previous solution (I assume it was done that way for optimization reasons). Premature optimization is the root of all evil :smile: 
PS: Another option would be to rewrite `SharpJson` a bit to pass the `lexer` explicitly instead of storing it in the field.