### PR TITLE
[cocos2d-x] Fix implicit conversion warning

### DIFF
--- a/spine-cocos2dx/src/spine/spine-cocos2dx.cpp
+++ b/spine-cocos2dx/src/spine/spine-cocos2dx.cpp
@@ -77,7 +77,7 @@ void _spAtlasPage_disposeTexture (spAtlasPage* self) {
 char* _spUtil_readFile (const char* path, int* length) {
 	Data data = FileUtils::getInstance()->getDataFromFile(
 			FileUtils::getInstance()->fullPathForFilename(path).c_str());
-	*length = data.getSize();
+	*length = static_cast<int>(data.getSize());
 	char* bytes = MALLOC(char, *length);
 	memcpy(bytes, data.getBytes(), *length);
 	return bytes;


### PR DESCRIPTION
This PR fixes the following warning when compiling `spine-cocos2dx.cpp` which included in cocos2d-x with Xcode 7.3.1 and Clang:

```
spine-cocos2dx.cpp:52:12: implicit conversion loses integer precision: 'ssize_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
```