### PR TITLE
[cpp] Fixes #1286 TrackEntry now resets renderer object

### DIFF
--- a/spine-cpp/spine-cpp/src/spine/AnimationState.cpp
+++ b/spine-cpp/spine-cpp/src/spine/AnimationState.cpp
@@ -171,6 +171,8 @@ void TrackEntry::reset() {
 	_mixingFrom = NULL;
 	_mixingTo = NULL;
 
+	setRendererObject(NULL);
+
 	_timelineMode.clear();
 	_timelineHoldMix.clear();
 	_timelinesRotation.clear();


### PR DESCRIPTION
Found that the TrackEntry properly deletes the RendererObject (at least in the cocos2d-x code) but never sets that pointer back to NULL which leads to problems later since track entries are pooled (again, at least in cocos2d-x). This patch will set the RendererObject back NULL when a TrackEntry is reset.  