### PR TITLE
[unity] Fix null reference on inspecting AnimationReferenceAsset

### DIFF
--- a/spine-unity/Assets/Spine/Editor/spine-unity/Editor/AnimationReferenceAssetEditor.cs
+++ b/spine-unity/Assets/Spine/Editor/spine-unity/Editor/AnimationReferenceAssetEditor.cs
@@ -82,18 +82,23 @@ namespace Spine.Unity.Editor {
 
 					if (animationNotFound) {
 						animationNameProperty.stringValue = "";
-						preview.ClearAnimationSetupPose();
 					}
 				}
 
-				preview.ClearAnimationSetupPose();
+                if (ThisSkeletonDataAsset != null)
+                {
+                    preview.ClearAnimationSetupPose();
+                }
 
 				if (!string.IsNullOrEmpty(animationNameProperty.stringValue))
 					preview.PlayPauseAnimation(animationNameProperty.stringValue, true);
 			}
 
 			lastSkeletonDataAsset = ThisSkeletonDataAsset;
-			lastSkeletonData = ThisSkeletonDataAsset.GetSkeletonData(true);
+			if(ThisSkeletonDataAsset != null)
+			{
+				lastSkeletonData = ThisSkeletonDataAsset.GetSkeletonData(true);
+			}
 
 			//EditorGUILayout.HelpBox(AnimationReferenceAssetEditor.InspectorHelpText, MessageType.Info, true);
 			EditorGUILayout.Space();


### PR DESCRIPTION
- Fix null reference on inspecting a newly created `AnimationReferenceAsset` from right click menu.
- Fix preview error when removing Skeleton Data Asset from `AnimationReferenceAsset` while inspecting it.