### PR TITLE
Fixed SkeletonRendererInspector UI

### DIFF
--- a/spine-unity/Assets/spine-unity/Editor/SkeletonRendererInspector.cs
+++ b/spine-unity/Assets/spine-unity/Editor/SkeletonRendererInspector.cs
@@ -139,7 +139,7 @@ namespace Spine.Unity.Editor {
 			var reloadButtonStyle = EditorStyles.miniButtonRight;
 
 			if (multi) {
-				using (new EditorGUILayout.HorizontalScope(EditorStyles.helpBox)) {
+				using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox)) {
 					SpineInspectorUtility.PropertyFieldFitLabel(skeletonDataAsset, SkeletonDataAssetLabel);
 					if (GUILayout.Button(ReloadButtonLabel, reloadButtonStyle, reloadWidth)) {
 						foreach (var c in targets) {
@@ -187,7 +187,7 @@ namespace Spine.Unity.Editor {
 					component.LateUpdate();
 				}
 
-				using (new EditorGUILayout.HorizontalScope(EditorStyles.helpBox)) {
+				using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox)) {
 					SpineInspectorUtility.PropertyFieldFitLabel(skeletonDataAsset, SkeletonDataAssetLabel);
 					if (component.valid) {
 						if (GUILayout.Button(ReloadButtonLabel, reloadButtonStyle, reloadWidth)) {


### PR DESCRIPTION
I'm pretty sure this was not the expected look:
![default](https://user-images.githubusercontent.com/928550/29948058-1f6299e2-8ead-11e7-9f72-5e1e648d0b0c.png)
So, fixed that.