### PR TITLE
[unity] Fix Spine icon positioning on the Hierarchy tab

### DIFF
--- a/spine-unity/Assets/Spine/Editor/spine-unity/Editor/SpineEditorUtilities.cs
+++ b/spine-unity/Assets/Spine/Editor/spine-unity/Editor/SpineEditorUtilities.cs
@@ -1804,7 +1804,8 @@ namespace Spine.Unity.Editor {
 			internal static void IconsOnGUI (int instanceId, Rect selectionRect) {
 				Rect r = new Rect(selectionRect);
 				if (skeletonRendererTable.ContainsKey(instanceId)) {
-					r.x = (r.width - 15) + selectionRect.x;;
+					r.x = (r.width - 15) + selectionRect.x;
+					r.y += 1;
 					r.width = 15;
 					GUI.Label(r, Icons.spine);
 				} else if (skeletonUtilityBoneTable.ContainsKey(instanceId)) {

--- a/spine-unity/Assets/Spine/Editor/spine-unity/Editor/SpineEditorUtilities.cs
+++ b/spine-unity/Assets/Spine/Editor/spine-unity/Editor/SpineEditorUtilities.cs
@@ -1804,7 +1804,7 @@ namespace Spine.Unity.Editor {
 			internal static void IconsOnGUI (int instanceId, Rect selectionRect) {
 				Rect r = new Rect(selectionRect);
 				if (skeletonRendererTable.ContainsKey(instanceId)) {
-					r.x = r.width - 15;
+					r.x = (r.width - 15) + selectionRect.x;;
 					r.width = 15;
 					GUI.Label(r, Icons.spine);
 				} else if (skeletonUtilityBoneTable.ContainsKey(instanceId)) {


### PR DESCRIPTION
The old code didn't account for indented space from the left edge in the case of deeper hierarchy. It didn't stick to the right edge as you may intended.

Before : 
<img width="570" alt="Screenshot 2019-07-12 13 00 52" src="https://user-images.githubusercontent.com/5653276/61105848-54c0ee80-a4a5-11e9-89b9-822c7c2f8c96.png">

After : 
<img width="697" alt="Screenshot 2019-07-12 12 52 55" src="https://user-images.githubusercontent.com/5653276/61105808-38bd4d00-a4a5-11e9-811c-8e44a02ba032.png">
