### PR TITLE
fix bug when using SkeletonBinary.

### DIFF
--- a/spine-c/src/spine/SkeletonBinary.c
+++ b/spine-c/src/spine/SkeletonBinary.c
@@ -716,6 +716,9 @@ spAttachment* spSkeletonBinary_readAttachment(spSkeletonBinary* self, _dataInput
 				mesh->width = 0;
 				mesh->height = 0;
 			}
+
+            spAttachmentLoader_configureAttachment(self->attachmentLoader, attachment);
+
 			return attachment;
 		}
 		case SP_ATTACHMENT_LINKED_MESH: {


### PR DESCRIPTION
will cause crash when display skeleton using mesh.
![bug](https://cloud.githubusercontent.com/assets/1967633/18081331/396d1b5c-6ecc-11e6-85a8-1c6219b3f9c5.png)
