### PR TITLE
[spine-unity]fix "add skeleton utility" button disappear under SkeletonAnimator

### DIFF
--- a/spine-unity/Assets/spine-unity/Editor/SkeletonRendererInspector.cs
+++ b/spine-unity/Assets/spine-unity/Editor/SkeletonRendererInspector.cs
@@ -258,7 +258,9 @@ namespace Spine.Unity.Editor {
 				//	}
 			} else {
 				EditorGUILayout.Space();
-				var component = (SkeletonAnimation)target;
+				//var component = (SkeletonAnimation)target;
+				//fix: "Add Skeleton Utility" button disapear when instantiate(mecanim)
+				var component = (SkeletonRenderer)target;
 				if (component.GetComponent<SkeletonUtility>() == null) {						
 					if (GUILayout.Button(buttonContent, GUILayout.Height(30)))
 						component.gameObject.AddComponent<SkeletonUtility>();


### PR DESCRIPTION
fix: "Add Skeleton Utility" button disappear when instantiate(mecanim)
When instantiate a SkeletonDataAsset file to mecanim animation system, the button "Add Skeleton Utility" should show under SkeletonAnimator component is gone.