### PR TITLE
[spine-c] Allocate more memory for events to prevent heap corruption

### DIFF
--- a/spine-c/src/spine/AnimationState.c
+++ b/spine-c/src/spine/AnimationState.c
@@ -59,7 +59,7 @@ void _spAnimationState_disposeTrackEntry (spTrackEntry* entry) {
 spAnimationState* spAnimationState_create (spAnimationStateData* data) {
 	_spAnimationState* internal = NEW(_spAnimationState);
 	spAnimationState* self = SUPER(internal);
-	internal->events = MALLOC(spEvent*, 64);
+	internal->events = MALLOC(spEvent*, 256);
 	self->timeScale = 1;
 	CONST_CAST(spAnimationStateData*, self->data) = data;
 	internal->createTrackEntry = _spAnimationState_createTrackEntry;


### PR DESCRIPTION
When using events with large string data, the allocated memory for event is too small to store the event data. It will overflow and cause heap corruption.
It has solved our random crash problem in a game with millions of users.