### PR TITLE
[as3] animation totally disappears if has alpha < 1

### DIFF
--- a/spine-starling/spine-starling/src/spine/starling/SkeletonSprite.as
+++ b/spine-starling/spine-starling/src/spine/starling/SkeletonSprite.as
@@ -69,7 +69,7 @@ public class SkeletonSprite extends DisplayObject {
 	}
 
 	override public function render (painter:Painter) : void {
-		alpha *= this.alpha * skeleton.a;
+		painter.state.alpha *= skeleton.a;
 		var originalBlendMode:String = painter.state.blendMode;
 		var r:Number = skeleton.r * 255;
 		var g:Number = skeleton.g * 255;


### PR DESCRIPTION
This problem was probably introduced while moving to new starling version where premultiplied alpha is no longer passed as an argument to `render()`. 

BTW if I get it right then there's no need to manually restore `blendMode` because `DisplayObjectContainer` wraps child's `render()` with `painter.pushState()`/`painter.popState()`.