### PR TITLE
[c] Fixed memory leak in _spSkeletonBinary_readAnimation

### DIFF
--- a/spine-c/spine-c/src/spine/SkeletonBinary.c
+++ b/spine-c/spine-c/src/spine/SkeletonBinary.c
@@ -582,6 +582,7 @@ static spAnimation* _spSkeletonBinary_readAnimation (spSkeletonBinary* self, con
 	kv_trim(spTimeline*, timelines);
 
 	animation = spAnimation_create(name, 0);
+	FREE(animation->timelines);
 	animation->duration = duration;
 	animation->timelinesCount = kv_size(timelines);
 	animation->timelines = kv_array(timelines);


### PR DESCRIPTION
Releases the memory allocated when spAnimation_create is called.
```
// Animation.c(40)
self->timelines = MALLOC(spTimeline*, timelinesCount);
```