### PR TITLE
Use [SettingsProvider] instead of obsolete [PreferenceItem] on Unity 2018.3+

### DIFF
--- a/spine-unity/Assets/Spine/Editor/spine-unity/Editor/SpineEditorUtilities.cs
+++ b/spine-unity/Assets/Spine/Editor/spine-unity/Editor/SpineEditorUtilities.cs
@@ -172,14 +172,26 @@ namespace Spine.Unity.Editor {
 
 		static int STRAIGHT_ALPHA_PARAM_ID = Shader.PropertyToID("_StraightAlphaInput");
 
-		// Preferences entry point
-		[PreferenceItem("Spine")]
-		static void PreferencesGUI () {
-			Preferences.HandlePreferencesGUI();
-		}
+        // Preferences entry point
+#if UNITY_2018_3_OR_NEWER
+        [SettingsProvider]
+        static SettingsProvider PreferencesGUI()
+        {
+            return new SettingsProvider("Preferences/Spine", SettingsScope.User)
+            {
+                guiHandler = (searchContext) => Preferences.HandlePreferencesGUI(),
+            };
+        }
+#else
+        [PreferenceItem("Spine")]
+        static void PreferencesGUI()
+        {
+            Preferences.HandlePreferencesGUI();
+        }
+#endif
 
-		// Auto-import entry point
-		static void OnPostprocessAllAssets (string[] imported, string[] deleted, string[] moved, string[] movedFromAssetPaths) {
+        // Auto-import entry point
+        static void OnPostprocessAllAssets (string[] imported, string[] deleted, string[] moved, string[] movedFromAssetPaths) {
 			if (imported.Length == 0)
 				return;
 


### PR DESCRIPTION
Use `[SettingsProvider]` instead of obsolete `[PreferenceItem]` to suppress a warning message on Unity 2018.3 and up.

```
Assets/Spine/Editor/spine-unity/Editor/SpineEditorUtilities.cs(186,10): warning CS0618: 'PreferenceItem' is obsolete: '[PreferenceItem] is deprecated. Use [SettingsProvider] instead.'
```