### PR TITLE
[unity] Fix inspector animation preview event tooltips.

### DIFF
--- a/spine-unity/Assets/spine-unity/Editor/SkeletonDataAssetInspector.cs
+++ b/spine-unity/Assets/spine-unity/Editor/SkeletonDataAssetInspector.cs
@@ -1079,7 +1079,8 @@ namespace Spine.Unity.Editor {
 				GUI.color = Color.red;
 				GUI.DrawTexture(lineRect, EditorGUIUtility.whiteTexture);
 				GUI.color = Color.white;
-
+                //draw tip(s) after all events checked. otherwise a tip may overlap by event logo
+                List<AnimationEventTooltip> tips = new List<AnimationEventTooltip>();
 				for (int i = 0; i < currentAnimationEvents.Count; i++) {
 					float fr = currentAnimationEventTimes[i];
 					var userEventIcon = Icons.userEvent;
@@ -1098,12 +1099,27 @@ namespace Spine.Unity.Editor {
 							Rect tooltipRect = new Rect(evRect);
 							tooltipRect.width = tooltipStyle.CalcSize(new GUIContent(currentAnimationEvents[i].Data.Name)).x;
 							tooltipRect.y -= 4;
+                            tooltipRect.y -= tooltipRect.height * tips.Count; //to avoid several tips overlap
 							tooltipRect.x += 4;
-							GUI.Label(tooltipRect,  currentAnimationEvents[i].Data.Name, tooltipStyle);
-							GUI.tooltip = currentAnimationEvents[i].Data.Name;
+                            //to avoid tip is too wide and part of it out of barrect
+                            var tmp = tooltipRect.x + tooltipRect.width - (barRect.x + barRect.width);
+                            if(tmp > 0) {
+                                tooltipRect.x -= tmp;
+                            }
+                            AnimationEventTooltip tip;
+                            tip.rect = tooltipRect;
+                            tip.strToShow = currentAnimationEvents[i].Data.Name;
+                            tip.style = tooltipStyle;
+                            tips.Add(tip);
 						}
 					}
 				}
+                
+                //draw tip(s)
+                for(int i = 0; i < tips.Count; i++) {
+                    GUI.Label(tips[i].rect, tips[i].strToShow, tips[i].style);
+                    GUI.tooltip = tips[i].strToShow;
+                }
 			}
 		}
 
@@ -1130,6 +1146,13 @@ namespace Spine.Unity.Editor {
 				previewGameObject = null;
 			}
 		}
+
+        public struct AnimationEventTooltip
+        {
+            public Rect rect;
+            public string strToShow;
+            public GUIStyle style;
+        }
 	}
 
 


### PR DESCRIPTION
mouse hover the event logo in SkeletonDataAssets preview window, the tooltip display event name may shown in some uncomfortable way, like covered by event logo after it, part of tip out of window, several tips overlap.
![cover](https://user-images.githubusercontent.com/13451839/41014986-829661d4-697b-11e8-90ba-b6fe5c43dc70.png)
![muilti](https://user-images.githubusercontent.com/13451839/41014988-82cb9a02-697b-11e8-8e4f-19c8bebef6fa.png)
![outofwindow](https://user-images.githubusercontent.com/13451839/41014990-8300549a-697b-11e8-98d6-1aece2ffda28.png)
after
![cover1](https://user-images.githubusercontent.com/13451839/41015200-ca817bd2-697b-11e8-92d6-8842f82c5d76.png)
![muilti1](https://user-images.githubusercontent.com/13451839/41015201-cab219d6-697b-11e8-8d26-7b1728805add.png)
![outofwindow1](https://user-images.githubusercontent.com/13451839/41015202-cae689fa-697b-11e8-8288-7c7a91b15019.png)



