### PR TITLE
Removed TextureAtlas operations in StarlingAtlasAttachmentLoader 

### DIFF
--- a/spine-starling/spine-starling/src/spine/starling/StarlingAtlasAttachmentLoader.as
+++ b/spine-starling/spine-starling/src/spine/starling/StarlingAtlasAttachmentLoader.as
@@ -59,11 +59,11 @@ package spine.starling {
 		}
 
 		public function newRegionAttachment(skin : Skin, name : String, path : String) : RegionAttachment {
-			var texture : Texture = getTexture(path);
+			var texture : SubTexture = getTexture(path) as SubTexture;//atlas.getTexture() method always return type of SubTexture
 			if (texture == null)
 				throw new Error("Region not found in Starling atlas: " + path + " (region attachment: " + name + ")");
 			var attachment : RegionAttachment = new RegionAttachment(name);
-			var rotated : Boolean = atlas.getRotation(path);
+			var rotated : Boolean = texture.rotated;//if texture == null you trhow exception, that is why atlas.getRotation() method always return texture.rotated.
 			attachment.rendererObject = new Image(Texture.fromTexture(texture)); // Discard frame.
 			var frame : Rectangle = texture.frame;
 			attachment.regionOffsetX = frame ? -frame.x : 0;
@@ -79,59 +79,58 @@ package spine.starling {
 				tmp = attachment.regionWidth;
 				attachment.regionWidth = attachment.regionHeight;
 				attachment.regionHeight = tmp;
+                attachment["regionU2"] = 0;
+                attachment["regionV2"] = 1;
+                attachment["regionU"] = 1;
+                attachment["regionV"] = 0;
+			}else{
+                attachment["regionU"] = 0;
+                attachment["regionV"] = 0;
+                attachment["regionU2"] = 1;
+                attachment["regionV2"] = 1;
 			}
-			if (!rotated) {
-				attachment["regionU"] = 0;
-				attachment["regionV"] = 0;
-				attachment["regionU2"] = 1;
-				attachment["regionV2"] = 1;
-			} else {
-				attachment["regionU2"] = 0;
-				attachment["regionV2"] = 1;
-				attachment["regionU"] = 1;
-				attachment["regionV"] = 0;
-			}
-			attachment.setUVs(attachment["regionU"], attachment["regionV"], attachment["regionU2"], attachment["regionV2"], atlas.getRotation(path));
+			attachment.setUVs(attachment["regionU"], attachment["regionV"], attachment["regionU2"], attachment["regionV2"], rotated);
 			return attachment;
 		}
 
 		public function newMeshAttachment(skin : Skin, name : String, path : String) : MeshAttachment {
-			var texture : Texture = getTexture(path);
+			var texture : SubTexture = getTexture(path) as SubTexture;
 			if (texture == null)
 				throw new Error("Region not found in Starling atlas: " + path + " (mesh attachment: " + name + ")");
-			var rotated : Boolean = atlas.getRotation(path);
+			var rotated : Boolean =texture.rotated;
 			var attachment : MeshAttachment = new MeshAttachment(name);
 			attachment.regionRotate = rotated;
 			attachment.rendererObject = new Image(Texture.fromTexture(texture)); // Discard frame.
-			var subTexture : SubTexture = texture as SubTexture;
-			if (subTexture) {
-				var root : Texture = subTexture.root;
+//			var subTexture : SubTexture = texture as SubTexture;
+//			if (subTexture) {//subTexture can't be null (line 99)
+				var root : Texture = texture.root;
 				var rectRegion : Rectangle = atlas.getRegion(path);
 				if (!rotated) {
 					attachment.regionU = rectRegion.x / root.width;
 					attachment.regionV = rectRegion.y / root.height;
-					attachment.regionU2 = (rectRegion.x + subTexture.width) / root.width;
-					attachment.regionV2 = (rectRegion.y + subTexture.height) / root.height;
+					attachment.regionU2 = (rectRegion.x + texture.width) / root.width;
+					attachment.regionV2 = (rectRegion.y + texture.height) / root.height;
 				} else {
 					attachment.regionU2 = rectRegion.x / root.width;
 					attachment.regionV2 = rectRegion.y / root.height;
-					attachment.regionU = (rectRegion.x + subTexture.height) / root.width;
-					attachment.regionV = (rectRegion.y + subTexture.width) / root.height;
+					attachment.regionU = (rectRegion.x + texture.height) / root.width;
+					attachment.regionV = (rectRegion.y + texture.width) / root.height;
 				}
 				attachment.rendererObject = new Image(root);
-			} else {
-				if (!rotated) {
-					attachment.regionU = 0;
-					attachment.regionV = 1;
-					attachment.regionU2 = 1;
-					attachment.regionV2 = 0;
-				} else {
-					attachment.regionU2 = 0;
-					attachment.regionV2 = 1;
-					attachment.regionU = 1;
-					attachment.regionV = 0;
-				}
-			}
+//			} else {
+				//Code never reached to here. if subTextre==null you throw exception.
+//				if (!rotated) {
+//					attachment.regionU = 0;
+//					attachment.regionV = 1;
+//					attachment.regionU2 = 1;
+//					attachment.regionV2 = 0;
+//				} else {
+//					attachment.regionU2 = 0;
+//					attachment.regionV2 = 1;
+//					attachment.regionU = 1;
+//					attachment.regionV = 0;
+//				}
+//			}
 			var frame : Rectangle = texture.frame;
 			attachment.regionOffsetX = frame ? -frame.x : 0;
 			attachment.regionOffsetY = frame ? -frame.y : 0;


### PR DESCRIPTION
My pull request ( https://github.com/EsotericSoftware/spine-runtimes/pull/929) merged partialy, but it didn't help me. Please merge this pull request if it possible.

We have textures dictionary in our project,  and we get the texture from dictionary, that is why in the PR I asked you add the getTexture() method. We  not necessary to know textureAtlas of the texture. so we need that the newMeshAttachment and newRegionAttachment methods did't operate with TextureAtlas. 
Below is presented how i whant to use StarlingAtlasAttachmentLoader 
`
public class CustomStarlingAtlasAttachmentLoader extends StarlingAtlasAttachmentLoader {

    public function CustomStarlingAtlasAttachmentLoader() {
        super(null);// we don't use atlas
    }

    override protected function getTexture(path:String):Texture {
        return GPURepository.getTexture(path);
    }

}
`

`
public class Test extends Sprite {

	public function Test () {
        var attachmentLoader:AttachmentLoader = new CustomStarlingAtlasAttachmentLoader ();
        var json:SkeletonJson = new SkeletonJson(attachmentLoader);
        var skeletonData:SkeletonData = json.readSkeletonData(jsonData);
         .............................
         }
   }
`