### PR TITLE
Adds a new API spTrackEntry_setDisposeCallback for notifying TrackEntry will be disposed.

### DIFF
--- a/spine-c/spine-c/include/spine/AnimationState.h
+++ b/spine-c/spine-c/include/spine/AnimationState.h
@@ -150,6 +150,9 @@ SP_API float spTrackEntry_getAnimationTime (spTrackEntry* entry);
 /** Use this to dispose static memory before your app exits to appease your memory leak detector*/
 SP_API void spAnimationState_disposeStatics ();
 
+typedef void (*TrackEntryDisposeCallback)(spTrackEntry*);
+SP_API void spTrackEntry_setDisposeCallback(TrackEntryDisposeCallback cb);
+
 #ifdef SPINE_SHORT_NAMES
 typedef spEventType EventType;
 #define ANIMATION_START SP_ANIMATION_START

--- a/spine-c/spine-c/src/spine/AnimationState.c
+++ b/spine-c/spine-c/src/spine/AnimationState.c
@@ -40,6 +40,8 @@
 _SP_ARRAY_IMPLEMENT_TYPE(spTrackEntryArray, spTrackEntry*)
 
 static spAnimation* SP_EMPTY_ANIMATION = 0;
+static TrackEntryDisposeCallback _trackEntryDisposeCallback = 0;
+
 void spAnimationState_disposeStatics () {
 	if (SP_EMPTY_ANIMATION) spAnimation_dispose(SP_EMPTY_ANIMATION);
 	SP_EMPTY_ANIMATION = 0;
@@ -181,6 +183,9 @@ void _spEventQueue_drain (_spEventQueue* self) {
 }
 
 void _spAnimationState_disposeTrackEntry (spTrackEntry* entry) {
+	if (_trackEntryDisposeCallback)
+		_trackEntryDisposeCallback(entry);
+
 	spIntArray_dispose(entry->timelineData);
 	spTrackEntryArray_dispose(entry->timelineDipMix);
 	FREE(entry->timelinesRotation);
@@ -199,6 +204,11 @@ void _spAnimationState_disposeTrackEntries (spAnimationState* state, spTrackEntr
 		_spAnimationState_disposeTrackEntry(entry);
 		entry = next;
 	}
+}
+
+void spTrackEntry_setDisposeCallback (TrackEntryDisposeCallback cb)
+{
+	_trackEntryDisposeCallback = cb;
 }
 
 spAnimationState* spAnimationState_create (spAnimationStateData* data) {


### PR DESCRIPTION
This method could be used for releasing script binding object.
Since we need to use native objects to control the life cycle of JS objects, and TrackEntry is exposed to script, spine runtime needs to notify that TrackEntry is disposed,
in that case, script object will be safe to be released in the callback of `spTrackEntry_setDisposeCallback`.