### PR TITLE
Use UE4's memory management functions.

### DIFF
--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Private/SpinePlugin.cpp
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Private/SpinePlugin.cpp
@@ -53,9 +53,11 @@ static void * SpineRealloc( void* ptr, size_t size ) {
 }
 
 void FSpinePlugin::StartupModule() {
+#if !UE_EDITOR
     _spSetMalloc( &SpineMalloc );
     _spSetRealloc( &SpineRealloc );
     _spSetFree( FMemory::Free );
+#endif
 }
 
 void FSpinePlugin::ShutdownModule() { }

--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Private/SpinePlugin.cpp
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Private/SpinePlugin.cpp
@@ -37,8 +37,26 @@ class FSpinePlugin : public SpinePlugin {
 
 IMPLEMENT_MODULE( FSpinePlugin, SpinePlugin )
 
-void FSpinePlugin::StartupModule() { }
+// These should be filled with UE4's specific allocator functions.
+extern "C" {
+    void _spSetMalloc( void* ( *_malloc ) ( size_t size ) );
+    void _spSetFree( void( *_free ) ( void* ptr ) );
+    void _spSetRealloc( void* ( *_realloc ) ( void* ptr, size_t size ) );
+}
 
+static void * SpineMalloc( size_t size ) {
+    return FMemory::Malloc( size );
+}
+
+static void * SpineRealloc( void* ptr, size_t size ) {
+    return FMemory::Realloc( ptr, size );
+}
+
+void FSpinePlugin::StartupModule() {
+    _spSetMalloc( &SpineMalloc );
+    _spSetRealloc( &SpineRealloc );
+    _spSetFree( FMemory::Free );
+}
 
 void FSpinePlugin::ShutdownModule() { }
 


### PR DESCRIPTION
This fixes unexpected behavior on certain platforms for which
UE4 specifically limits the maximum allocation size of malloc
in favor of using optimized allocation schemes.