### PR TITLE
[spine-unity] Support sprite attachments with pivot placed outside the sprite

### DIFF
--- a/spine-unity/Assets/spine-unity/Modules/SpriteAttacher.cs
+++ b/spine-unity/Assets/spine-unity/Modules/SpriteAttacher.cs
@@ -169,8 +169,8 @@ namespace Spine.Unity.Modules {
 			attachment.SetColor(Color.white);
 			attachment.ScaleX = 1;
 			attachment.ScaleY = 1;
-			attachment.RegionOffsetX = sprite.rect.width * (0.5f - Mathf.InverseLerp(bounds.min.x, bounds.max.x, 0)) / sprite.pixelsPerUnit;
-			attachment.RegionOffsetY = sprite.rect.height * (0.5f - Mathf.InverseLerp(bounds.min.y, bounds.max.y, 0)) / sprite.pixelsPerUnit;
+			attachment.RegionOffsetX = sprite.rect.width * (0.5f - InverseLerp(bounds.min.x, bounds.max.x, 0)) / sprite.pixelsPerUnit;
+			attachment.RegionOffsetY = sprite.rect.height * (0.5f - InverseLerp(bounds.min.y, bounds.max.y, 0)) / sprite.pixelsPerUnit;
 			attachment.Width = size.x;
 			attachment.Height = size.y;
 			attachment.RegionWidth = size.x;
@@ -193,6 +193,11 @@ namespace Spine.Unity.Modules {
 
 		public BoundingBoxAttachment NewBoundingBoxAttachment (Skin skin, string name) {
 			throw new System.NotImplementedException();
+		}
+		
+		private float InverseLerp(float a, float b, float value)
+		{
+			return (value - a) / (b - a);
 		}
 	}
 


### PR DESCRIPTION
The case here is as follows:
 - create random unity sprite prefab
 - place sprite's pivot point outside of the sprite (say, pivot U is 2.53 and pivot V is -1.22)
 - try to attach this sprite via the SpriteAttacher script

Expected result here would be seeing the sprite sticking with it's pivot point to the placeholder.
Actual result here looks like the sprite's pivot point is somewhere in U: 1 and V: 0.

The bug is caused by Mathf.InverseLerp - it just cannot return values outside of [0; 1] range.

So the solution would be to make our own version of InverseLerp, which handles such situations correctly.