### PR TITLE
[unity] Adding followBoneScale to BoneFollower.cs

### DIFF
--- a/spine-unity/Assets/spine-unity/BoneFollower.cs
+++ b/spine-unity/Assets/spine-unity/BoneFollower.cs
@@ -53,7 +53,8 @@ namespace Spine.Unity {
 
 		public bool followZPosition = true;
 		public bool followBoneRotation = true;
-
+        	public bool followBoneScale = false;
+        	
 		[Tooltip("Follows the skeleton's flip state by controlling this Transform's local scale.")]
 		public bool followSkeletonFlip = false;
 
@@ -131,6 +132,9 @@ namespace Spine.Unity {
 				float flipScaleY = bone.skeleton.flipX ^ bone.skeleton.flipY ? -1f : 1f;
 				thisTransform.localScale = new Vector3(1f, flipScaleY, 1f);
 			}
+			
+            		if (followBoneScale)
+                		thisTransform.localScale = new Vector3 (bone.WorldScaleX, bone.WorldScaleY); 
 		}
 	}
 

--- a/spine-unity/Assets/spine-unity/BoneFollower.cs
+++ b/spine-unity/Assets/spine-unity/BoneFollower.cs
@@ -128,13 +128,16 @@ namespace Spine.Unity {
 				}
 			}
 
+            		if (followBoneScale)
+                		thisTransform.localScale = new Vector3 (bone.WorldScaleX, bone.WorldScaleY, 1f);
+                	else
+                		thisTransform.localScale = Vector3.one;
+                		
 			if (followSkeletonFlip) {
 				float flipScaleY = bone.skeleton.flipX ^ bone.skeleton.flipY ? -1f : 1f;
-				thisTransform.localScale = new Vector3(1f, flipScaleY, 1f);
+				thisTransform.localScale = new Vector3(thisTransform.localScale.x, thisTransform.localScale.y*flipScaleY, 1f);
 			}
 			
-            		if (followBoneScale)
-                		thisTransform.localScale = new Vector3 (bone.WorldScaleX, bone.WorldScaleY); 
 		}
 	}
 

--- a/spine-unity/Assets/spine-unity/Editor/BoneFollowerInspector.cs
+++ b/spine-unity/Assets/spine-unity/Editor/BoneFollowerInspector.cs
@@ -35,7 +35,7 @@ using UnityEngine;
 namespace Spine.Unity.Editor {	
 	[CustomEditor(typeof(BoneFollower))]
 	public class BoneFollowerInspector : UnityEditor.Editor {
-		SerializedProperty boneName, skeletonRenderer, followZPosition, followBoneRotation, followSkeletonFlip;
+		SerializedProperty boneName, skeletonRenderer, followZPosition, followBoneRotation, followSkeletonFlip, followBoneScale;
 		BoneFollower targetBoneFollower;
 		bool needsReset;
 
@@ -45,6 +45,7 @@ namespace Spine.Unity.Editor {
 			followBoneRotation = serializedObject.FindProperty("followBoneRotation");
 			followZPosition = serializedObject.FindProperty("followZPosition");
 			followSkeletonFlip = serializedObject.FindProperty("followSkeletonFlip");
+			followBoneScale = serializedObject.FindProperty("followBoneScale");
 
 			targetBoneFollower = (BoneFollower)target;
 			if (targetBoneFollower.SkeletonRenderer != null)
@@ -89,6 +90,7 @@ namespace Spine.Unity.Editor {
 				EditorGUILayout.PropertyField(followBoneRotation);
 				EditorGUILayout.PropertyField(followZPosition);
 				EditorGUILayout.PropertyField(followSkeletonFlip);
+				EditorGUILayout.PropertyField(followBoneScale);
 			} else {
 				var boneFollowerSkeletonRenderer = targetBoneFollower.skeletonRenderer;
 				if (boneFollowerSkeletonRenderer == null) {


### PR DESCRIPTION
Used the bone's world scale value. Set to default false to prevent accidental, unwanted scale changes in active users.

Just realized this conflicts with the value of flip... adjusting the pull request.