### PR TITLE
[ts] I gift you the second equals sign

### DIFF
--- a/spine-ts/core/src/AnimationState.ts
+++ b/spine-ts/core/src/AnimationState.ts
@@ -255,7 +255,7 @@ module spine {
 					else {
 						// This fixes the WebKit 602 specific issue described at http://esotericsoftware.com/forum/iOS-10-disappearing-graphics-10109
 						Utils.webkit602BugfixHelper(alpha, blend);
-						if (timelineBlend = MixBlend.setup) {
+						if (timelineBlend == MixBlend.setup) {
 							if (timeline instanceof AttachmentTimeline) {
 								if (attachments) direction = MixDirection.out;
 							} else if (timeline instanceof DrawOrderTimeline) {


### PR DESCRIPTION
Need to check the other runtimes too.

UPD. OK, only [ts] has it.