### PR TITLE
[Unity] Use AssetDatabase for locating editor base directory

### DIFF
--- a/spine-unity/Assets/Spine/Editor/spine-unity/Editor/SpineEditorUtilities.cs
+++ b/spine-unity/Assets/Spine/Editor/spine-unity/Editor/SpineEditorUtilities.cs
@@ -177,9 +177,9 @@ namespace Spine.Unity.Editor {
 		static void Initialize () {
 			Preferences.Load();
 
-			var rootDir = new DirectoryInfo(Application.dataPath);
-			FileInfo[] files = rootDir.GetFiles("SpineEditorUtilities.cs", SearchOption.AllDirectories);
-			editorPath = Path.GetDirectoryName(files[0].FullName.Replace("\\", "/").Replace(Application.dataPath, "Assets"));
+			var assets = AssetDatabase.FindAssets("t:script SpineEditorUtilities");
+			var assetPath = AssetDatabase.GUIDToAssetPath(assets[0]);
+			editorPath = Path.GetDirectoryName(assetPath).Replace("\\", "/");
 			editorGUIPath = editorPath + "/GUI";
 
 			Icons.Initialize();


### PR DESCRIPTION
The current method assumes the Spine Runtime exists in a sub-directory of the project's "Assets" folder.

With the package manager, and the support of local packages in Unity 2018, the runtime could be located elsewhere. The AssetDatabase would be a more reliable option for finding this path.