### PR TITLE
Fix -Wshadow warning when compiling with Clang

### DIFF
--- a/spine-c/src/spine/Animation.c
+++ b/spine-c/src/spine/Animation.c
@@ -267,7 +267,7 @@ void _spRotateTimeline_apply (const spTimeline* timeline, spSkeleton* skeleton, 
 	bone = skeleton->bones[self->boneIndex];
 
 	if (time >= self->frames[self->framesCount - 2]) { /* Time is after last frame. */
-		float amount = bone->data->rotation + self->frames[self->framesCount - 1] - bone->rotation;
+		amount = bone->data->rotation + self->frames[self->framesCount - 1] - bone->rotation;
 		while (amount > 180)
 			amount -= 360;
 		while (amount < -180)


### PR DESCRIPTION
Hello, I get the following `-Wshadow` warning when compiling spine-c runtime with Xcode 7.3 and Clang:

```
spine/Animation.c:270:9: Declaration shadows a local variable
```

This PR fixes it. Thanks!