### PR TITLE
Fixes heap corruption with more than 1000 mesh vertices (cocos2dx) 

### DIFF
--- a/spine-cocos2dx/src/spine/SkeletonRenderer.cpp
+++ b/spine-cocos2dx/src/spine/SkeletonRenderer.cpp
@@ -61,8 +61,6 @@ SkeletonRenderer* SkeletonRenderer::createWithFile (const std::string& skeletonD
 }
 
 void SkeletonRenderer::initialize () {
-	_worldVertices = new float[1000]; // Max number of vertices per mesh.
-	
 	_clipper = spSkeletonClipping_create();
 
 	_blendFunc = BlendFunc::ALPHA_PREMULTIPLIED;
@@ -70,13 +68,13 @@ void SkeletonRenderer::initialize () {
 
 	setupGLProgramState(false);
 }
-	
+
 void SkeletonRenderer::setupGLProgramState (bool twoColorTintEnabled) {
 	if (twoColorTintEnabled) {
 		setGLProgramState(SkeletonTwoColorBatch::getInstance()->getTwoColorTintProgramState());
 		return;
 	}
-	
+
 	Texture2D *texture = nullptr;
 	for (int i = 0, n = _skeleton->slotsCount; i < n; i++) {
 		spSlot* slot = _skeleton->drawOrder[i];
@@ -95,7 +93,7 @@ void SkeletonRenderer::setupGLProgramState (bool twoColorTintEnabled) {
 			default:
 				continue;
 		}
-		
+
 		if (texture != nullptr) {
 			break;
 		}
@@ -105,25 +103,71 @@ void SkeletonRenderer::setupGLProgramState (bool twoColorTintEnabled) {
 
 void SkeletonRenderer::setSkeletonData (spSkeletonData *skeletonData, bool ownsSkeletonData) {
 	_skeleton = spSkeleton_create(skeletonData);
+	size_t maxCount = 0;
+
+	for (int i = 0, n = _skeleton->slotsCount; i < n; ++i) {
+	  spSlot* slot = _skeleton->drawOrder[i];
+
+	  if (!slot || !slot->attachment) {
+	    continue;
+	  }
+
+	  if (slot->attachment->type == SP_ATTACHMENT_MESH) {
+	    spMeshAttachment* meshAtt =
+				reinterpret_cast<spMeshAttachment*>(slot->attachment)
+			;
+
+			if (meshAtt->super.worldVerticesLength > maxCount) {
+				maxCount = meshAtt->super.worldVerticesLength;
+			}
+	  }
+	}
+
+	size_t newLength = _worldVerticesLength;
+
+	if (newLength == 0) {
+		newLength = SkeletonRenderer::INITIAL_WORLD_VERTICES_LENGTH;
+	}
+
+	if (maxCount > newLength) {
+		newLength = std::max(newLength * 2, maxCount);
+	}
+
+	if (newLength > _worldVerticesLength) {
+		float* oldVertices = _worldVertices;
+		_worldVertices = new float[newLength];
+
+		if (oldVertices && _worldVerticesLength > 0) {
+			memcpy(_worldVertices, oldVertices, sizeof(float) * _worldVerticesLength);
+			delete[] oldVertices;
+		}
+
+		_worldVerticesLength = newLength;
+	}
+
 	_ownsSkeletonData = ownsSkeletonData;
 }
 
 SkeletonRenderer::SkeletonRenderer ()
-	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false), _timeScale(1), _effect(nullptr) {
+	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false),
+	_timeScale(1), _effect(nullptr), _worldVertices(0), _worldVerticesLength(0) {
 }
 
 SkeletonRenderer::SkeletonRenderer (spSkeletonData *skeletonData, bool ownsSkeletonData)
-	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false), _timeScale(1), _effect(nullptr) {
+	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false),
+	_timeScale(1), _effect(nullptr), _worldVertices(0), _worldVerticesLength(0) {
 	initWithData(skeletonData, ownsSkeletonData);
 }
 
 SkeletonRenderer::SkeletonRenderer (const std::string& skeletonDataFile, spAtlas* atlas, float scale)
-	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false), _timeScale(1), _effect(nullptr) {
+	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false),
+	_timeScale(1), _effect(nullptr), _worldVertices(0), _worldVerticesLength(0) {
 	initWithJsonFile(skeletonDataFile, atlas, scale);
 }
 
 SkeletonRenderer::SkeletonRenderer (const std::string& skeletonDataFile, const std::string& atlasFile, float scale)
-	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false), _timeScale(1), _effect(nullptr) {
+	: _atlas(nullptr), _attachmentLoader(nullptr), _debugSlots(false), _debugBones(false), _debugMeshes(false),
+	_timeScale(1), _effect(nullptr), _worldVertices(0), _worldVerticesLength(0) {
 	initWithJsonFile(skeletonDataFile, atlasFile, scale);
 }
 
@@ -132,7 +176,7 @@ SkeletonRenderer::~SkeletonRenderer () {
 	spSkeleton_dispose(_skeleton);
 	if (_atlas) spAtlas_dispose(_atlas);
 	if (_attachmentLoader) spAttachmentLoader_dispose(_attachmentLoader);
-	delete [] _worldVertices;
+	if (_worldVertices) delete [] _worldVertices;
 	spSkeletonClipping_dispose(_clipper);
 }
 
@@ -173,36 +217,36 @@ void SkeletonRenderer::initWithJsonFile (const std::string& skeletonDataFile, co
 
 	initialize();
 }
-    
+
 void SkeletonRenderer::initWithBinaryFile (const std::string& skeletonDataFile, spAtlas* atlas, float scale) {
     _atlas = atlas;
     _attachmentLoader = SUPER(Cocos2dAttachmentLoader_create(_atlas));
-    
+
     spSkeletonBinary* binary = spSkeletonBinary_createWithLoader(_attachmentLoader);
     binary->scale = scale;
     spSkeletonData* skeletonData = spSkeletonBinary_readSkeletonDataFile(binary, skeletonDataFile.c_str());
     CCASSERT(skeletonData, binary->error ? binary->error : "Error reading skeleton data file.");
     spSkeletonBinary_dispose(binary);
-    
+
     setSkeletonData(skeletonData, true);
-    
+
     initialize();
 }
 
 void SkeletonRenderer::initWithBinaryFile (const std::string& skeletonDataFile, const std::string& atlasFile, float scale) {
     _atlas = spAtlas_createFromFile(atlasFile.c_str(), 0);
     CCASSERT(_atlas, "Error reading atlas file.");
-    
+
     _attachmentLoader = SUPER(Cocos2dAttachmentLoader_create(_atlas));
-    
+
     spSkeletonBinary* binary = spSkeletonBinary_createWithLoader(_attachmentLoader);
     binary->scale = scale;
     spSkeletonData* skeletonData = spSkeletonBinary_readSkeletonDataFile(binary, skeletonDataFile.c_str());
     CCASSERT(skeletonData, binary->error ? binary->error : "Error reading skeleton data file.");
     spSkeletonBinary_dispose(binary);
-    
+
     setSkeletonData(skeletonData, true);
-    
+
     initialize();
 }
 
@@ -216,7 +260,7 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 	SkeletonBatch* batch = SkeletonBatch::getInstance();
 	SkeletonTwoColorBatch* twoColorBatch = SkeletonTwoColorBatch::getInstance();
 	bool isTwoColorTint = this->isTwoColorTint();
-	
+
 	if (_effect) _effect->begin(_effect, _skeleton);
 
 	Color4F nodeColor;
@@ -224,7 +268,7 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 	nodeColor.g = getDisplayedColor().g / (float)255;
 	nodeColor.b = getDisplayedColor().b / (float)255;
 	nodeColor.a = getDisplayedOpacity() / (float)255;
-	
+
     Color4F color;
 	Color4F darkColor;
 	float darkPremultipliedAlpha = _premultipliedAlpha ? 255 : 0;
@@ -236,15 +280,15 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 			spSkeletonClipping_clipEnd(_clipper, slot);
 			continue;
 		}
