### PR TITLE
spine-ts: fix dark in both pma and non-pma

### DIFF
--- a/spine-ts/webgl/src/Shader.ts
+++ b/spine-ts/webgl/src/Shader.ts
@@ -247,9 +247,8 @@ module spine.webgl {
 
 				void main () {
 					vec4 texColor = texture2D(u_texture, v_texCoords);
-					float alpha = texColor.a * v_light.a;
-					gl_FragColor.a = alpha;
-					gl_FragColor.rgb = (1.0 - texColor.rgb) * v_dark.rgb * alpha + texColor.rgb * v_light.rgb;
+					gl_FragColor.a = texColor.a * v_light.a;
+					gl_FragColor.rgb = ((texColor.a - 1.0) * v_dark.a + 1.0 - texColor.rgb) * v_dark.rgb + texColor.rgb * v_light.rgb;
 				}
 			`;
 

--- a/spine-ts/webgl/src/SkeletonRenderer.ts
+++ b/spine-ts/webgl/src/SkeletonRenderer.ts
@@ -122,8 +122,18 @@ module spine.webgl {
 						finalColor.b *= finalColor.a;
 					}
 					let darkColor = this.tempColor2;
-					if (slot.darkColor == null) darkColor.set(0, 0, 0, 1);
-					else darkColor.setFromColor(slot.darkColor);
+					if (slot.darkColor == null)
+						darkColor.set(0, 0, 0, 1.0);
+					else {
+						if (premultipliedAlpha) {
+							darkColor.r = slot.darkColor.r * finalColor.a;
+							darkColor.g = slot.darkColor.g * finalColor.a;
+							darkColor.b = slot.darkColor.b * finalColor.a;
+						} else {
+							darkColor.setFromColor(slot.darkColor);
+						}
+						darkColor.a = premultipliedAlpha ? 1.0 : 0.0;
+					}
 
 					let slotBlendMode = slot.data.blendMode;
 					if (slotBlendMode != blendMode) {


### PR DESCRIPTION
#992 

According to my calculations, both modes were wrong. I do not know about other runtimes.

To make shader work in both modes, I've added v_dark.a = 1.0 in PMA, 0.0 in non-PMA.

### PMA mode

- FIX 1.0 switched to texColor.a , because that's what math says
- IMPROVEMENT premultiply dark.rgb to alpha

### NON-PMA

- FIX alpha should not affect rgb at all