### PR TITLE
[spine-c] Fixed uninitialized value

### DIFF
--- a/spine-c/src/spine/PathConstraint.c
+++ b/spine-c/src/spine/PathConstraint.c
@@ -101,6 +101,7 @@ void spPathConstraint_apply (spPathConstraint* self) {
 		self->spacesCount = spacesCount;
 	}
 	spaces = self->spaces;
+	spaces[0] = 0;
 	lengths = 0;
 	spacing = self->spacing;
 	if (scale || lengthSpacing) {


### PR DESCRIPTION
* First space of path constraint spaces remained uninitialized
* This led to various visual bugs with path constraints