### PR TITLE
[csharp] Avoid file locking in SkeletonBinary.

### DIFF
--- a/spine-csharp/src/SkeletonBinary.cs
+++ b/spine-csharp/src/SkeletonBinary.cs
@@ -94,7 +94,7 @@ namespace Spine {
 		#if WINDOWS_PHONE
 			using (var input = new BufferedStream(Microsoft.Xna.Framework.TitleContainer.OpenStream(path))) {
 		#else
-			using (var input = new BufferedStream(new FileStream(path, FileMode.Open))) {
+			using (var input = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.SequentialScan)) {
 		#endif // WINDOWS_PHONE
 				SkeletonData skeletonData = ReadSkeletonData(input);
 				skeletonData.name = Path.GetFileNameWithoutExtension(path);


### PR DESCRIPTION
Hello! After switching from json to binary format I found that C# runtime locks the binary file while reading it though runtime doesn't lock json files. The problem is that `SkeletonJson` uses `StreamReader` which correctly sets `FileAccess` argument but `SkeletonBinary` use `FileStream` directly and doesn't set this argument that is identical to setting `FileAccess.ReadWrite`.
Also I found some small improvements which can be achieved by specifying additional arguments for `FileStream` ctor:
- Remove `BufferedStream` because `FileStream` is buffered itself with 4096 `bufferSize` by default.
- Specify `FileOptions.SequentialScan` to give OS the chance to cache the file optimally.