### PR TITLE
Added basic support for Timeline with SkeletonGraphic

### DIFF
--- a/spine-unity/Assets/Spine/Editor/spine-unity/Editor/AnimationReferenceAssetEditor.cs
+++ b/spine-unity/Assets/Spine/Editor/spine-unity/Editor/AnimationReferenceAssetEditor.cs
@@ -82,18 +82,23 @@ namespace Spine.Unity.Editor {
 
 					if (animationNotFound) {
 						animationNameProperty.stringValue = "";
-						preview.ClearAnimationSetupPose();
 					}
 				}
 
-				preview.ClearAnimationSetupPose();
+                if (ThisSkeletonDataAsset != null)
+                {
+                    preview.ClearAnimationSetupPose();
+                }
 
 				if (!string.IsNullOrEmpty(animationNameProperty.stringValue))
 					preview.PlayPauseAnimation(animationNameProperty.stringValue, true);
 			}
 
 			lastSkeletonDataAsset = ThisSkeletonDataAsset;
-			lastSkeletonData = ThisSkeletonDataAsset.GetSkeletonData(true);
+			if(ThisSkeletonDataAsset != null)
+			{
+				lastSkeletonData = ThisSkeletonDataAsset.GetSkeletonData(true);
+			}
 
 			//EditorGUILayout.HelpBox(AnimationReferenceAssetEditor.InspectorHelpText, MessageType.Info, true);
 			EditorGUILayout.Space();

--- a/spine-unity/Assets/Spine/Runtime/spine-unity/Modules/Timeline/SpineAnimationState/SpineGraphicAnimationStateTrack.cs
+++ b/spine-unity/Assets/Spine/Runtime/spine-unity/Modules/Timeline/SpineAnimationState/SpineGraphicAnimationStateTrack.cs
@@ -35,8 +35,8 @@ using UnityEngine.Timeline;
 namespace Spine.Unity.Playables {
 	[TrackColor(0.9960785f, 0.2509804f, 0.003921569f)]
 	[TrackClipType(typeof(SpineAnimationStateClip))]
-	[TrackBindingType(typeof(SkeletonAnimation))]
-	public class SpineAnimationStateTrack : TrackAsset {
+	[TrackBindingType(typeof(SkeletonGraphic))]
+	public class SpineGraphicAnimationStateTrack : TrackAsset {
 		public int trackIndex = 0;
 
 		public override Playable CreateTrackMixer(PlayableGraph graph, GameObject go, int inputCount) {
@@ -48,10 +48,10 @@ namespace Spine.Unity.Playables {
 
         public override void GatherProperties(PlayableDirector director, IPropertyCollector driver)
 		{
-            SkeletonAnimation skeletonAnimation = (SkeletonAnimation)director.GetGenericBinding(this);
-			if(skeletonAnimation != null)
+            SkeletonGraphic skeletonGraphic = (SkeletonGraphic)director.GetGenericBinding(this);
+			if(skeletonGraphic != null)
 			{
-				driver.AddFromComponent(skeletonAnimation.gameObject, skeletonAnimation);
+				driver.AddFromComponent(skeletonGraphic.gameObject, skeletonGraphic);
 			}
 		}
 	}

--- a/spine-unity/Assets/Spine/Runtime/spine-unity/Modules/Timeline/SpineAnimationState/SpineGraphicAnimationStateTrack.cs.meta
+++ b/spine-unity/Assets/Spine/Runtime/spine-unity/Modules/Timeline/SpineAnimationState/SpineGraphicAnimationStateTrack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 60f379e66a8814c49885aeb7c8b4f7e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Added `SkeletonGraphic` supported timeline track.
- Modified timeline behaviour to support both `SkeletonAnimation` and `SkeletonGraphic`.
- Make the timeline preview revert changes when in edit mode for both `SkeletonAnimation` and `SkeletonGraphic`.