### PR TITLE
Fix for CS1032 in 2018.3 Unity

### DIFF
--- a/spine-unity/Assets/Spine/Editor/spine-unity/Editor/SkeletonBakingWindow.cs
+++ b/spine-unity/Assets/Spine/Editor/spine-unity/Editor/SkeletonBakingWindow.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEditor;
-
 #if UNITY_2018_3 || UNITY_2019
 #define NEW_PREFAB_SYSTEM
 #endif
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
 
 
 namespace Spine.Unity.Editor {


### PR DESCRIPTION
Getting CS1032 error under 2018.3. Apparently define needs to be done before any `using` declarations. https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs1032