### PR TITLE
[spine-c] Fixed calculation of number of path constraint timelines.

### DIFF
--- a/spine-c/src/spine/SkeletonJson.c
+++ b/spine-c/src/spine/SkeletonJson.c
@@ -162,7 +162,8 @@ static spAnimation* _spSkeletonJson_readAnimation (spSkeletonJson* self, Json* r
 		timelinesCount += slotMap->size;
 	timelinesCount += ik ? ik->size : 0;
 	timelinesCount += transform ? transform->size : 0;
-	timelinesCount += paths ? paths->size : 0;
+	for (constraintMap = paths ? paths->child : 0; constraintMap; constraintMap = constraintMap->next)
+		timelinesCount += constraintMap->size;
 	for (constraintMap = deform ? deform->child : 0; constraintMap; constraintMap = constraintMap->next)
 		for (slotMap = constraintMap->child; slotMap; slotMap = slotMap->next)
 			timelinesCount += slotMap->size;


### PR DESCRIPTION
* The json structure is that the path constraint timelines are added per path constraint
* Instead of the number of timelines what was calculated was the number of path constraints for which we have timelines
* If there were more timelines than path constraints, this led to memory corruption (writing past the buffer)