### PR TITLE
[UE4] UBoneDriverComponent and UBoneFollowerComponent as USceneComponent

### DIFF
--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Private/SpineBoneDriverComponent.cpp
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Private/SpineBoneDriverComponent.cpp
@@ -41,9 +41,14 @@ void USpineBoneDriverComponent::BeginPlay () {
 }
 
 void USpineBoneDriverComponent::BeforeUpdateWorldTransform(USpineSkeletonComponent* skeleton) {	
-	AActor* owner = GetOwner();
-	if (owner && skeleton == lastBoundComponent) {		
-		skeleton->SetBoneWorldPosition(BoneName, owner->GetActorLocation() );
+	if (skeleton == lastBoundComponent) {		
+		if (UseComponentTransform) {
+			skeleton->SetBoneWorldPosition(BoneName, GetComponentLocation());
+		}
+		else {
+			AActor* owner = GetOwner();
+			if (owner) skeleton->SetBoneWorldPosition(BoneName, owner->GetActorLocation());
+		}
 	}
 }
 

--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Private/SpineBoneFollowerComponent.cpp
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Private/SpineBoneFollowerComponent.cpp
@@ -43,14 +43,23 @@ void USpineBoneFollowerComponent::BeginPlay () {
 void USpineBoneFollowerComponent::TickComponent ( float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction ) {
 	Super::TickComponent( DeltaTime, TickType, ThisTickFunction );
 
-	AActor* owner = GetOwner();
-	if (Target && owner) {
+	if (Target) {
 		USpineSkeletonComponent* skeleton = static_cast<USpineSkeletonComponent*>(Target->GetComponentByClass(USpineSkeletonComponent::StaticClass()));
 		if (skeleton) {
 			FTransform transform = skeleton->GetBoneWorldTransform(BoneName);
-			if (UsePosition) owner->SetActorLocation(transform.GetLocation());
-			if (UseRotation) owner->SetActorRotation(transform.GetRotation());
-			if (UseScale) owner->SetActorScale3D(transform.GetScale3D());
+			if (UseComponentTransform) {
+				if (UsePosition) SetWorldLocation(transform.GetLocation());
+				if (UseRotation) SetWorldRotation(transform.GetRotation());
+				if (UseScale) SetWorldScale3D(transform.GetScale3D());
+			}
+			else {
+				AActor* owner = GetOwner();
+				if (owner) {
+					if (UsePosition) owner->SetActorLocation(transform.GetLocation());
+					if (UseRotation) owner->SetActorRotation(transform.GetRotation());
+					if (UseScale) owner->SetActorScale3D(transform.GetScale3D());
+				}
+			}
 		}
 	}
 }

--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineBoneDriverComponent.h
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineBoneDriverComponent.h
@@ -30,13 +30,13 @@
 
 #pragma once
 
-#include "Components/ActorComponent.h"
+#include "Components/SceneComponent.h"
 #include "SpineBoneDriverComponent.generated.h"
 
 class USpineSkeletonComponent;
 
 UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
-class SPINEPLUGIN_API USpineBoneDriverComponent : public UActorComponent {
+class SPINEPLUGIN_API USpineBoneDriverComponent : public USceneComponent {
 	GENERATED_BODY()
 
 public:
@@ -45,6 +45,10 @@ public:
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	FString BoneName;
+
+	//Uses just this component when set to true. Updates owning actor otherwise.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	bool UseComponentTransform = false;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	bool UsePosition = true;

--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineBoneFollowerComponent.h
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineBoneFollowerComponent.h
@@ -35,7 +35,7 @@
 
 
 UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
-class SPINEPLUGIN_API USpineBoneFollowerComponent : public UActorComponent {
+class SPINEPLUGIN_API USpineBoneFollowerComponent : public USceneComponent {
 	GENERATED_BODY()
 
 public:
@@ -44,6 +44,10 @@ public:
 	
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	FString BoneName;
+
+	//Updates just this component when set to true. Updates owning actor otherwise.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	bool UseComponentTransform = false;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	bool UsePosition = true;


### PR DESCRIPTION
I would like to propose a change for both `UBoneDriverComponent` and `UBoneFollowerComponent `to be `USceneComponents `instead `UActorComponents`. We could then use component transform instead of owning actor transform which is more flexible and opens new options.

This behavior is optional, and can be switched on by setting `UseComponentTransform `property to true. Default value is set to false, which means that by default the behavior is unchanged from what it is now.