### PR TITLE
[c] Prevent crash when setting new animation during event callback on same trackId

### DIFF
--- a/spine-c/src/spine/AnimationState.c
+++ b/spine-c/src/spine/AnimationState.c
@@ -207,12 +207,17 @@ void spAnimationState_clearTrack (spAnimationState* self, int trackIndex) {
 	current = self->tracks[trackIndex];
 	if (!current) return;
 
-	if (current->listener) current->listener(self, trackIndex, SP_ANIMATION_END, 0, 0);
-	if (self->listener) self->listener(self, trackIndex, SP_ANIMATION_END, 0, 0);
+	spAnimationStateListener tempcurrentlistener = current->listener;
+	spAnimationStateListener tempselflistener = self->listener;
+	
 
 	self->tracks[trackIndex] = 0;
 
 	_spAnimationState_disposeAllEntries(self, current);
+
+	if (tempcurrentlistener) tempcurrentlistener(self, trackIndex, SP_ANIMATION_END, 0, 0);
+	if (tempselflistener) tempselflistener(self, trackIndex, SP_ANIMATION_END, 0, 0);
+
 }
 
 spTrackEntry* _spAnimationState_expandToIndex (spAnimationState* self, int index) {


### PR DESCRIPTION
user may set new animation with the same trackid  in  callback.
so do all clean jobs before callback to user's code