### PR TITLE
Fixed illogical comparison warning

### DIFF
--- a/spine-as3/spine-as3/src/spine/animation/TrackEntry.as
+++ b/spine-as3/spine-as3/src/spine/animation/TrackEntry.as
@@ -99,7 +99,7 @@ package spine.animation {
 				var id : String = intId.toString();
 				var contained: Object = propertyIDs[id];
 				propertyIDs[id] = true;
-				if (contained != undefined) {					
+				if (contained != null) {
 					timelineData[i] = AnimationState.SUBSEQUENT;
 				} else if (to == null || !to.hasTimeline(intId)) {				
 					timelineData[i] = AnimationState.FIRST;


### PR DESCRIPTION
Please, fix this (Illogical comparison with undefined.  Only untyped variables (or variables of type *) can be undefined) warning.