### PR TITLE
[unity] Fixed Unity 5 compiler condition to include Unity 2017 compatibility

### DIFF
--- a/spine-unity/Assets/spine-unity/Editor/SkeletonBaker.cs
+++ b/spine-unity/Assets/spine-unity/Editor/SkeletonBaker.cs
@@ -135,7 +135,7 @@ namespace Spine.Unity.Editor {
 					//generate new dummy clip
 					AnimationClip newClip = new AnimationClip();
 					newClip.name = name;
-					#if !(UNITY_5)
+					#if !(UNITY_5_3_OR_NEWER)
 					AnimationUtility.SetAnimationType(newClip, ModelImporterAnimationType.Generic);
 					#endif
 					AssetDatabase.AddObjectToAsset(newClip, controller);


### PR DESCRIPTION
In Unity 2017 the **UNITY_2017** compiler flag can be used, however this flag is not available in versions prior. **UNITY_5_3_OR_NEWER** resolves this problem for now.