### PR TITLE
old "fix warnings" exist some error, and this fix it

### DIFF
--- a/spine-c/spine-c/src/spine/Animation.c
+++ b/spine-c/spine-c/src/spine/Animation.c
@@ -745,7 +745,7 @@ void _spAttachmentTimeline_apply (const spTimeline* timeline, spSkeleton* skelet
 	spSlot* slot = skeleton->slots[self->slotIndex];
 
 	if (direction == SP_MIX_DIRECTION_OUT && pose == SP_MIX_POSE_SETUP) {
-		const char* attachmentName = slot->data->attachmentName;
+		attachmentName = slot->data->attachmentName;
         spSlot_setAttachment(slot, attachmentName ? spSkeleton_getAttachmentForSlotIndex(skeleton, self->slotIndex, attachmentName) : 0);
 		return;
 	}

--- a/spine-c/spine-c/src/spine/SkeletonBinary.c
+++ b/spine-c/spine-c/src/spine/SkeletonBinary.c
@@ -307,9 +307,8 @@ static spAnimation* _spSkeletonBinary_readAnimation (spSkeletonBinary* self, con
 					break;
 				}
 				default: {
-					int i;
-					for (i = 0; i < kv_size(timelines); ++i)
-						spTimeline_dispose(kv_A(timelines, i));
+					for (iii = 0; iii < kv_size(timelines); ++iii)
+						spTimeline_dispose(kv_A(timelines, iii));
 					kv_destroy(timelines);
 					_spSkeletonBinary_setError(self, "Invalid timeline type for a slot: ", skeletonData->slots[slotIndex]->name);
 					return 0;
@@ -370,9 +369,8 @@ static spAnimation* _spSkeletonBinary_readAnimation (spSkeletonBinary* self, con
 					break;
 				}
 				default: {
-					int i;
-					for (i = 0; i < kv_size(timelines); ++i)
-						spTimeline_dispose(kv_A(timelines, i));
+					for (iii = 0; iii < kv_size(timelines); ++iii)
+						spTimeline_dispose(kv_A(timelines, iii));
 					kv_destroy(timelines);
 					_spSkeletonBinary_setError(self, "Invalid timeline type for a bone: ", skeletonData->bones[boneIndex]->name);
 					return 0;
@@ -482,9 +480,9 @@ static spAnimation* _spSkeletonBinary_readAnimation (spSkeletonBinary* self, con
 				spVertexAttachment* attachment = SUB_CAST(spVertexAttachment,
 						spSkin_getAttachment(skin, slotIndex, attachmentName));
 				if (!attachment) {
-					int i;
-					for (i = 0; i < kv_size(timelines); ++i)
-						spTimeline_dispose(kv_A(timelines, i));
+					int iiii;
+					for (iiii = 0; iiii < kv_size(timelines); ++iiii)
+						spTimeline_dispose(kv_A(timelines, iiii));
 					kv_destroy(timelines);
 					_spSkeletonBinary_setError(self, "Attachment not found: ", attachmentName);
 					FREE(attachmentName);
@@ -601,7 +599,7 @@ static spAnimation* _spSkeletonBinary_readAnimation (spSkeletonBinary* self, con
 	animation = spAnimation_create(name, 0);
 	FREE(animation->timelines);
 	animation->duration = duration;
-	animation->timelinesCount = kv_size(timelines);
+	animation->timelinesCount = (int)kv_size(timelines);
 	animation->timelines = kv_array(timelines);
 	return animation;
 }
@@ -665,11 +663,11 @@ static void _readVertices(spSkeletonBinary* self, _dataInput* input, spVertexAtt
 	}
 
 	kv_trim(float, weights);
-	attachment->verticesCount = kv_size(weights);
+	attachment->verticesCount = (int)kv_size(weights);
 	attachment->vertices = kv_array(weights);
 
 	kv_trim(int, bones);
-	attachment->bonesCount = kv_size(bones);
+	attachment->bonesCount = (int)kv_size(bones);
 	attachment->bones = kv_array(bones);
 }
 

--- a/spine-c/spine-c/src/spine/SkeletonJson.c
+++ b/spine-c/spine-c/src/spine/SkeletonJson.c
@@ -408,14 +408,14 @@ static spAnimation* _spSkeletonJson_readAnimation (spSkeletonJson* self, Json* r
 					if (!vertices) {
 						if (weighted) {
 							deform2 = tempDeform;
-							memset(deform, 0, sizeof(float) * deformLength);
+							memset(deform2, 0, sizeof(float) * deformLength);
 						} else
 							deform2 = attachment->vertices;
 					} else {
 						int v, start = Json_getInt(valueMap, "offset", 0);
 						Json* vertex;
 						deform2 = tempDeform;
-						memset(deform, 0, sizeof(float) * start);
+						memset(deform2, 0, sizeof(float) * start);
 						if (self->scale == 1) {
 							for (vertex = vertices->child, v = start; vertex; vertex = vertex->next, ++v)
 								deform2[v] = vertex->valueFloat;
@@ -423,7 +423,7 @@ static spAnimation* _spSkeletonJson_readAnimation (spSkeletonJson* self, Json* r
 							for (vertex = vertices->child, v = start; vertex; vertex = vertex->next, ++v)
 								deform2[v] = vertex->valueFloat * self->scale;
 						}
-						memset(deform + v, 0, sizeof(float) * (deformLength - v));
+						memset(deform2 + v, 0, sizeof(float) * (deformLength - v));
 						if (!weighted) {
 							float* verticesAttachment = attachment->vertices;
 							for (v = 0; v < deformLength; ++v)

--- a/spine-c/spine-c/src/spine/SkeletonJson.c
+++ b/spine-c/spine-c/src/spine/SkeletonJson.c
@@ -94,7 +94,8 @@ static float toColor (const char* value, int index) {
 	int color;
 
 	if (index >= strlen(value) / 2)
-		return -1;
+ 	    return -1;
+
 	value += index * 2;
 
 	digits[0] = *value;
@@ -403,33 +404,33 @@ static spAnimation* _spSkeletonJson_readAnimation (spSkeletonJson* self, Json* r
 
 				for (valueMap = timelineMap->child, frameIndex = 0; valueMap; valueMap = valueMap->next, ++frameIndex) {
 					Json* vertices = Json_getItem(valueMap, "vertices");
-					float* deform;
+					float* deform2;
 					if (!vertices) {
 						if (weighted) {
-							deform = tempDeform;
+							deform2 = tempDeform;
 							memset(deform, 0, sizeof(float) * deformLength);
 						} else
-							deform = attachment->vertices;
+							deform2 = attachment->vertices;
 					} else {
 						int v, start = Json_getInt(valueMap, "offset", 0);
 						Json* vertex;
-						deform = tempDeform;
+						deform2 = tempDeform;
 						memset(deform, 0, sizeof(float) * start);
 						if (self->scale == 1) {
 							for (vertex = vertices->child, v = start; vertex; vertex = vertex->next, ++v)
-								deform[v] = vertex->valueFloat;
+								deform2[v] = vertex->valueFloat;
 						} else {
 							for (vertex = vertices->child, v = start; vertex; vertex = vertex->next, ++v)
-								deform[v] = vertex->valueFloat * self->scale;
+								deform2[v] = vertex->valueFloat * self->scale;
 						}
 						memset(deform + v, 0, sizeof(float) * (deformLength - v));
 						if (!weighted) {
-							float* vertices = attachment->vertices;
+							float* verticesAttachment = attachment->vertices;
 							for (v = 0; v < deformLength; ++v)
-								deform[v] += vertices[v];
+								deform2[v] += verticesAttachment[v];
 						}
 					}
-					spDeformTimeline_setFrame(timeline, frameIndex, Json_getFloat(valueMap, "time", 0), deform);
+					spDeformTimeline_setFrame(timeline, frameIndex, Json_getFloat(valueMap, "time", 0), deform2);
 					readCurve(valueMap, SUPER(timeline), frameIndex);
 				}
 				FREE(tempDeform);
@@ -445,16 +446,16 @@ static spAnimation* _spSkeletonJson_readAnimation (spSkeletonJson* self, Json* r
 		spDrawOrderTimeline* timeline = spDrawOrderTimeline_create(drawOrder->size, skeletonData->slotsCount);
 		for (valueMap = drawOrder->child, frameIndex = 0; valueMap; valueMap = valueMap->next, ++frameIndex) {
 			int ii;
-			int* drawOrder = 0;
+			int* drawOrder2 = 0;
 			Json* offsets = Json_getItem(valueMap, "offsets");
 			if (offsets) {
 				Json* offsetMap;
 				int* unchanged = MALLOC(int, skeletonData->slotsCount - offsets->size);
 				int originalIndex = 0, unchangedIndex = 0;
 
-				drawOrder = MALLOC(int, skeletonData->slotsCount);
+				drawOrder2 = MALLOC(int, skeletonData->slotsCount);
 				for (ii = skeletonData->slotsCount - 1; ii >= 0; --ii)
-					drawOrder[ii] = -1;
+					drawOrder2[ii] = -1;
 
 				for (offsetMap = offsets->child; offsetMap; offsetMap = offsetMap->next) {
 					int slotIndex = spSkeletonData_findSlotIndex(skeletonData, Json_getString(offsetMap, "slot", 0));
@@ -467,7 +468,7 @@ static spAnimation* _spSkeletonJson_readAnimation (spSkeletonJson* self, Json* r
 					while (originalIndex != slotIndex)
 						unchanged[unchangedIndex++] = originalIndex++;
 					/* Set changed items. */
-					drawOrder[originalIndex + Json_getInt(offsetMap, "offset", 0)] = originalIndex;
+					drawOrder2[originalIndex + Json_getInt(offsetMap, "offset", 0)] = originalIndex;
 					originalIndex++;
 				}
 				/* Collect remaining unchanged items. */
@@ -475,11 +476,11 @@ static spAnimation* _spSkeletonJson_readAnimation (spSkeletonJson* self, Json* r
 					unchanged[unchangedIndex++] = originalIndex++;
 				/* Fill in unchanged items. */
 				for (ii = skeletonData->slotsCount - 1; ii >= 0; ii--)
-					if (drawOrder[ii] == -1) drawOrder[ii] = unchanged[--unchangedIndex];
+					if (drawOrder2[ii] == -1) drawOrder2[ii] = unchanged[--unchangedIndex];
 				FREE(unchanged);
 			}
-			spDrawOrderTimeline_setFrame(timeline, frameIndex, Json_getFloat(valueMap, "time", 0), drawOrder);
-			FREE(drawOrder);
+			spDrawOrderTimeline_setFrame(timeline, frameIndex, Json_getFloat(valueMap, "time", 0), drawOrder2);
+			FREE(drawOrder2);
 		}
 		animation->timelines[animation->timelinesCount++] = SUPER_CAST(spTimeline, timeline);
 		animation->duration = MAX(animation->duration, timeline->frames[drawOrder->size - 1]);
@@ -873,7 +874,7 @@ spSkeletonData* spSkeletonJson_readSkeletonData (spSkeletonJson* self, const cha
 					spAttachment* attachment;
 					const char* skinAttachmentName = attachmentMap->name;
 					const char* attachmentName = Json_getString(attachmentMap, "name", skinAttachmentName);
-					const char* path = Json_getString(attachmentMap, "path", attachmentName);
+					const char* attachmentPath = Json_getString(attachmentMap, "path", attachmentName);
 					const char* color;
 					Json* entry;
 
@@ -897,7 +898,7 @@ spSkeletonData* spSkeletonJson_readSkeletonData (spSkeletonJson* self, const cha
 						return 0;
 					}
 
-					attachment = spAttachmentLoader_createAttachment(self->attachmentLoader, skin, type, attachmentName, path);
+					attachment = spAttachmentLoader_createAttachment(self->attachmentLoader, skin, type, attachmentName, attachmentPath);
 					if (!attachment) {
 						if (self->attachmentLoader->error1) {
 							spSkeletonData_dispose(skeletonData);
@@ -910,7 +911,7 @@ spSkeletonData* spSkeletonJson_readSkeletonData (spSkeletonJson* self, const cha
 					switch (attachment->type) {
 					case SP_ATTACHMENT_REGION: {
 						spRegionAttachment* region = SUB_CAST(spRegionAttachment, attachment);
-						if (path) MALLOC_STR(region->path, path);
+						if (path) MALLOC_STR(region->path, attachmentPath);
 						region->x = Json_getFloat(attachmentMap, "x", 0) * self->scale;
 						region->y = Json_getFloat(attachmentMap, "y", 0) * self->scale;
 						region->scaleX = Json_getFloat(attachmentMap, "scaleX", 1);
@@ -937,7 +938,7 @@ spSkeletonData* spSkeletonJson_readSkeletonData (spSkeletonJson* self, const cha
 					case SP_ATTACHMENT_LINKED_MESH: {
 						spMeshAttachment* mesh = SUB_CAST(spMeshAttachment, attachment);
 
-						MALLOC_STR(mesh->path, path);
+						MALLOC_STR(mesh->path, attachmentPath);
 
 						color = Json_getString(attachmentMap, "color", 0);
 						if (color) {
@@ -997,19 +998,19 @@ spSkeletonData* spSkeletonJson_readSkeletonData (spSkeletonJson* self, const cha
 						break;
 					}
 					case SP_ATTACHMENT_PATH: {
-						spPathAttachment* path = SUB_CAST(spPathAttachment, attachment);
+						spPathAttachment* pathAttatchment = SUB_CAST(spPathAttachment, attachment);
 						int vertexCount = 0;
-						path->closed = Json_getInt(attachmentMap, "closed", 0);
-						path->constantSpeed = Json_getInt(attachmentMap, "constantSpeed", 1);
+						pathAttatchment->closed = Json_getInt(attachmentMap, "closed", 0);
+						pathAttatchment->constantSpeed = Json_getInt(attachmentMap, "constantSpeed", 1);
 						vertexCount = Json_getInt(attachmentMap, "vertexCount", 0);
-						_readVertices(self, attachmentMap, SUPER(path), vertexCount << 1);
+						_readVertices(self, attachmentMap, SUPER(pathAttatchment), vertexCount << 1);
 
-						path->lengthsLength = vertexCount / 3;
-						path->lengths = MALLOC(float, path->lengthsLength);
+						pathAttatchment->lengthsLength = vertexCount / 3;
+						pathAttatchment->lengths = MALLOC(float, pathAttatchment->lengthsLength);
 
 						curves = Json_getItem(attachmentMap, "lengths");
 						for (curves = curves->child, ii = 0; curves; curves = curves->next, ++ii) {
-							path->lengths[ii] = curves->valueFloat * self->scale;
+							pathAttatchment->lengths[ii] = curves->valueFloat * self->scale;
 						}
 						break;
 					}

--- a/spine-c/spine-c/src/spine/Triangulator.c
+++ b/spine-c/spine-c/src/spine/Triangulator.c
@@ -152,8 +152,9 @@ spShortArray* spTriangulator_triangulate(spTriangulator* self, spFloatArray* ver
 	spShortArray_ensureCapacity(triangles, MAX(0, vertexCount - 2) << 2);
 
 	while (vertexCount > 3) {
-		int previous = vertexCount - 1, i = 0, next = 1;
+		int previous = vertexCount - 1, next = 1;
 		int previousIndex, nextIndex;
+		i = 0;
 		while (1) {
 			if (!isConcave[i]) {
 				int p1 = indices[previous] << 1, p2 = indices[i] << 1, p3 = indices[next] << 1;

--- a/spine-cocos2dx/src/spine/SkeletonAnimation.cpp
+++ b/spine-cocos2dx/src/spine/SkeletonAnimation.cpp
@@ -114,8 +114,6 @@ void SkeletonAnimation::initialize () {
 	_state = spAnimationState_create(spAnimationStateData_create(_skeleton->data));
 	_state->rendererObject = this;
 	_state->listener = animationCallback;
-
-	_spAnimationState* stateInternal = (_spAnimationState*)_state;
 }
 
 SkeletonAnimation::SkeletonAnimation ()

--- a/spine-cocos2dx/src/spine/SkeletonBatch.cpp
+++ b/spine-cocos2dx/src/spine/SkeletonBatch.cpp
@@ -146,8 +146,8 @@ void SkeletonBatch::reset() {
 
 cocos2d::TrianglesCommand* SkeletonBatch::nextFreeCommand() {
 	if (_commandsPool.size() <= _nextFreeCommand) {
-		unsigned int newSize = _commandsPool.size() * 2 + 1;
-		for (int i = _commandsPool.size();  i < newSize; i++) {
+		size_t newSize = _commandsPool.size() * 2 + 1;
+		for (size_t i = _commandsPool.size();  i < newSize; i++) {
 			_commandsPool.push_back(new TrianglesCommand());
 		}
 	}

--- a/spine-cocos2dx/src/spine/SkeletonRenderer.cpp
+++ b/spine-cocos2dx/src/spine/SkeletonRenderer.cpp
@@ -282,8 +282,8 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 				trianglesTwoColor.indexCount = attachmentVertices->_triangles->indexCount;
 				trianglesTwoColor.verts = twoColorBatch->allocateVertices(attachmentVertices->_triangles->vertCount);
 				trianglesTwoColor.vertCount = attachmentVertices->_triangles->vertCount;
-				for (int i = 0; i < trianglesTwoColor.vertCount; i++) {
-					trianglesTwoColor.verts[i].texCoords = attachmentVertices->_triangles->verts[i].texCoords;
+				for (int ii = 0; ii < trianglesTwoColor.vertCount; ii++) {
+					trianglesTwoColor.verts[ii].texCoords = attachmentVertices->_triangles->verts[ii].texCoords;
 				}
 				spRegionAttachment_computeWorldVertices(attachment, slot->bone, (float*)trianglesTwoColor.verts, 0, 7);
 			}
@@ -311,8 +311,8 @@ void SkeletonRenderer::draw (Renderer* renderer, const Mat4& transform, uint32_t
 				trianglesTwoColor.indexCount = attachmentVertices->_triangles->indexCount;
 				trianglesTwoColor.verts = twoColorBatch->allocateVertices(attachmentVertices->_triangles->vertCount);
 				trianglesTwoColor.vertCount = attachmentVertices->_triangles->vertCount;
-				for (int i = 0; i < trianglesTwoColor.vertCount; i++) {
-					trianglesTwoColor.verts[i].texCoords = attachmentVertices->_triangles->verts[i].texCoords;
+				for (int ii = 0; ii < trianglesTwoColor.vertCount; ii++) {
+					trianglesTwoColor.verts[ii].texCoords = attachmentVertices->_triangles->verts[ii].texCoords;
 				}
 				spVertexAttachment_computeWorldVertices(SUPER(attachment), slot, 0, trianglesTwoColor.vertCount * sizeof(V3F_C4B_C4B_T2F) / 4, (float*)trianglesTwoColor.verts, 0, 7);
 			}

--- a/spine-cocos2dx/src/spine/SkeletonTwoColorBatch.cpp
+++ b/spine-cocos2dx/src/spine/SkeletonTwoColorBatch.cpp
@@ -336,8 +336,8 @@ void SkeletonTwoColorBatch::reset() {
 
 TwoColorTrianglesCommand* SkeletonTwoColorBatch::nextFreeCommand() {
 	if (_commandsPool.size() <= _nextFreeCommand) {
-		unsigned int newSize = _commandsPool.size() * 2 + 1;
-		for (int i = _commandsPool.size();  i < newSize; i++) {
+		size_t newSize = _commandsPool.size() * 2 + 1;
+		for (size_t i = _commandsPool.size();  i < newSize; i++) {
 			_commandsPool.push_back(new TwoColorTrianglesCommand());
 		}
 	}


### PR DESCRIPTION
`deform` was renamed to `deform2`, but some places where `deform` was quoted were not modified at the same time.

I think it's the reason you revert "fix warnings (#1034 )", now I revert you revert commit and fix this.