### PR TITLE
[unity] Fix ps4 shader compile error

### DIFF
--- a/spine-unity/Assets/Spine/Runtime/spine-unity/Modules/Shaders/Sprite/CGIncludes/SpriteShadows.cginc
+++ b/spine-unity/Assets/Spine/Runtime/spine-unity/Modules/Shaders/Sprite/CGIncludes/SpriteShadows.cginc
@@ -38,7 +38,7 @@ vertexOutput vert(vertexInput v)
 
 uniform fixed _ShadowAlphaCutoff;
 
-fixed4 frag(vertexOutput IN) : COLOR 
+fixed4 frag(vertexOutput IN) : SV_Target 
 {
 	fixed4 texureColor = calculateTexturePixel(IN.texcoord);
 	clip(texureColor.a - _ShadowAlphaCutoff);


### PR DESCRIPTION
Use SV_Target to fix shader compile error on PS4 platform.