### PR TITLE
Expose USpineAtlasAsset and USpineSkeletonDataAsset types for Unreal 4 blueprints.

### DIFF
--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineAtlasAsset.h
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineAtlasAsset.h
@@ -34,7 +34,7 @@
 #include "spine/spine.h"
 #include "SpineAtlasAsset.generated.h"
 
-UCLASS(ClassGroup=(Spine))
+UCLASS(BlueprintType, ClassGroup=(Spine))
 class SPINEPLUGIN_API USpineAtlasAsset: public UObject {
 	GENERATED_BODY()
 	

--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineSkeletonDataAsset.h
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineSkeletonDataAsset.h
@@ -49,7 +49,7 @@ public:
 		float Mix = 0;
 };
 
-UCLASS(ClassGroup=(Spine))
+UCLASS(BlueprintType, ClassGroup=(Spine))
 class SPINEPLUGIN_API USpineSkeletonDataAsset: public UObject {
 	GENERATED_BODY()
 	


### PR DESCRIPTION
Currently, it is not possible to set the current atlas and skeleton data of a USpineSkeletonAnimationComponent through blueprints.

Adding the BlueprintType property to the UCLASS definition resolves this issue.