### PR TITLE
- (UE4) Changes meant to support PaperZD or any other external plugin…

### DIFF
--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Private/SpineSkeletonAnimationComponent.cpp
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Private/SpineSkeletonAnimationComponent.cpp
@@ -94,7 +94,7 @@ void USpineSkeletonAnimationComponent::TickComponent(float DeltaTime, ELevelTick
 void USpineSkeletonAnimationComponent::InternalTick(float DeltaTime, bool CallDelegates) {
 	CheckState();
 
-	if (state) {
+	if (state && bAutoPlaying) {
 		state->update(DeltaTime);
 		state->apply(*skeleton);
 		if (CallDelegates) BeforeUpdateWorldTransform.Broadcast(this);
@@ -142,6 +142,36 @@ void USpineSkeletonAnimationComponent::DisposeState () {
 void USpineSkeletonAnimationComponent::FinishDestroy () {
 	DisposeState();
 	Super::FinishDestroy();
+}
+
+void USpineSkeletonAnimationComponent::SetAutoPlay(bool bInAutoPlays)
+{
+	bAutoPlaying = bInAutoPlays;
+}
+
+void USpineSkeletonAnimationComponent::SetPlaybackTime(float InPlaybackTime, bool bCallDelegates)
+{
+	CheckState();
+
+	if (state && state->getCurrent(0)) {
+		spine::Animation* CurrentAnimation = state->getCurrent(0)->getAnimation();
+		const float CurrentTime = state->getCurrent(0)->getTrackTime();
+		InPlaybackTime = FMath::Clamp(InPlaybackTime, 0.0f, CurrentAnimation->getDuration());
+		const float DeltaTime = InPlaybackTime - CurrentTime;
+		state->update(DeltaTime);
+		state->apply(*skeleton);
+
+		//Call delegates and perform the world transform
+		if (bCallDelegates)
+		{
+			BeforeUpdateWorldTransform.Broadcast(this);
+		}
+		skeleton->updateWorldTransform();
+		if (bCallDelegates)
+		{
+			AfterUpdateWorldTransform.Broadcast(this);
+		}
+	}
 }
 
 void USpineSkeletonAnimationComponent::SetTimeScale(float timeScale) {

--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineSkeletonAnimationComponent.h
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineSkeletonAnimationComponent.h
@@ -194,6 +194,16 @@ public:
 	virtual void TickComponent (float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 
 	virtual void FinishDestroy () override;
+
+	//Added functions for manual configuration
+
+	/* Manages if this skeleton should update automatically or is paused. */
+	UFUNCTION(BlueprintCallable, Category="Components|Spine|Animation")
+	void SetAutoPlay(bool bInAutoPlays);
+
+	/* Directly set the time of the current animation, will clamp to animation range. */
+	UFUNCTION(BlueprintCallable, Category = "Components|Spine|Animation")
+	void SetPlaybackTime(float InPlaybackTime, bool bCallDelegates = true);
 	
 	// Blueprint functions
 	UFUNCTION(BlueprintCallable, Category="Components|Spine|Animation")
@@ -255,4 +265,9 @@ protected:
 	// in transit within a blueprint
 	UPROPERTY()
 	TSet<UTrackEntry*> trackEntries;
+
+private:
+	/* If the animation should update automatically. */
+	UPROPERTY()
+	bool bAutoPlaying;
 };

--- a/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineSkeletonRendererComponent.h
+++ b/spine-ue4/Plugins/SpinePlugin/Source/SpinePlugin/Public/SpineSkeletonRendererComponent.h
@@ -86,10 +86,20 @@ public:
 	UPROPERTY(Category = Spine, EditAnywhere, BlueprintReadWrite)
 	FLinearColor Color = FLinearColor(1, 1, 1, 1);
 
-    	/** Whether to generate collision geometry for the skeleton, or not. */
-    	UPROPERTY(Category = Spine, EditAnywhere, BlueprintReadWrite)
-    	bool bCreateCollision;
+    /** Whether to generate collision geometry for the skeleton, or not. */
+    UPROPERTY(Category = Spine, EditAnywhere, BlueprintReadWrite)
+    bool bCreateCollision;
 
+	/* Updates this renderer with the lastest skeleton info. */
+	void UpdateRenderer();
+
+	/* Obtains the cached SkeletonComponent */
+	USpineSkeletonComponent* GetSkeleton() const;
+
+	/* Sets the cached SkeletonComponent */
+	void SetSkeleton(USpineSkeletonComponent* InSkeleton);
+
+	/* Called when the component is destroyed */
 	virtual void FinishDestroy() override;
 	
 protected:
@@ -99,4 +109,8 @@ protected:
 	
 	spine::Vector<float> worldVertices;
 	spine::SkeletonClipping clipper;
+
+private:
+	/* Cached skeleton to use to avoid Find functions on TICK */
+	TWeakObjectPtr<USpineSkeletonComponent> CachedSkeleton;
 };


### PR DESCRIPTION
- (UE4) Changes meant to support PaperZD or any other external plugins which
    need to interface directly with the renderer.
- (UE4) Added skeleton animation caching on SkeletonRenderer to avoid
per tick searches which are costly. The skeleton animation component can
be setup externally.
- (UE4) Added bAutoPlays members to AnimationComponent, so the skeleton
doesn't update automatically if its needed.
- (UE4) Added SetPlaybackTime method to AnimationComponent.