### PR TITLE
[ue4] make the plugin build on UE 4.16.x

### DIFF
--- a/spine-ue4/Plugins/SpinePlugin/Source/SpineEditorPlugin/SpineEditorPlugin.Build.cs
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpineEditorPlugin/SpineEditorPlugin.Build.cs
@@ -4,7 +4,7 @@ namespace UnrealBuildTool.Rules
 {
 	public class SpineEditorPlugin : ModuleRules
 	{
-		public SpineEditorPlugin(TargetInfo Target)
+		public SpineEditorPlugin(ReadOnlyTargetRules Target) : base(Target)
 		{
 			PublicIncludePaths.AddRange(new string[] { "SpineEditorPlugin/Public", "SpinePlugin/Public/spine-c/include" });
             

--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/SpinePlugin.Build.cs
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/SpinePlugin.Build.cs
@@ -4,7 +4,7 @@ namespace UnrealBuildTool.Rules
 {
 	public class SpinePlugin : ModuleRules
 	{
-		public SpinePlugin(TargetInfo Target)
+		public SpinePlugin(ReadOnlyTargetRules Target) : base(Target)
 		{
 			PublicIncludePaths.AddRange(new string[] { "SpinePlugin/Public", "SpinePlugin/Public/spine-c/include" });
             PrivateIncludePaths.AddRange(new string[] { "SpinePlugin/Private", "SpinePlugin/Public/spine-c/include" });

--- a/spine-ue4/Source/SpineUE4.Target.cs
+++ b/spine-ue4/Source/SpineUE4.Target.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 public class SpineUE4Target : TargetRules
 {
-	public SpineUE4Target(TargetInfo Target)
+	public SpineUE4Target(ReadOnlyTargetRules Target) : base(Target)
 	{
 		Type = TargetType.Game;		
 	}

--- a/spine-ue4/Source/SpineUE4/SpineUE4.Build.cs
+++ b/spine-ue4/Source/SpineUE4/SpineUE4.Build.cs
@@ -4,7 +4,7 @@ using UnrealBuildTool;
 
 public class SpineUE4 : ModuleRules
 {
-	public SpineUE4(TargetInfo Target)
+	public SpineUE4(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "ProceduralMeshComponent" });
 

--- a/spine-ue4/Source/SpineUE4Editor.Target.cs
+++ b/spine-ue4/Source/SpineUE4Editor.Target.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 public class SpineUE4EditorTarget : TargetRules
 {
-	public SpineUE4EditorTarget(TargetInfo Target)
+	public SpineUE4EditorTarget(ReadOnlyTargetRules Target) : base(Target)
 	{
 		Type = TargetType.Editor;
 	}


### PR DESCRIPTION
Any project using ue4-spine plugin fails to build on UE 4.16.x unless the build system is modified according to the new changes in the UE4 build system.