### PR TITLE
[spine-c] Fixed spBone_worldToLocalRotationY

### DIFF
--- a/spine-c/src/spine/Bone.c
+++ b/spine-c/src/spine/Bone.c
@@ -1,10 +1,10 @@
 /******************************************************************************
  * Spine Runtimes Software License
  * Version 2.3
- * 
+ *
  * Copyright (c) 2013-2015, Esoteric Software
  * All rights reserved.
- * 
+ *
  * You are granted a perpetual, non-exclusive, non-sublicensable and
  * non-transferable license to use, install, execute and perform the Spine
  * Runtimes Software (the "Software") and derivative works solely for personal
@@ -16,7 +16,7 @@
  * or other intellectual property or proprietary rights notices on or in the
  * Software, including any copy thereof. Redistributions in binary or source
  * form must include this license and terms.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY ESOTERIC SOFTWARE "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
@@ -213,7 +213,7 @@ float spBone_worldToLocalRotationX (spBone* self) {
 
 float spBone_worldToLocalRotationY (spBone* self) {
 	spBone* parent = self->parent;
-	if (self->parent) return self->rotation;
+	if (!parent) return self->rotation;
 	return ATAN2(parent->a * self->d - parent->c * self->b, parent->d * self->b - parent->b * self->d) * RAD_DEG;
 }
 


### PR DESCRIPTION
* crashes when bone has no parent
* doesn't calculate local rotation when bone has parent

I stumbled upon this while porting 3.4 to spinecpp :)