-		
+
 		cocos2d::TrianglesCommand::Triangles triangles;
 		TwoColorTriangles trianglesTwoColor;
-		
+
 		switch (slot->attachment->type) {
 		case SP_ATTACHMENT_REGION: {
 			spRegionAttachment* attachment = (spRegionAttachment*)slot->attachment;
 			attachmentVertices = getAttachmentVertices(attachment);
-			
+
 			if (!isTwoColorTint) {
 				triangles.indices = attachmentVertices->_triangles->indices;
 				triangles.indexCount = attachmentVertices->_triangles->indexCount;
@@ -262,18 +306,18 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 				}
 				spRegionAttachment_computeWorldVertices(attachment, slot->bone, (float*)trianglesTwoColor.verts, 0, 7);
 			}
-			
+
             color.r = attachment->color.r;
 			color.g = attachment->color.g;
 			color.b = attachment->color.b;
 			color.a = attachment->color.a;
-			
+
 			break;
 		}
 		case SP_ATTACHMENT_MESH: {
 			spMeshAttachment* attachment = (spMeshAttachment*)slot->attachment;
 			attachmentVertices = getAttachmentVertices(attachment);
-			
+
 			if (!isTwoColorTint) {
 				triangles.indices = attachmentVertices->_triangles->indices;
 				triangles.indexCount = attachmentVertices->_triangles->indexCount;
@@ -291,12 +335,12 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 				}
 				spVertexAttachment_computeWorldVertices(SUPER(attachment), slot, 0, trianglesTwoColor.vertCount * sizeof(V3F_C4B_C4B_T2F) / 4, (float*)trianglesTwoColor.verts, 0, 7);
 			}
