### PR TITLE
Added requires in attachment loader

### DIFF
--- a/spine-lua/Animation.lua
+++ b/spine-lua/Animation.lua
@@ -604,7 +604,7 @@ function Animation.FfdTimeline.new ()
 
 	function self:apply (skeleton, lastTime, time, firedEvents, alpha)
 		local slot = skeleton.slots[self.slotIndex]
-		if slot.attachment ~= attachment then return end
+		if slot.attachment ~= self.attachment then return end
 
 		local frames = self.frames
 		if time < frames[0] then return end -- Time is before first frame.
@@ -612,7 +612,7 @@ function Animation.FfdTimeline.new ()
 		local frameVertices = self.frameVertices
 		local vertexCount = #frameVertices[0]
 		local vertices = slot.attachmentVertices
-		if #vertices < vertexCount then
+		if not vertices or #vertices < vertexCount then
 			vertices = {}
 			slot.attachmentVertices = vertices
 		end
@@ -620,16 +620,15 @@ function Animation.FfdTimeline.new ()
 			alpha = 1 -- Don't mix from uninitialized slot vertices.
 		end
 		slot.attachmentVerticesCount = vertexCount
-
-		if time >= frames[#frames] then -- Time is after last frame.
-			local lastVertices = frameVertices[#frames]
+		if time >= frames[#frames - 1] then -- Time is after last frame.
+			local lastVertices = frameVertices[#frames - 1]
 			if alpha < 1 then
-				for i = 0, vertexCount do
+				for i = 1, vertexCount do
 					local vertex = vertices[i]
 					vertices[i] = vertex + (lastVertices[i] - vertex) * alpha
 				end
 			else
-				for i = 0, vertexCount do
+				for i = 1, vertexCount do
 					vertices[i] = lastVertices[i]
 				end
 			end
@@ -647,13 +646,13 @@ function Animation.FfdTimeline.new ()
 		local nextVertices = frameVertices[frameIndex]
 
 		if alpha < 1 then
-			for i = 0, vertexCount do
+			for i = 1, vertexCount do
 				local prev = prevVertices[i]
-				local vertices = vertices[i]
-				vertices[i] = vertices + (prev + (nextVertices[i] - prev) * percent - vertices) * alpha
+				local vertex = vertices[i]
+				vertices[i] = vertex + (prev + (nextVertices[i] - prev) * percent - vertex) * alpha
 			end
 		else
-			for i = 0, vertexCount do
+			for i = 1, vertexCount do
 				local prev = prevVertices[i]
 				vertices[i] = prev + (nextVertices[i] - prev) * percent
 			end

--- a/spine-lua/AttachmentLoader.lua
+++ b/spine-lua/AttachmentLoader.lua
@@ -32,6 +32,8 @@
 local AttachmentType = require "spine-lua.AttachmentType"
 local RegionAttachment = require "spine-lua.RegionAttachment"
 local BoundingBoxAttachment = require "spine-lua.BoundingBoxAttachment"
+local MeshAttachment = require "spine-lua.MeshAttachment"
+local SkinningMeshAttachment = require "spine-lua.SkinnedMeshAttachment"
 
 local AttachmentLoader = {}
 function AttachmentLoader.new ()

--- a/spine-lua/MeshAttachment.lua
+++ b/spine-lua/MeshAttachment.lua
@@ -34,7 +34,7 @@ local AttachmentType = require "spine-lua.AttachmentType"
 local MeshAttachment = {}
 function MeshAttachment.new (name)
 	if not name then error("name cannot be nil", 2) end
-	
+
 	local self = {
 		name = name,
 		type = AttachmentType.mesh,
@@ -46,7 +46,7 @@ function MeshAttachment.new (name)
 		r = 1, g = 1, b = 1, a = 1,
 		path = nil,
 		rendererObject = nil,
-		regionU = 0, regionV = 0, regionU2 = 0, regionV2 = 0, regionRotate = false,
+		regionU = 0, regionV = 0, regionU2 = 1, regionV2 = 1, regionRotate = false,
 		regionOffsetX = 0, regionOffsetY = 0,
 		regionWidth = 0, regionHeight = 0,
 		regionOriginalWidth = 0, regionOriginalHeight = 0,
@@ -75,12 +75,13 @@ function MeshAttachment.new (name)
 
 	function self:computeWorldVertices (x, y, slot, worldVertices)
 		local bone = slot.bone
+x,y=slot.bone.skeleton.x,slot.bone.skeleton.y
 		x = x + bone.worldX
 		y = y + bone.worldY
 		local m00, m01, m10, m11 = bone.m00, bone.m01, bone.m10, bone.m11
 		local vertices = self.vertices
-		local verticesCount = vertices.length
-		if #slot.attachmentVertices == verticesCount then vertices = slot.attachmentVertices end
+		local verticesCount = #vertices
+		if slot.attachmentVertices and #slot.attachmentVertices == verticesCount then vertices = slot.attachmentVertices end
 		for i = 1, verticesCount, 2 do
 			local vx = vertices[i]
 			local vy = vertices[i + 1]

--- a/spine-lua/SkeletonJson.lua
+++ b/spine-lua/SkeletonJson.lua
@@ -178,9 +178,8 @@ function SkeletonJson.new (attachmentLoader)
 				end
 				if skin.name == "default" then
 					skeletonData.defaultSkin = skin
-				else
-					table.insert(skeletonData.skins, skin)
 				end
+				table.insert(skeletonData.skins, skin)
 			end
 		end
 
@@ -470,22 +469,21 @@ function SkeletonJson.new (attachmentLoader)
 		local ffd = map["ffd"]
 		if ffd then
 			for skinName,slotMap in pairs(ffd) do
-				local skin = skeletonData.findSkin(skinName)
+				local skin = skeletonData:findSkin(skinName)
 				for slotName,meshMap in pairs(slotMap) do
-					local slotIndex = skeletonData.findSlotIndex(slotName)
+					local slotIndex = skeletonData:findSlotIndex(slotName)
 					for meshName,values in pairs(meshMap) do
 						local timeline = Animation.FfdTimeline.new()
 						local attachment = skin:getAttachment(slotIndex, meshName)
 						if not attachment then error("FFD attachment not found: " .. meshName) end
 						timeline.slotIndex = slotIndex
 						timeline.attachment = attachment
-
 						local isMesh = attachment.type == AttachmentType.mesh
 						local vertexCount
 						if isMesh then
-							vertexCount = attachment.vertices.length
+							vertexCount = #attachment.vertices
 						else
-							vertexCount = attachment.weights.length / 3 * 2
+							vertexCount = #attachment.weights / 3 * 2
 						end
 
 						local frameIndex = 0
@@ -496,12 +494,18 @@ function SkeletonJson.new (attachmentLoader)
 									vertices = attachment.vertices
 								else
 									vertices = {}
-									vertices.length = vertexCount
+									for i = 1, vertexCount do
+										vertices[i] = 0
+									end
 								end
 							else
 								local verticesValue = valueMap["vertices"]
-								local vertices = {}
+								local scale = self.scale
+								vertices = {}
 								local start = valueMap["offset"] or 0
+								for ii = 1, start do
+									vertices[ii] = 0
+								end
 								if scale == 1 then
 									for ii = 1, #verticesValue do
 										vertices[ii + start] = verticesValue[ii]
@@ -520,7 +524,6 @@ function SkeletonJson.new (attachmentLoader)
 									vertices[vertexCount] = 0
 								end
 							end
-
 							timeline:setFrame(frameIndex, valueMap["time"], vertices)
 							readCurve(timeline, frameIndex, valueMap)
 							frameIndex = frameIndex + 1

--- a/spine-lua/SkeletonJson.lua
+++ b/spine-lua/SkeletonJson.lua
@@ -266,19 +266,21 @@ function SkeletonJson.new (attachmentLoader)
 			return mesh
 
 		elseif type == AttachmentType.skinnedmesh then
-			local mesh = self.attachmentLoader.newSkinnedMeshAttachment(skin, name, path)
+			local mesh = self.attachmentLoader.newSkinningMeshAttachment(skin, name, path)
 			if not mesh then return null end
 			mesh.path = path
 
 			local uvs = getArray(map, "uvs", 1)
-			vertices = getArray(map, "vertices", 1)
+			local vertices = getArray(map, "vertices", 1)
 			local weights = {}
 			local bones = {}
-			for i = 1, vertices do
+			local i, n = 1, #vertices
+			while i < n do
 				local boneCount = vertices[i]
 				i = i + 1
 				table.insert(bones, boneCount)
-				for ii = 1, i + boneCount * 4 do
+				local nn = i + boneCount * 4
+				while i < nn do
 					table.insert(bones, vertices[i])
 					table.insert(weights, vertices[i + 1] * scale)
 					table.insert(weights, vertices[i + 2] * scale)

--- a/spine-lua/SkinnedMeshAttachment.lua
+++ b/spine-lua/SkinnedMeshAttachment.lua
@@ -47,7 +47,7 @@ function SkinnedMeshAttachment.new (name)
 		r = 1, g = 1, b = 1, a = 1,
 		path = nil,
 		rendererObject = nil,
-		regionU = 0, regionV = 0, regionU2 = 0, regionV2 = 0, regionRotate = false,
+		regionU = 0, regionV = 0, regionU2 = 1, regionV2 = 1, regionRotate = false,
 		regionOffsetX = 0, regionOffsetY = 0,
 		regionWidth = 0, regionHeight = 0,
 		regionOriginalWidth = 0, regionOriginalHeight = 0,
@@ -76,9 +76,9 @@ function SkinnedMeshAttachment.new (name)
 
 	function self:computeWorldVertices (x, y, slot, worldVertices)
 		local skeletonBones = slot.bone.skeleton.bones
+x,y=slot.bone.skeleton.x,slot.bone.skeleton.y
 		local weights = self.weights
 		local bones = self.bones
-
 		local w, v, b, f = 1, 1, 1, 1
 		local	n = #bones
 		local wx, wy, bone, vx, vy, weight
@@ -104,13 +104,13 @@ function SkinnedMeshAttachment.new (name)
 			end
 		else
 			local ffd = slot.attachmentVertices
-			while v < n do
+			while v <= n do
 				wx = 0
 				wy = 0
 				local nn = bones[v] + v
 				v = v + 1
 				while v <= nn do
-					bone = skeletonBones[bones[v]]
+					bone = skeletonBones[bones[v] + 1]
 					vx = weights[b] + ffd[f]
 					vy = weights[b + 1] + ffd[f + 1]
 					weight = weights[b + 2]

--- a/spine-lua/SkinnedMeshAttachment.lua
+++ b/spine-lua/SkinnedMeshAttachment.lua
@@ -89,7 +89,7 @@ function SkinnedMeshAttachment.new (name)
 				local nn = bones[v] + v
 				v = v + 1
 				while v <= nn do
-					bone = skeletonBones[bones[v]]
+					bone = skeletonBones[bones[v] + 1]
 					vx = weights[b]
 					vy = weights[b + 1]
 					weight = weights[b + 2]

--- a/spine-lua/SkinnedMeshAttachment.lua
+++ b/spine-lua/SkinnedMeshAttachment.lua
@@ -37,7 +37,7 @@ function SkinnedMeshAttachment.new (name)
 	
 	local self = {
 		name = name,
-		type = AttachmentType.mesh,
+		type = AttachmentType.skinnedmesh,
 		bones = nil,
 		weights = nil,
 		uvs = nil,
@@ -75,15 +75,15 @@ function SkinnedMeshAttachment.new (name)
 	end
 
 	function self:computeWorldVertices (x, y, slot, worldVertices)
-		local skeletonBones = slot.skeleton.bones
+		local skeletonBones = slot.bone.skeleton.bones
 		local weights = self.weights
 		local bones = self.bones
 
-		local w, v, b, f = 0, 0, 0, 0
-		local	n = bones.length
+		local w, v, b, f = 1, 1, 1, 1
+		local	n = #bones
 		local wx, wy, bone, vx, vy, weight
-		if #slot.attachmentVertices == 0 then
-			while v < n do
+		if slot.attachmentVerticesCount == 0 then
+			while v <= n do
 				wx = 0
 				wy = 0
 				local nn = bones[v] + v


### PR DESCRIPTION
Minor fixes for off-by-one indexing and loop counts for skinned meshes

Some fixes for names or counts, again for skinned meshes

(This does not include the mesh logic itself, nor have I tested basic meshes.)