### PR TITLE
reuse existing canvas element when possible

### DIFF
--- a/spine-ts/widget/src/Widget.ts
+++ b/spine-ts/widget/src/Widget.ts
@@ -60,10 +60,14 @@ module spine {
 
 			this.validateConfig(config);
 
-			let canvas = this.canvas = document.createElement("canvas");
+			let existingCanvas = <HTMLCanvasElement> element.children[0];
+			let canvas = this.canvas = existingCanvas || document.createElement("canvas");
 			canvas.style.width = "100%";
 			canvas.style.height = "100%";
-			(<HTMLElement> element).appendChild(canvas);
+			// only create a new canvas when one doesn't already exist
+			if (!existingCanvas) {
+				(<HTMLElement>element).appendChild(canvas);
+			}
 			canvas.width = (<HTMLElement>element).clientWidth;
 			canvas.height = (<HTMLElement>element).clientHeight;
 			var webglConfig = { alpha: config.alpha };

--- a/spine-ts/widget/src/Widget.ts
+++ b/spine-ts/widget/src/Widget.ts
@@ -239,10 +239,12 @@ module spine {
 
 		private resize () {
 			let canvas = this.canvas;
-			let w = canvas.clientWidth;
-			let h = canvas.clientHeight;
 			let bounds = this.bounds;
-			if (canvas.width != w || canvas.height != h) {
+			let w = bounds.size.x;
+			let h = bounds.size.y;
+			// set canvas drawingBuffer equal to skeleton bounds (enables retina quality graphics)
+			// Math.floor is for matching how browsers round canvas size
+			if (canvas.width != Math.floor(w) || canvas.height != Math.floor(h)) {
 				canvas.width = w;
 				canvas.height = h;
 			}


### PR DESCRIPTION
When using Widget with React and other frameworks it's common to change properties but reuse the same DOM element. But when creating a new widget while reusing the same DOM element, spine-widget creates a new canvas object each time. This results in one element containing many canvases at once. 

This solution checks for an existing canvas to use instead of assuming a new one needs to be created each time. Makes Widget much more React friendly. 