-			
+
 			color.r = attachment->color.r;
 			color.g = attachment->color.g;
 			color.b = attachment->color.b;
 			color.a = attachment->color.a;
-			
+
 			break;
 		}
 		case SP_ATTACHMENT_CLIPPING: {
@@ -308,7 +352,7 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 			spSkeletonClipping_clipEnd(_clipper, slot);
 			continue;
 		}
-		
+
 		if (slot->darkColor) {
 			darkColor.r = slot->darkColor->r * 255;
 			darkColor.g = slot->darkColor->g * 255;
@@ -319,7 +363,7 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 			darkColor.b = 0;
 		}
 		darkColor.a = darkPremultipliedAlpha;
-		
+
 		color.a *= nodeColor.a * _skeleton->color.a * slot->color.a * 255;
 		// skip rendering if the color of this attachment is 0
 		if (color.a == 0){
@@ -330,7 +374,7 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 		color.r *= nodeColor.r * _skeleton->color.r * slot->color.r * multiplier;
 		color.g *= nodeColor.g * _skeleton->color.g * slot->color.g * multiplier;
 		color.b *= nodeColor.b * _skeleton->color.b * slot->color.b * multiplier;
-		
+
 		BlendFunc blendFunc;
 		switch (slot->data->blendMode) {
 			case SP_BLEND_MODE_ADDITIVE:
@@ -349,25 +393,25 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 				blendFunc.src = _premultipliedAlpha ? GL_ONE : GL_SRC_ALPHA;
 				blendFunc.dst = GL_ONE_MINUS_SRC_ALPHA;
 		}
-		
+
 		if (!isTwoColorTint) {
 			if (spSkeletonClipping_isClipping(_clipper)) {
 				spSkeletonClipping_clipTriangles(_clipper, (float*)&triangles.verts[0].vertices, triangles.vertCount * sizeof(cocos2d::V3F_C4B_T2F) / 4, triangles.indices, triangles.indexCount, (float*)&triangles.verts[0].texCoords, 6);
 				batch->deallocateVertices(triangles.vertCount);
-				
+
 				if (_clipper->clippedTriangles->size == 0){
 					spSkeletonClipping_clipEnd(_clipper, slot);
 					continue;
 				}
-				
+
 				triangles.vertCount = _clipper->clippedVertices->size >> 1;
 				triangles.verts = batch->allocateVertices(triangles.vertCount);
 				triangles.indexCount = _clipper->clippedTriangles->size;
 				triangles.indices = batch->allocateIndices(triangles.indexCount);
 				memcpy(triangles.indices, _clipper->clippedTriangles->items, sizeof(unsigned short) * _clipper->clippedTriangles->size);
-				
+
 				cocos2d::TrianglesCommand* batchedTriangles = batch->addCommand(renderer, _globalZOrder, attachmentVertices->_texture, _glProgramState, blendFunc, triangles, transform, transformFlags);
-				
+
 				float* verts = _clipper->clippedVertices->items;
 				float* uvs = _clipper->clippedUVs->items;
 				if (_effect) {
@@ -407,7 +451,7 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 				}
 			} else {
 				cocos2d::TrianglesCommand* batchedTriangles = batch->addCommand(renderer, _globalZOrder, attachmentVertices->_texture, _glProgramState, blendFunc, triangles, transform, transformFlags);
-				
+
 				if (_effect) {
 					spColor light;
 					spColor dark;
@@ -440,23 +484,23 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 			if (spSkeletonClipping_isClipping(_clipper)) {
 				spSkeletonClipping_clipTriangles(_clipper, (float*)&trianglesTwoColor.verts[0].position, trianglesTwoColor.vertCount * sizeof(V3F_C4B_C4B_T2F) / 4, trianglesTwoColor.indices, trianglesTwoColor.indexCount, (float*)&trianglesTwoColor.verts[0].texCoords, 7);
 				twoColorBatch->deallocateVertices(trianglesTwoColor.vertCount);
-				
+
 				if (_clipper->clippedTriangles->size == 0){
 					spSkeletonClipping_clipEnd(_clipper, slot);
 					continue;
 				}
-				
+
 				trianglesTwoColor.vertCount = _clipper->clippedVertices->size >> 1;
 				trianglesTwoColor.verts = twoColorBatch->allocateVertices(trianglesTwoColor.vertCount);
 				trianglesTwoColor.indexCount = _clipper->clippedTriangles->size;
 				trianglesTwoColor.indices = twoColorBatch->allocateIndices(trianglesTwoColor.indexCount);
 				memcpy(trianglesTwoColor.indices, _clipper->clippedTriangles->items, sizeof(unsigned short) * _clipper->clippedTriangles->size);
-				
+
 				TwoColorTrianglesCommand* batchedTriangles = lastTwoColorTrianglesCommand = twoColorBatch->addCommand(renderer, _globalZOrder, attachmentVertices->_texture->getName(), _glProgramState, blendFunc, trianglesTwoColor, transform, transformFlags);
-				
+
 				float* verts = _clipper->clippedVertices->items;
 				float* uvs = _clipper->clippedUVs->items;
-				
+
 				if (_effect) {
 					spColor light;
 					spColor dark;
@@ -505,7 +549,7 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 				}
 			} else {
 				TwoColorTrianglesCommand* batchedTriangles = lastTwoColorTrianglesCommand = twoColorBatch->addCommand(renderer, _globalZOrder, attachmentVertices->_texture->getName(), _glProgramState, blendFunc, trianglesTwoColor, transform, transformFlags);
-				
+
 				if (_effect) {
 					spColor light;
 					spColor dark;
@@ -517,7 +561,7 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 					dark.g = darkColor.g / 255.0f;
 					dark.b = darkColor.b / 255.0f;
 					dark.a = darkColor.a / 255.0f;
-					
+
 					for (int v = 0, vn = batchedTriangles->getTriangles().vertCount; v < vn; ++v) {
 						V3F_C4B_C4B_T2F* vertex = batchedTriangles->getTriangles().verts + v;
 						spColor lightCopy = light;
@@ -550,10 +594,10 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 		spSkeletonClipping_clipEnd(_clipper, slot);
 	}
 	spSkeletonClipping_clipEnd2(_clipper);
-	
+
 	if (lastTwoColorTrianglesCommand) {
 		Node* parent = this->getParent();
-		
+
 		// We need to decide if we can postpone flushing the current
 		// batch. We can postpone if the next sibling node is a
 		// two color tinted skeleton with the same global-z.
@@ -587,7 +631,7 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 			}
 		}
 	}
-	
+
 	if (_effect) _effect->end(_effect);
 
 	if (_debugSlots || _debugBones || _debugMeshes) {
@@ -600,9 +644,9 @@ void SkeletonRenderer::drawDebug (Renderer* renderer, const Mat4 &transform, uin
     Director* director = Director::getInstance();
     director->pushMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
     director->loadMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW, transform);
-    
+
     DrawNode* drawNode = DrawNode::create();
-    
+
     if (_debugSlots) {
         // Slots.
         // DrawPrimitives::setDrawColor4B(0, 0, 255, 255);
@@ -638,14 +682,14 @@ void SkeletonRenderer::drawDebug (Renderer* renderer, const Mat4 &transform, uin
             if (i == 0) color = Color4F::GREEN;
         }
     }
-	
+
 	if (_debugMeshes) {
 		// Meshes.
 		glLineWidth(1);
 		for (int i = 0, n = _skeleton->slotsCount; i < n; ++i) {
 			spSlot* slot = _skeleton->drawOrder[i];
 			if (!slot->attachment || slot->attachment->type != SP_ATTACHMENT_MESH) continue;
-			spMeshAttachment* attachment = (spMeshAttachment*)slot->attachment;			
+			spMeshAttachment* attachment = (spMeshAttachment*)slot->attachment;
 			spVertexAttachment_computeWorldVertices(SUPER(attachment), slot, 0, attachment->super.worldVerticesLength, _worldVertices, 0, 2);
 			for (int ii = 0; ii < attachment->trianglesCount;) {
 				Vec2 v1(_worldVertices + (attachment->triangles[ii++] * 2));
@@ -656,9 +700,9 @@ void SkeletonRenderer::drawDebug (Renderer* renderer, const Mat4 &transform, uin
 				drawNode->drawLine(v3, v1, Color4F::YELLOW);
 			}
 		}
-		
+
 	}
-    
+
     drawNode->draw(renderer, transform, transformFlags);
     director->popMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_MODELVIEW);
 }
@@ -697,7 +741,7 @@ Rect SkeletonRenderer::getBoundingBox () const {
 		}
 	}
 	Vec2 position = getPosition();
-    if (minX == FLT_MAX) minX = minY = maxX = maxY = 0;    
+    if (minX == FLT_MAX) minX = minY = maxX = maxY = 0;
 	return Rect(position.x + minX, position.y + minY, maxX - minX, maxY - minY);
 }
 
@@ -741,7 +785,7 @@ bool SkeletonRenderer::setAttachment (const std::string& slotName, const std::st
 bool SkeletonRenderer::setAttachment (const std::string& slotName, const char* attachmentName) {
 	return spSkeleton_setAttachment(_skeleton, slotName.c_str(), attachmentName) ? true : false;
 }
-	
+
 void SkeletonRenderer::setTwoColorTint(bool enabled) {
 	setupGLProgramState(enabled);
 }
@@ -749,7 +793,7 @@ void SkeletonRenderer::setTwoColorTint(bool enabled) {
 bool SkeletonRenderer::isTwoColorTint() {
 	return getGLProgramState() == SkeletonTwoColorBatch::getInstance()->getTwoColorTintProgramState();
 }
-	
+
 void SkeletonRenderer::setVertexEffect(spVertexEffect *effect) {
 	this->_effect = effect;
 }
@@ -778,7 +822,7 @@ void SkeletonRenderer::setDebugBonesEnabled (bool enabled) {
 bool SkeletonRenderer::getDebugBonesEnabled () const {
 	return _debugBones;
 }
-	
+
 void SkeletonRenderer::setDebugMeshesEnabled (bool enabled) {
 	_debugMeshes = enabled;
 }

--- a/spine-cocos2dx/src/spine/SkeletonRenderer.h
+++ b/spine-cocos2dx/src/spine/SkeletonRenderer.h
@@ -41,6 +41,9 @@ class AttachmentVertices;
 /* Draws a skeleton. */
 class SkeletonRenderer: public cocos2d::Node, public cocos2d::BlendProtocol {
 public:
+	static const size_t INITIAL_WORLD_VERTICES_LENGTH = 1000;
+
+public:
 	CREATE_FUNC(SkeletonRenderer);
 	static SkeletonRenderer* createWithData (spSkeletonData* skeletonData, bool ownsSkeletonData = false);
 	static SkeletonRenderer* createWithFile (const std::string& skeletonDataFile, spAtlas* atlas, float scale = 1);
@@ -64,7 +67,7 @@ public:
 
 	void setDebugBonesEnabled(bool enabled);
 	bool getDebugBonesEnabled() const;
-	
+
 	void setDebugMeshesEnabled(bool enabled);
 	bool getDebugMeshesEnabled() const;
 
@@ -79,14 +82,14 @@ public:
 	spBone* findBone (const std::string& boneName) const;
 	/* Returns 0 if the slot was not found. */
 	spSlot* findSlot (const std::string& slotName) const;
-	
+
 	/* Sets the skin used to look up attachments not found in the SkeletonData defaultSkin. Attachments from the new skin are
 	 * attached if the corresponding attachment from the old skin was attached. Returns false if the skin was not found.
 	 * @param skin May be empty string ("") for no skin.*/
 	bool setSkin (const std::string& skinName);
 	/** @param skin May be 0 for no skin.*/
 	bool setSkin (const char* skinName);
-	
+
 	/* Returns 0 if the slot or attachment was not found. */
 	spAttachment* getAttachment (const std::string& slotName, const std::string& attachmentName) const;
 	/* Returns false if the slot or attachment was not found.
@@ -94,12 +97,12 @@ public:
 	bool setAttachment (const std::string& slotName, const std::string& attachmentName);
 	/* @param attachmentName May be 0 for no attachment. */
 	bool setAttachment (const std::string& slotName, const char* attachmentName);
-	
+
 	/* Enables/disables two color tinting for this instance. May break batching */
 	void setTwoColorTint(bool enabled);
 	/* Whether two color tinting is enabled */
 	bool isTwoColorTint();
-	
+
 	/* Sets the vertex effect to be used, set to 0 to disable vertex effects */
 	void setVertexEffect(spVertexEffect* effect);
 
@@ -124,7 +127,7 @@ CC_CONSTRUCTOR_ACCESS:
 	void initWithBinaryFile (const std::string& skeletonDataFile, const std::string& atlasFile, float scale = 1);
 
 	virtual void initialize ();
-	
+
 protected:
 	void setSkeletonData (spSkeletonData* skeletonData, bool ownsSkeletonData);
 	virtual AttachmentVertices* getAttachmentVertices (spRegionAttachment* attachment) const;
@@ -137,6 +140,7 @@ protected:
 	cocos2d::CustomCommand _debugCommand;
 	cocos2d::BlendFunc _blendFunc;
 	float* _worldVertices;
+	size_t _worldVerticesLength;
 	bool _premultipliedAlpha;
 	spSkeleton* _skeleton;
 	float _timeScale;


### PR DESCRIPTION
We are using the cocos2dx runtime for one of our games and we have been experiencing odd crashes and bugs that looked like the result of heap corruption. Since they seemed to happen after a particular animation was played I started investigating the Spine runtime and eventually found that  the world vertices array was hardcoded to 1000 vertices and there was no check in place to at least crash the application with a clear error message when the code addressed more than 1000 vertices, not even an assert. We had 1002 vertices and this caused really nasty bugs all over the place which took a lot of time to track down.

I've made an attempt to fix the issue by pre-determining the array size when the skeleton data is assigned to the SkeletonRenderer instance. The array is still reused and resized at runtime if needed by doubling its size to minimize the chance of frequent resizing. I don't know if this is the right approach with the issue because I do not have much experience with the internal workings of the Spine runtime, but we have been using this solution for a while and it seems to work just fine so I'm submitting it.