### PR TITLE
[ue4] Made compiling in VS work; defined behavior for GetTrackEntry()

### DIFF
--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineSkeletonAnimationComponent.h
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineSkeletonAnimationComponent.h
@@ -82,7 +82,7 @@ public:
 	UTrackEntry () { }		
 
 	void SetTrackEntry (spTrackEntry* entry);
-	spTrackEntry* GetTrackEntry();
+	spTrackEntry* GetTrackEntry() { return entry; }
 	
 	UFUNCTION(BlueprintCallable, Category="Components|Spine|TrackEntry")
 	int GetTrackIndex () { return entry ? entry->trackIndex : 0; }

--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineSkeletonComponent.h
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineSkeletonComponent.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "Components/ActorComponent.h"
+#include "SpineSkeletonDataAsset.h"
 #include "spine/spine.h"
 #include "SpineSkeletonComponent.generated.h"
 


### PR DESCRIPTION
Without this, line 52 (now line 53) of SpineSkeletonComponent.h would throw an error not recognizing USpineSkeletonDataAsset.

Also, attempting to use GetTrackEntry() from SpineSkeletonAnimationComponent.h would throw a Linker error as the behavior was not defined.