### PR TITLE
Fixed exception in SkeletonGhost.OnDestroy() if it was never enabled

### DIFF
--- a/spine-unity/Assets/spine-unity/Modules/Ghost/SkeletonGhost.cs
+++ b/spine-unity/Assets/spine-unity/Modules/Ghost/SkeletonGhost.cs
@@ -155,8 +155,10 @@ namespace Spine.Unity.Modules {
 		}
 
 		void OnDestroy () {
-			for (int i = 0; i < maximumGhosts; i++)
-				if (pool[i] != null) pool[i].Cleanup();
+			if (pool != null) {
+				for (int i = 0; i < maximumGhosts; i++)
+					if (pool[i] != null) pool[i].Cleanup();
+			}
 
 			foreach (var mat in materialTable.Values)
 				Destroy(mat);


### PR DESCRIPTION
SkeletonGhost.OnDestroy() was throwing an exception if it was initially disabled, and the GO is then destroyed.