### PR TITLE
Remove dipping in interruped mix

### DIFF
--- a/spine-libgdx/spine-libgdx/src/com/esotericsoftware/spine/AnimationState.java
+++ b/spine-libgdx/spine-libgdx/src/com/esotericsoftware/spine/AnimationState.java
@@ -398,7 +398,8 @@ public class AnimationState {
 				}
 
 				// The interrupted mix will mix out from its current percentage to zero.
-				current.mixAlpha *= Math.min(from.mixTime / from.mixDuration, 1);
+				if (multipleMixing) current.mixAlpha *= Math.min(from.mixTime / from.mixDuration, 1);
+				else current.mixAlpha = 1;
 
 				// End the other animation after it is applied one last time.
 				if (!multipleMixing) {


### PR DESCRIPTION
If there's no multipleMixing == false, the mix progress should not be inherited as mixAlpha since this will cause a dip in the common cases where a mix is interrupted.