### PR TITLE
Fix find Bone after bone get worldX and worldY Is 0 bug.

### DIFF
--- a/spine-cocos2dx/3/src/spine/SkeletonRenderer.cpp
+++ b/spine-cocos2dx/3/src/spine/SkeletonRenderer.cpp
@@ -75,6 +75,7 @@ void SkeletonRenderer::initialize () {
 
 void SkeletonRenderer::setSkeletonData (spSkeletonData *skeletonData, bool ownsSkeletonData) {
 	_skeleton = spSkeleton_create(skeletonData);
+	updateWorldTransform();
 	_ownsSkeletonData = ownsSkeletonData;
 }
 


### PR DESCRIPTION
When getting worldX of bones after calling setSkeletonData, the value is still 0 because updateWorldTransform not yet invoked.