### PR TITLE
[spine-c] Fix redefinition of macro MIN and MAX

### DIFF
--- a/spine-c/include/spine/extension.h
+++ b/spine-c/include/spine/extension.h
@@ -83,8 +83,12 @@
 #define SIN_DEG(A) SIN((A) * DEG_RAD)
 #define COS_DEG(A) COS((A) * DEG_RAD)
 #define CLAMP(x, min, max) ((x) < (min) ? (min) : ((x) > (max) ? (max) : (x)))
+#ifndef MIN
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
+#endif
+#ifndef MAX
 #define MAX(x, y) ((x) > (y) ? (x) : (y))
+#endif
 
 #define UNUSED(x) (void)(x)
 


### PR DESCRIPTION
When trying to compiling Spine 3.4 with cocos2d-x v3.13 (in progress) on Xcode 7.3.1/Clang, I get the following warnings:

```
extension.h:86:9: 'MIN' macro redefined
extension.h:87:9: 'MAX' macro redefined
```

The CCStdC header has defined `MIN` and `MAX` macros but those macros are defined unconditionally in `extension.h` as follows:

- [cocos2d-x/cocos/platform/ios/CCStdC-ios.h#L43-L49](https://github.com/cocos2d/cocos2d-x/blob/294596861436c918b08a7f4efa9f321890c991f9/cocos/platform/ios/CCStdC-ios.h#L43-L49)
- [cocos2d-x/cocos/platform/mac/CCStdC-mac.h#L43-L49](https://github.com/cocos2d/cocos2d-x/blob/294596861436c918b08a7f4efa9f321890c991f9/cocos/platform/mac/CCStdC-mac.h#L43-L49)

So this pull request adds `#ifndef MIN` and `#ifndef MAX` conditions to fix the warnings.

Thank you for your amazing tool!
