### PR TITLE
renderer should support normal blend mode

### DIFF
--- a/spine-cocos2dx/3/src/spine/SkeletonRenderer.cpp
+++ b/spine-cocos2dx/3/src/spine/SkeletonRenderer.cpp
@@ -219,6 +219,9 @@ void SkeletonRenderer::drawSkeleton (const Mat4 &transform, uint32_t transformFl
 				_batch->flush();
 				blendMode = slot->data->blendMode;
 				switch (slot->data->blendMode) {
+				case SP_BLEND_MODE_NORMAL:
+					GL::blendFunc(_premultipliedAlpha ? GL_ONE : GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+					break;
 				case SP_BLEND_MODE_ADDITIVE:
 					GL::blendFunc(_premultipliedAlpha ? GL_ONE : GL_SRC_ALPHA, GL_ONE);
 					break;


### PR DESCRIPTION
support `SP_BLEND_MODE_NORMAL` in SkeletonRenderer

Test animation：
[aitiwen.zip](https://github.com/cocos2d/cocos2d-x/files/189123/aitiwen.zip)

Wrong rendered result: (a spot light appeared on "COCOS2D")
![image](https://cloud.githubusercontent.com/assets/1503156/14039193/d0cb4474-f294-11e5-9fde-c97268dcd49f.png)

Fixed result: (the spot light become transparent)
![image](https://cloud.githubusercontent.com/assets/1503156/14039182/b5da1dac-f294-11e5-9849-1c965a2d62e8.png)