### PR TITLE
[spine-c] fix strict C compiler error

### DIFF
--- a/spine-c/src/spine/Skeleton.c
+++ b/spine-c/src/spine/Skeleton.c
@@ -188,7 +188,8 @@ static void _sortPathConstraintAttachmentBones(_spSkeleton* const internal, spAt
 		int i = 0;
 		while (i < pathBonesCount) {
 			int boneCount = pathBones[i++];
-			for (int n = i + boneCount; i < n; i++)
+            int n;
+			for (n = i + boneCount; i < n; i++)
 				_sortBone(internal, bones[pathBones[i]]);
 		}
 	}


### PR DESCRIPTION
Android C-Compiler build kicks this out as an error.
