### PR TITLE
[cocos2dx] When the Director is paused while spine animations are running it crashes the app

### DIFF
--- a/spine-cocos2dx/3/src/spine/SkeletonBatch.cpp
+++ b/spine-cocos2dx/3/src/spine/SkeletonBatch.cpp
@@ -34,6 +34,8 @@
 #include <algorithm>
 
 USING_NS_CC;
+#define EVENT_AFTER_DRAW_RESET_POSITION "director_after_draw"
+
 using std::max;
 
 namespace spine {
@@ -57,11 +59,13 @@ SkeletonBatch::SkeletonBatch (int capacity) :
 	_firstCommand = new Command();
 	_command = _firstCommand;
 
-	Director::getInstance()->getScheduler()->scheduleUpdate(this, -1, false);
+	Director::getInstance()->getEventDispatcher()->addCustomEventListener(EVENT_AFTER_DRAW_RESET_POSITION, [this](EventCustom* eventCustom){
+	    this->update(0);
+	});	
 }
 
 SkeletonBatch::~SkeletonBatch () {
-	Director::getInstance()->getScheduler()->unscheduleUpdate(this);
+	Director::getInstance()->getEventDispatcher()->removeCustomEventListeners(EVENT_AFTER_DRAW_RESET_POSITION);
 
 	Command* command = _firstCommand;
 	while (command) {


### PR DESCRIPTION
I noticed that the scheduled update calls do not get called when Director is paused but draw callback continue to be called. This was causing the app to crash.

The solution is really simple, instead of doing the _position reset in update callback, I registered a cusom event listener for "director_after_draw" event. This event is raised after every update call irrespective of whether the director is paused or not.

Tested it in our game and it seems to be fixing the crash.