### PR TITLE
[cocos2dx] allow load custom atlas texture in _spAtlasPage_createTexture

### DIFF
--- a/spine-cocos2dx/src/spine/spine-cocos2dx.cpp
+++ b/spine-cocos2dx/src/spine/spine-cocos2dx.cpp
@@ -31,6 +31,13 @@
 #include <spine/spine-cocos2dx.h>
 #include <spine/extension.h>
 
+namespace spine {
+	static CustomTextureLoader _customTextureLoader = nullptr;
+	void spAtlasPage_setCustomTextureLoader (CustomTextureLoader texLoader) {
+		_customTextureLoader = texLoader;
+	}
+}
+
 USING_NS_CC;
 
 GLuint wrap (spAtlasWrap wrap) {
@@ -60,7 +67,13 @@ GLuint filter (spAtlasFilter filter) {
 }
 
 void _spAtlasPage_createTexture (spAtlasPage* self, const char* path) {
-	Texture2D* texture = Director::getInstance()->getTextureCache()->addImage(path);
+	Texture2D* texture = nullptr;
+	if (spine::_customTextureLoader) {
+		texture = spine::_customTextureLoader(path);
+	}
+	if (!texture) {
+		texture = Director::getInstance()->getTextureCache()->addImage(path);
+	}
 	CCASSERT(texture != nullptr, "Invalid image");
 	texture->retain();
 

--- a/spine-cocos2dx/src/spine/spine-cocos2dx.h
+++ b/spine-cocos2dx/src/spine/spine-cocos2dx.h
@@ -38,4 +38,10 @@
 #include <spine/SkeletonAnimation.h>
 #include <spine/SkeletonBatch.h>
 
+namespace spine {
+	typedef cocos2d::Texture2D* (*CustomTextureLoader)(const char* path);
+	// set custom texture loader for _spAtlasPage_createTexture
+	void spAtlasPage_setCustomTextureLoader(CustomTextureLoader texLoader);
+}
+
 #endif /* SPINE_COCOS2DX_H_ */


### PR DESCRIPTION
This PR is for CocosCreator. In CocosCreator 1.8, atlas texture will be preloaded by scene, so it will not cached in TextureCache. We want to add a custom loader to get preloaded textures from Creator. Thanks!