### PR TITLE
Fix code examples accessing internal fields

### DIFF
--- a/spine-unity/Assets/Spine Examples/Scripts/SpineboyBodyTilt.cs
+++ b/spine-unity/Assets/Spine Examples/Scripts/SpineboyBodyTilt.cs
@@ -27,7 +27,7 @@ namespace Spine.Unity.Examples {
 
 			hipBone = skeleton.FindBone(hip);
 			headBone = skeleton.FindBone(head);
-			baseHeadRotation = headBone.rotation;
+			baseHeadRotation = headBone.Rotation;
 
 			skeletonAnimation.UpdateLocal += UpdateLocal;
 		}
@@ -35,8 +35,8 @@ namespace Spine.Unity.Examples {
 		private void UpdateLocal (ISkeletonAnimation animated) {
 			hipRotationTarget = planter.Balance * hipTiltScale;
 			hipRotationSmoothed = Mathf.MoveTowards(hipRotationSmoothed, hipRotationTarget, Time.deltaTime * hipRotationMoveScale * Mathf.Abs(2f * planter.Balance / planter.offBalanceThreshold));
-			hipBone.rotation = hipRotationSmoothed;
-			headBone.rotation = baseHeadRotation + (-hipRotationSmoothed * headTiltScale);
+			hipBone.Rotation = hipRotationSmoothed;
+			headBone.Rotation = baseHeadRotation + (-hipRotationSmoothed * headTiltScale);
 		}
 	}
 

--- a/spine-unity/Assets/Spine Examples/Scripts/SpineboyFacialExpression.cs
+++ b/spine-unity/Assets/Spine Examples/Scripts/SpineboyFacialExpression.cs
@@ -48,11 +48,11 @@ namespace Spine.Unity.Examples {
 				shockTimer -= Time.deltaTime;
 
 			if (shockTimer > 0) {
-				eyeSlot.attachment = shockEye;
-				mouthSlot.attachment = shockMouth;
+				eyeSlot.Attachment = shockEye;
+				mouthSlot.Attachment = shockMouth;
 			} else {
-				eyeSlot.attachment = normalEye;
-				mouthSlot.attachment = normalMouth;
+				eyeSlot.Attachment = normalEye;
+				mouthSlot.Attachment = normalMouth;
 			}
 		}
 	}


### PR DESCRIPTION
Use public properties instead of internal fields in code examples to allow spine to be placed in Plugins subfolder.