### PR TITLE
[as3] rename applyFFD -> applyDeform

### DIFF
--- a/spine-as3/spine-as3/src/spine/attachments/MeshAttachment.as
+++ b/spine-as3/spine-as3/src/spine/attachments/MeshAttachment.as
@@ -83,7 +83,7 @@ public dynamic class MeshAttachment extends VertexAttachment {
 		}
 	}
 
-	public function applyFFD (sourceAttachment:Attachment) : Boolean {
+	override public function applyDeform (sourceAttachment:Attachment) : Boolean {
 		return this == sourceAttachment || (inheritDeform && _parentMesh == sourceAttachment);
 	}
 


### PR DESCRIPTION
It seems like this MeshAttachment method should be overriding the one in VertexAttachment for linked meshes to work correctly.