### PR TITLE
Expose collision generation for skeleons for Unreal 4 blueprints.

### DIFF
--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Private/SpineSkeletonRendererComponent.cpp
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Private/SpineSkeletonRendererComponent.cpp
@@ -169,7 +169,7 @@ void USpineSkeletonRendererComponent::Flush (int &Idx, TArray<FVector> &Vertices
 	if (Vertices.Num() == 0) return;
 	SetMaterial(Idx, Material);
 
-	CreateMeshSection(Idx, Vertices, Indices, TArray<FVector>(), Uvs, Colors, TArray<FProcMeshTangent>(), false);
+	CreateMeshSection(Idx, Vertices, Indices, TArray<FVector>(), Uvs, Colors, TArray<FProcMeshTangent>(), bCreateCollision);
 
 	Vertices.SetNum(0);
 	Indices.SetNum(0);

--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineSkeletonRendererComponent.h
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineSkeletonRendererComponent.h
@@ -68,6 +68,10 @@ public:
 	UPROPERTY(Category = Spine, EditAnywhere, BlueprintReadWrite)
 	FLinearColor Color = FLinearColor(1, 1, 1, 1);
 
+    /** Whether to generate collision geometry for the skeleton, or not. */
+    UPROPERTY(Category = Spine, EditAnywhere, BlueprintReadWrite)
+    bool bCreateCollision;
+
 	virtual void FinishDestroy() override;
 	
 protected:


### PR DESCRIPTION
Following up on the following discussions, automatic generation for collision data for skeletons in Unreal 4 has been disabled by default:

http://ar.esotericsoftware.com/forum/UE4-Spine-Runtime-Mesh-Component-performance-9873
http://esotericsoftware.com/forum/UE4-Performance-problem-example-project-current-branch-9482

Exposing the flag to blueprints allows us to decide for every skeleton whether to generate this data, or not.