### PR TITLE
Fix mismatched memory deallocator in SkeletonRenderer.cpp

### DIFF
--- a/spine-cocos2dx/src/spine/SkeletonRenderer.cpp
+++ b/spine-cocos2dx/src/spine/SkeletonRenderer.cpp
@@ -98,7 +98,7 @@ SkeletonRenderer::~SkeletonRenderer () {
 	spSkeleton_dispose(_skeleton);
 	if (_atlas) spAtlas_dispose(_atlas);
 	if (_attachmentLoader) spAttachmentLoader_dispose(_attachmentLoader);
-	delete _worldVertices;
+	delete [] _worldVertices;
 }
 
 void SkeletonRenderer::initWithData (spSkeletonData* skeletonData, bool ownsSkeletonData) {


### PR DESCRIPTION
Currently valgrind reports the following error:

    ==3357== Mismatched free() / delete / delete []
    ==3357==    at 0x4C2B1C6: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==3357==    by 0x199EDB9: spine::SkeletonRenderer::~SkeletonRenderer() (SkeletonRenderer.cpp:101)

The memory which `_worldVertices` points to gets allocated in [SkeletonRenderer.cpp#L64](https://github.com/EsotericSoftware/spine-runtimes/blob/master/spine-cocos2dx/src/spine/SkeletonRenderer.cpp#L64), and therefore a `delete []` must be used instead. Otherwise we might get undefined behavior on some devices.