### PR TITLE
Fix a bug caused a crash on VS2013 or later when in Debug mode if there is any Unicode chars such as Chinese in Atlas file.

### DIFF
--- a/spine-c/spine-c/src/spine/Atlas.c
+++ b/spine-c/spine-c/src/spine/Atlas.c
@@ -66,11 +66,11 @@ typedef struct {
 } Str;
 
 static void trim (Str* str) {
-	while (isspace(*str->begin) && str->begin < str->end)
+	while (isspace((unsigned char)*str->begin) && str->begin < str->end)
 		(str->begin)++;
 	if (str->begin == str->end) return;
 	str->end--;
-	while (isspace(*str->end) && str->end >= str->begin)
+	while (isspace((unsigned char)*str->end) && str->end >= str->begin)
 		str->end--;
 	str->end++;
 }


### PR DESCRIPTION
In brief, the 'isspace' function allows a *unsigned* value between 0 and 255, while char is signed by default, so a char code over 0x80 represents a negative value which caused a assertion in the 'isspace' function.
The workaround is force converting the char into unsigned char.