### PR TITLE
expandToIndex should not subtract its current length

### DIFF
--- a/spine-ts/core/src/AnimationState.ts
+++ b/spine-ts/core/src/AnimationState.ts
@@ -527,7 +527,7 @@ module spine {
 
 		expandToIndex (index: number) {
 			if (index < this.tracks.length) return this.tracks[index];
-			Utils.ensureArrayCapacity(this.tracks, index - this.tracks.length + 1, null);
+			Utils.ensureArrayCapacity(this.tracks, index + 1, null);
 			this.tracks.length = index + 1;
 			return null;
 		}


### PR DESCRIPTION
If the length is first expanded to 2 and then to 5, the result end result is a list with length 3. That is not working as intended