### PR TITLE
[c] Fix incorrect blending of translate timelines

### DIFF
--- a/spine-c/spine-c/src/spine/Animation.c
+++ b/spine-c/spine-c/src/spine/Animation.c
@@ -343,12 +343,11 @@ void _spTranslateTimeline_apply (const spTimeline* timeline, spSkeleton* skeleto
 		y += (frames[frame + TRANSLATE_Y] - y) * percent;
 	}
 	if (setupPose) {
-		bone->x = bone->data->x + x * alpha;
-		bone->y = bone->data->y + y * alpha;
-	} else {
-		bone->x += (bone->data->x + x - bone->x) * alpha;
-		bone->y += (bone->data->y + y - bone->y) * alpha;
+		bone->x = bone->data->x;
+		bone->y = bone->data->y;
 	}
+	bone->x += x * alpha;
+	bone->y += y * alpha;
 
 	UNUSED(lastTime);
 	UNUSED(firedEvents);


### PR DESCRIPTION
I just updated from a rather old version of spine-c, and animation blending appeared to not be working right.  In my specific case, I have a bone at X=200, and two animations, both of which have a translation of -200, so, obviously, whatever the alpha between the two, the result should be 0.  With an alpha of 0.5, the old code would set bone->x = 200 + -200 * 0.5 (100) on the first pass, and then bone->x += (200 + -200 - 100) * 0.5 -> bone->x += -50 -> bone->x = 50!

The alpha should simply be applied to the translation coming out of the animation, the second pass should not use the results of the first pass to decide how much of the second pass to apply!  In theory, this should be commutative (A * 0.2 + B * 0.8 == B * 0.8 + A * 0.2), and this fix also ensures that.

Just glancing at it, I *think* _spScaleTimeline_apply has a similar issue (if bone->data->scale is 100, and two animations are each scaling to 1/100, it's going to blend to a scale of, maybe 25.75?), but it's more complicated with the mixingOut stuff and I don't have a good example set up for that.