### PR TITLE
fix comment: CPP comment not allowed in C90

### DIFF
--- a/spine-c/spine-c/src/spine/AnimationState.c
+++ b/spine-c/spine-c/src/spine/AnimationState.c
@@ -180,7 +180,7 @@ void _spEventQueue_drain (_spEventQueue* self) {
 	self->drainDisabled = 0;
 }
 
-// These two functions are needed in the UE4 runtime, see #1037
+/* These two functions are needed in the UE4 runtime, see #1037 */
 void _spAnimationState_enableQueue(spAnimationState* self) {
 	_spAnimationState* internal = SUB_CAST(_spAnimationState, self);
 	internal->queue->drainDisabled = 0;


### PR DESCRIPTION
Just a minor fix on a CPP comment, need to keep up with C90 standards!

```
/spine-runtimes/spine-c/spine-c/src/spine/AnimationState.c:183:1: error: C++ style comments are not allowed in ISO C90
 // These two functions are needed in the UE4 runtime, see #1037
 ^

```