### PR TITLE
Fixed exception in SkeletonGhost.OnDestroy()

### DIFF
--- a/spine-csharp/src/Animation.cs
+++ b/spine-csharp/src/Animation.cs
@@ -436,11 +436,11 @@ namespace Spine {
 				}
 				// Mixing out uses sign of setup or current pose, else use sign of key.
 				if (direction == MixDirection.Out) {
-					x = Math.Abs(x) * Math.Sign(bx);
-					y = Math.Abs(y) * Math.Sign(by);
+					x = (x >= 0 ? x : -x) * (bx >= 0 ? 1 : -1);
+					y = (y >= 0 ? y : -y) * (by >= 0 ? 1 : -1);
 				} else {
-					bx = Math.Abs(bx) * Math.Sign(x);
-					by = Math.Abs(by) * Math.Sign(y);
+					bx = (bx >= 0 ? bx : -bx) * (x >= 0 ? 1 : -1);
+					by = (by >= 0 ? by : -by) * (y >= 0 ? 1 : -1);
 				}
 				bone.scaleX = bx + (x - bx) * alpha;
 				bone.scaleY = by + (y - by) * alpha;

--- a/spine-unity/Assets/spine-unity/Modules/Ghost/SkeletonGhost.cs
+++ b/spine-unity/Assets/spine-unity/Modules/Ghost/SkeletonGhost.cs
@@ -155,8 +155,10 @@ namespace Spine.Unity.Modules {
 		}
 
 		void OnDestroy () {
-			for (int i = 0; i < maximumGhosts; i++)
-				if (pool[i] != null) pool[i].Cleanup();
+			if (pool != null) {
+				for (int i = 0; i < maximumGhosts; i++)
+					if (pool[i] != null) pool[i].Cleanup();
+			}
 
 			foreach (var mat in materialTable.Values)
 				Destroy(mat);


### PR DESCRIPTION
SkeletonGhost.OnDestroy() was throwing an exception if it was initially disabled, and the GO is then destroyed.