### PR TITLE
[c][js] Fixed spine-js and spine-c "addAnimation" function not triggering "onStart" callback when queue was empty

### DIFF
--- a/spine-c/src/spine/AnimationState.c
+++ b/spine-c/src/spine/AnimationState.c
@@ -304,7 +304,7 @@ spTrackEntry* spAnimationState_addAnimation (spAnimationState* self, int trackIn
 			last = last->next;
 		last->next = entry;
 	} else
-		self->tracks[trackIndex] = entry;
+		_spAnimationState_setCurrent(self, trackIndex, entry);
 
 	if (delay <= 0) {
 		if (last)

--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -1681,7 +1681,7 @@ spine.AnimationState.prototype = {
 				last = last.next;
 			last.next = entry;
 		} else
-			this.tracks[trackIndex] = entry;
+			this.setCurrent(trackIndex, entry);
 
 		if (delay <= 0) {
 			if (last)


### PR DESCRIPTION
I need to use addAnimation after listening to the start event.