### PR TITLE
[unity] Check more accurately whether a json is for Spine or not

### DIFF
--- a/spine-unity/Assets/Spine/Editor/spine-unity/Editor/SpineEditorUtilities.cs
+++ b/spine-unity/Assets/Spine/Editor/spine-unity/Editor/SpineEditorUtilities.cs
@@ -1166,7 +1166,16 @@ namespace Spine.Unity.Editor {
 
 					isSpineData = root.ContainsKey("skeleton");
 					if (isSpineData) {
-						var skeletonInfo = (Dictionary<string, object>)root["skeleton"];
+						var skeletonInfo = root["skeleton"] as Dictionary<string, object>;
+						if (skeletonInfo == null)
+						{
+							Debug.LogWarningFormat("Could not parse '{0}' as a Spine JSON file, no skeleton key!", asset.name);
+							return false;
+						}
+						if (!skeletonInfo.ContainsKey("spine")) {
+							Debug.LogWarningFormat("Could not parse '{0}' as a Spine JSON file, no spine key!", asset.name);
+							return false;
+						}
 						object jv;
 						skeletonInfo.TryGetValue("spine", out jv);
 						rawVersion = jv as string;


### PR DESCRIPTION
Do not assume a json file with contents like '{ "skeleton": ...} '
means that the file is for Spine. Instead try a little harder and also
seek out the spine key under skeleton.

This came up in our game development. (Some enemies are skeletons :)