### PR TITLE
Android NDK r10d  wouldn't compile, blamed wrong types

### DIFF
--- a/spine-c/spine-c/src/spine/AnimationState.c
+++ b/spine-c/spine-c/src/spine/AnimationState.c
@@ -142,7 +142,7 @@ void _spEventQueue_drain (_spEventQueue* self) {
 	if (self->drainDisabled) return;
 	self->drainDisabled = 1;
 	for (i = 0; i < self->objectsCount; i += 2) {
-		spEventType type = self->objects[i].type;
+		spEventType type = (spEventType)self->objects[i].type;
 		spTrackEntry* entry = self->objects[i+1].entry;
 		spEvent* event;
 		switch (type) {

--- a/spine-c/spine-c/src/spine/Skeleton.c
+++ b/spine-c/spine-c/src/spine/Skeleton.c
@@ -161,7 +161,7 @@ static void _addToUpdateCache(_spSkeleton* const internal, _spUpdateType type, v
 	_spUpdate* update;
 	if (internal->updateCacheCount == internal->updateCacheCapacity) {
 		internal->updateCacheCapacity *= 2;
-		internal->updateCache = realloc(internal->updateCache, sizeof(_spUpdate) * internal->updateCacheCapacity);
+		internal->updateCache = (_spUpdate*)realloc(internal->updateCache, sizeof(_spUpdate) * internal->updateCacheCapacity);
 	}
 	update = internal->updateCache + internal->updateCacheCount;
 	update->type = type;
@@ -172,7 +172,7 @@ static void _addToUpdateCache(_spSkeleton* const internal, _spUpdateType type, v
 static void _addToUpdateCacheReset(_spSkeleton* const internal, spBone* bone) {
 	if (internal->updateCacheResetCount == internal->updateCacheResetCapacity) {
 		internal->updateCacheResetCapacity *= 2;
-		internal->updateCacheReset = realloc(internal->updateCacheReset, sizeof(spBone*) * internal->updateCacheResetCapacity);
+		internal->updateCacheReset = (spBone**)realloc(internal->updateCacheReset, sizeof(spBone*) * internal->updateCacheResetCapacity);
 	}
 	internal->updateCacheReset[internal->updateCacheResetCount] = bone;
 	++internal->updateCacheResetCount;


### PR DESCRIPTION
Would be cool to have those type casts added, my guess is those can also happen on other compilers.

- Added type cast to spEventType from AnimationState objects
- Added type cast to void-type realloc calls in Skeleton.c