### PR TITLE
Supporting ETC1 Alpha channel 

### DIFF
--- a/spine-cocos2dx/src/spine/SkeletonBatch.cpp
+++ b/spine-cocos2dx/src/spine/SkeletonBatch.cpp
@@ -77,7 +77,7 @@ namespace spine {
         _command = _firstCommand;
     }
 
-    void SkeletonBatch::addCommand (cocos2d::Renderer* renderer, float globalZOrder, GLuint textureID, GLProgramState* glProgramState,
+    void SkeletonBatch::addCommand (cocos2d::Renderer* renderer, float globalZOrder, Texture2D* texture, GLProgramState* glProgramState,
                                     BlendFunc blendFunc, const TrianglesCommand::Triangles& triangles, const Mat4& transform, uint32_t transformFlags
                                     ) {
         if (_command->triangles->verts) {
@@ -92,7 +92,7 @@ namespace spine {
         _command->triangles->indexCount = triangles.indexCount;
         _command->triangles->indices = triangles.indices;
         
-        _command->trianglesCommand->init(globalZOrder, textureID, glProgramState, blendFunc, *_command->triangles, transform);
+        _command->trianglesCommand->init(globalZOrder, texture, glProgramState, blendFunc, *_command->triangles, transform);
         renderer->addCommand(_command->trianglesCommand);
         
         if (!_command->next) _command->next = new Command();

--- a/spine-cocos2dx/src/spine/SkeletonBatch.h
+++ b/spine-cocos2dx/src/spine/SkeletonBatch.h
@@ -44,7 +44,7 @@ namespace spine {
         
         void update (float delta);
         
-        void addCommand (cocos2d::Renderer* renderer, float globalOrder, GLuint textureID, cocos2d::GLProgramState* glProgramState,
+        void addCommand (cocos2d::Renderer* renderer, float globalOrder, cocos2d::Texture2D* texture, cocos2d::GLProgramState* glProgramState,
                          cocos2d::BlendFunc blendType, const cocos2d::TrianglesCommand:: Triangles& triangles, const cocos2d::Mat4& mv, uint32_t flags);
         
     protected:

--- a/spine-cocos2dx/src/spine/SkeletonRenderer.cpp
+++ b/spine-cocos2dx/src/spine/SkeletonRenderer.cpp
@@ -252,7 +252,7 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 			blendFunc.dst = GL_ONE_MINUS_SRC_ALPHA;
 		}
 
-		batch->addCommand(renderer, _globalZOrder, attachmentVertices->_texture->getName(), _glProgramState, blendFunc,
+		batch->addCommand(renderer, _globalZOrder, attachmentVertices->_texture, _glProgramState, blendFunc,
 			*attachmentVertices->_triangles, transform, transformFlags);
 	}
 


### PR DESCRIPTION
For supporting ETC1 Alpha channel, we should pass whole "texture" to "trianglesCommand", not only its id, so that we can obtain the alpha texture of the texture in the triangles command.