### PR TITLE
[cocos2d-x] Add missing switch case

### DIFF
--- a/spine-cocos2dx/src/spine/spine-cocos2dx.cpp
+++ b/spine-cocos2dx/src/spine/spine-cocos2dx.cpp
@@ -40,6 +40,8 @@ GLuint wrap (spAtlasWrap wrap) {
 
 GLuint filter (spAtlasFilter filter) {
 	switch (filter) {
+	case SP_ATLAS_UNKNOWN_FILTER:
+		break;
 	case SP_ATLAS_NEAREST:
 		return GL_NEAREST;
 	case SP_ATLAS_LINEAR:


### PR DESCRIPTION
This pull request adds missing switch case `SP_ATLAS_UNKNOWN_FILTER` to prevent the following warning on Xcode 7.3.1 (Clang).

```
spine-cocos2dx.cpp:42:10: Enumeration value 'SP_ATLAS_UNKNOWN_FILTER' not handled in switch [-Wswitch]
```