### PR TITLE
Update MonoGame iOS example in line with recent changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,11 @@ spine-csharp/src/*.cs.meta
 
 spine-monogame/xamarinstudio-ios/src/bin
 spine-monogame/xamarinstudio-ios/src/obj
+spine-monogame/xamarinstudio-ios/src/packages
 
 spine-monogame/xamarinstudio-ios/example/bin
 spine-monogame/xamarinstudio-ios/example/obj
+spine-monogame/xamarinstudio-ios/example/packages
 
 spine-monogame/windows8-store/src/bin
 spine-monogame/windows8-store/src/obj

--- a/spine-monogame/xamarinstudio-ios/example/AppDelegate.cs
+++ b/spine-monogame/xamarinstudio-ios/example/AppDelegate.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 using Spine;
 
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
+using Foundation;
+using UIKit;
 
 namespace spinemonogameexample
 {

--- a/spine-monogame/xamarinstudio-ios/example/Main.cs
+++ b/spine-monogame/xamarinstudio-ios/example/Main.cs
@@ -1,9 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
-using MonoTouch.Foundation;
-using MonoTouch.UIKit;
+using Foundation;
+using UIKit;
 
 namespace spinemonogameexample
 {

--- a/spine-monogame/xamarinstudio-ios/example/packages.config
+++ b/spine-monogame/xamarinstudio-ios/example/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MonoGame.Framework.iOS" version="3.5.0.1678" targetFramework="xamarinios10" />
+</packages>

--- a/spine-monogame/xamarinstudio-ios/example/spine-monogame-example.csproj
+++ b/spine-monogame/xamarinstudio-ios/example/spine-monogame-example.csproj
@@ -17,16 +17,17 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
+    <DefineConstants>DEBUG;IOS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
     <MtouchLink>None</MtouchLink>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchDebug>true</MtouchDebug>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchArch>i386</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
-    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -34,13 +35,14 @@
     <MtouchLink>None</MtouchLink>
     <ConsolePause>false</ConsolePause>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <DefineConstants>IOS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\iPhone\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
+    <DefineConstants>DEBUG;IOS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -48,9 +50,10 @@
     <MtouchDebug>true</MtouchDebug>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchArch>ARMv7</MtouchArch>
+    <IpaPackageName>
+    </IpaPackageName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
-    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhone\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -59,9 +62,9 @@
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <DefineConstants>IOS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
-    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhone\Ad-Hoc</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -72,9 +75,9 @@
     <CodesignProvision>Automatic:AdHoc</CodesignProvision>
     <CodesignKey>iPhone Distribution</CodesignKey>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <DefineConstants>IOS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
-    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\iPhone\AppStore</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -84,6 +87,7 @@
     <ConsolePause>false</ConsolePause>
     <CodesignProvision>Automatic:AppStore</CodesignProvision>
     <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <DefineConstants>IOS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/spine-monogame/xamarinstudio-ios/example/spine-monogame-example.csproj
+++ b/spine-monogame/xamarinstudio-ios/example/spine-monogame-example.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
-    <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>spinemonogameexample</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>spinemonogameexample</AssemblyName>
+    <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>
@@ -45,6 +47,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <MtouchDebug>true</MtouchDebug>
     <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchArch>ARMv7</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>full</DebugType>
@@ -55,6 +58,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
     <DebugType>full</DebugType>
@@ -67,6 +71,7 @@
     <BuildIpa>true</BuildIpa>
     <CodesignProvision>Automatic:AdHoc</CodesignProvision>
     <CodesignKey>iPhone Distribution</CodesignKey>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'AppStore|iPhone' ">
     <DebugType>full</DebugType>
@@ -78,12 +83,16 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <ConsolePause>false</ConsolePause>
     <CodesignProvision>Automatic:AppStore</CodesignProvision>
+    <MtouchArch>ARMv7, ARM64</MtouchArch>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <Reference Include="monotouch" />
+    <Reference Include="Xamarin.iOS" />
+    <Reference Include="MonoGame.Framework">
+      <HintPath>packages\MonoGame.Framework.iOS.3.5.0.1678\lib\XamariniOS\MonoGame.Framework.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
@@ -92,6 +101,7 @@
   <ItemGroup>
     <None Include="Info.plist" />
     <None Include="Entitlements.plist" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />
@@ -100,12 +110,7 @@
       <Link>ExampleGame.cs</Link>
     </Compile>
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\MonoGame\MonoGame.Framework\MonoGame.Framework.iOS.csproj">
-      <Project>{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}</Project>
-      <Name>MonoGame.Framework.iOS</Name>
-    </ProjectReference>
     <ProjectReference Include="..\src\spine-monogame-xamarinstudio-ios.csproj">
       <Project>{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}</Project>
       <Name>spine-monogame-xamarinstudio-ios</Name>
@@ -139,5 +144,9 @@
     <Content Include="..\..\..\spine-xna\example\data\goblins-mesh.atlas">
       <Link>data\goblins-mesh.atlas</Link>
     </Content>
+    <Content Include="..\..\..\spine-xna\example\data\raptor.skel">
+      <Link>data\raptor.skel</Link>
+    </Content>
   </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/spine-monogame/xamarinstudio-ios/example/spine-monogame-example.sln
+++ b/spine-monogame/xamarinstudio-ios/example/spine-monogame-example.sln
@@ -3,10 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "spine-monogame-example", "spine-monogame-example.csproj", "{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lidgren.Network.iOS", "..\..\..\..\MonoGame\ThirdParty\Lidgren.Network\Lidgren.Network.iOS.csproj", "{734EAA48-F1CA-481A-B391-0285BC0E8B40}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoGame.Framework.iOS", "..\..\..\..\MonoGame\MonoGame.Framework\MonoGame.Framework.iOS.csproj", "{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "spine-monogame-xamarinstudio-ios", "..\src\spine-monogame-xamarinstudio-ios.csproj", "{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}"
 EndProject
 Global
@@ -43,30 +39,6 @@ Global
 		{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}.Release|iPhone.Build.0 = Release|iPhone
 		{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
 		{1B40F8C5-B8CA-4F5C-8B48-61D1E8981CA9}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
-		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Ad-Hoc|iPhone.ActiveCfg = Release|Any CPU
-		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Ad-Hoc|iPhone.Build.0 = Release|Any CPU
-		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.AppStore|iPhone.ActiveCfg = Release|Any CPU
-		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.AppStore|iPhone.Build.0 = Release|Any CPU
-		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Debug|iPhone.Build.0 = Debug|Any CPU
-		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Release|iPhone.Build.0 = Release|Any CPU
-		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{734EAA48-F1CA-481A-B391-0285BC0E8B40}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Ad-Hoc|iPhone.ActiveCfg = Release|iPhone
-		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Ad-Hoc|iPhone.Build.0 = Release|iPhone
-		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.AppStore|iPhone.ActiveCfg = Release|iPhone
-		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.AppStore|iPhone.Build.0 = Release|iPhone
-		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Debug|iPhone.ActiveCfg = Debug|iPhone
-		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Debug|iPhone.Build.0 = Debug|iPhone
-		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
-		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
-		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Release|iPhone.ActiveCfg = Release|iPhone
-		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Release|iPhone.Build.0 = Release|iPhone
-		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
-		{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = spine-monogame-example.csproj

--- a/spine-monogame/xamarinstudio-ios/src/packages.config
+++ b/spine-monogame/xamarinstudio-ios/src/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MonoGame.Framework.iOS" version="3.5.0.1678" targetFramework="xamarinios10" />
+</packages>

--- a/spine-monogame/xamarinstudio-ios/src/spine-monogame-xamarinstudio-ios.csproj
+++ b/spine-monogame/xamarinstudio-ios/src/spine-monogame-xamarinstudio-ios.csproj
@@ -4,11 +4,13 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}</ProjectGuid>
-    <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>spinecsharpxamarinios</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>spine-monogame-xamarinstudio-ios</AssemblyName>
+    <TargetFrameworkIdentifier>Xamarin.iOS</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -33,20 +35,15 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <Reference Include="monotouch" />
+    <Reference Include="Xamarin.iOS" />
+    <Reference Include="MonoGame.Framework">
+      <HintPath>..\example\packages\MonoGame.Framework.iOS.3.5.0.1678\lib\XamariniOS\MonoGame.Framework.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="spine-csharp\" />
     <Folder Include="spine-xna\" />
     <Folder Include="spine-csharp\Attachments\" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\MonoGame\MonoGame.Framework\MonoGame.Framework.iOS.csproj">
-      <Project>{DB8508BB-9849-4CC2-BC0F-8EB5DACB3C47}</Project>
-      <Name>MonoGame.Framework.iOS</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\spine-csharp\src\Attachments\AtlasAttachmentLoader.cs">
@@ -139,14 +136,36 @@
     <Compile Include="..\..\..\spine-csharp\src\Attachments\MeshAttachment.cs">
       <Link>spine-csharp\Attachments\MeshAttachment.cs</Link>
     </Compile>
-    <Compile Include="..\..\..\spine-csharp\src\Attachments\SkinnedMeshAttachment.cs">
-      <Link>spine-csharp\Attachments\SkinnedMeshAttachment.cs</Link>
-    </Compile>
     <Compile Include="..\..\..\spine-csharp\src\IkConstraint.cs">
       <Link>spine-csharp\IkConstraint.cs</Link>
     </Compile>
     <Compile Include="..\..\..\spine-csharp\src\IkConstraintData.cs">
       <Link>spine-csharp\IkConstraintData.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\spine-csharp\src\BlendMode.cs">
+      <Link>spine-csharp\BlendMode.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\spine-csharp\src\SkeletonBinary.cs">
+      <Link>spine-csharp\SkeletonBinary.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\spine-csharp\src\Attachments\WeightedMeshAttachment.cs">
+      <Link>spine-csharp\Attachments\WeightedMeshAttachment.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\spine-csharp\src\IUpdatable.cs">
+      <Link>spine-csharp\IUpdatable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\spine-csharp\src\MathUtils.cs">
+      <Link>spine-csharp\MathUtils.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\spine-csharp\src\TransformConstraint.cs">
+      <Link>spine-csharp\TransformConstraint.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\spine-csharp\src\TransformConstraintData.cs">
+      <Link>spine-csharp\TransformConstraintData.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/spine-monogame/xamarinstudio-ios/src/spine-monogame-xamarinstudio-ios.sln
+++ b/spine-monogame/xamarinstudio-ios/src/spine-monogame-xamarinstudio-ios.sln
@@ -1,0 +1,17 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "spine-monogame-xamarinstudio-ios", "spine-monogame-xamarinstudio-ios.csproj", "{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08DC311B-1F38-4CBD-B7B6-B734984A8CB3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/spine-xna/example/src/ExampleGame.cs
+++ b/spine-xna/example/src/ExampleGame.cs
@@ -137,7 +137,10 @@ namespace Spine {
 
 		protected override void Update (GameTime gameTime) {
 			// TODO: Add your update logic here
-
+#if (!WINDOWS_STOREAPP || WINDOWS_PHONE81) && !IOS	
+			if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed)
+					this.Exit();
+#endif
 			base.Update(gameTime);
 		}
 

--- a/spine-xna/example/src/ExampleGame.cs
+++ b/spine-xna/example/src/ExampleGame.cs
@@ -125,7 +125,7 @@ namespace Spine {
 			}
 
 			skeleton.X = 400;
-			skeleton.Y = 590;
+			skeleton.Y = 690;
 			skeleton.UpdateWorldTransform();
 
 			headSlot = skeleton.FindSlot("head");
@@ -136,11 +136,6 @@ namespace Spine {
 		}
 
 		protected override void Update (GameTime gameTime) {
-			// Allows the game to exit
-#if !WINDOWS_STOREAPP	
-			if (GamePad.GetState(PlayerIndex.One).Buttons.Back == ButtonState.Pressed)
-				this.Exit();
-#endif
 			// TODO: Add your update logic here
 
 			base.Update(gameTime);


### PR DESCRIPTION
 * Migrate to unified API to support 64 bit platforms.
 * Remove call to game.exit() in ExampleGame.cs as this is no longer supported.
 * Use MonoGame.ios Nuget package instead of relying on external repo being present on the machine.