### PR TITLE
[spine-js] Fixed a bug where ffd would never be used in "computeWorldVertices".

### DIFF
--- a/spine-js/spine.js
+++ b/spine-js/spine.js
@@ -989,8 +989,11 @@ spine.FfdTimeline.prototype = {
 		var vertexCount = frameVertices[0].length;
 
 		var vertices = slot.attachmentVertices;
-		if (vertices.length != vertexCount) alpha = 1;
-		vertices.length = vertexCount;
+		if (vertices.length != vertexCount) {
+			vertices = slot.attachmentVertices = new spine.Float32Array(vertexCount);
+			vertices.length = vertexCount;
+			alpha = 1;
+		}
 
 		if (time >= frames[frames.length - 1]) { // Time is after last frame.
 			var lastVertices = frameVertices[frames.length - 1];


### PR DESCRIPTION
Float32Array.length is read only and will not resize the array. This caused the .length to always be 0 and thus not use ffd in spine.WeightedMeshAttachment.computerWorldVertices(). This proposed fix instead creates a new array when the size has changed.