### PR TITLE
Remove unnecessary STL includes

### DIFF
--- a/spine-cpp/spine-cpp/include/spine/RTTI.h
+++ b/spine-cpp/spine-cpp/include/spine/RTTI.h
@@ -32,16 +32,27 @@
 
 #include <spine/SpineObject.h>
 
+#ifdef SPINE_UE4
 #include <string>
+#else
+#include <spine/SpineString.h>
+#endif
 
 namespace spine {
+
+#ifdef SPINE_UE4
+typedef std::string StringImpl;
+#else
+typedef String StringImpl;
+#endif
+
 class SP_API RTTI : public SpineObject {
 public:
-	explicit RTTI(const std::string &className);
+	explicit RTTI(const StringImpl &className);
 
-	RTTI(const std::string &className, const RTTI &baseRTTI);
+	RTTI(const StringImpl &className, const RTTI &baseRTTI);
 
-	const std::string &getClassName() const;
+	const StringImpl &getClassName() const;
 
 	bool isExactly(const RTTI &rtti) const;
 
@@ -53,7 +64,7 @@ private:
 
 	RTTI &operator=(const RTTI &obj);
 
-	const std::string _className;
+	const StringImpl _className;
 	const RTTI *_pBaseRTTI;
 };
 }

--- a/spine-cpp/spine-cpp/include/spine/RegionAttachment.h
+++ b/spine-cpp/spine-cpp/include/spine/RegionAttachment.h
@@ -34,7 +34,6 @@
 #include <spine/Vector.h>
 #include <spine/Color.h>
 
-#include <string>
 #include <spine/HasRendererObject.h>
 
 #define NUM_UVS 8

--- a/spine-cpp/spine-cpp/include/spine/Skeleton.h
+++ b/spine-cpp/spine-cpp/include/spine/Skeleton.h
@@ -36,8 +36,6 @@
 #include <spine/SpineString.h>
 #include <spine/Color.h>
 
-#include <limits> // std::numeric_limits
-
 namespace spine {
 class SkeletonData;
 

--- a/spine-cpp/spine-cpp/include/spine/Slot.h
+++ b/spine-cpp/spine-cpp/include/spine/Slot.h
@@ -34,8 +34,6 @@
 #include <spine/SpineObject.h>
 #include <spine/Color.h>
 
-#include <string>
-
 namespace spine {
 class SlotData;
 

--- a/spine-cpp/spine-cpp/include/spine/Vector.h
+++ b/spine-cpp/spine-cpp/include/spine/Vector.h
@@ -33,8 +33,6 @@
 #include <spine/Extension.h>
 #include <spine/SpineObject.h>
 #include <spine/SpineString.h>
-#include <stdlib.h>
-#include <memory>
 #include <assert.h>
 
 namespace spine {
@@ -131,7 +129,9 @@ public:
 
 		if (inIndex != _size) {
 			for (size_t i = inIndex; i < _size; ++i) {
-				std::swap(_buffer[i], _buffer[i + 1]);
+				T tmp(_buffer[i]);
+				_buffer[i] = _buffer[i + 1];
+				_buffer[i + 1] = tmp;
 			}
 		}
 

--- a/spine-cpp/spine-cpp/include/spine/spine.h
+++ b/spine-cpp/spine-cpp/include/spine/spine.h
@@ -49,7 +49,6 @@
 #include <spine/ConstraintData.h>
 #include <spine/ContainerUtil.h>
 #include <spine/CurveTimeline.h>
-#include <spine/Debug.h>
 #include <spine/DeformTimeline.h>
 #include <spine/DrawOrderTimeline.h>
 #include <spine/Event.h>

--- a/spine-cpp/spine-cpp/src/spine/AnimationState.cpp
+++ b/spine-cpp/spine-cpp/src/spine/AnimationState.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include <spine/AnimationState.h>
+
 #include <spine/Animation.h>
 #include <spine/Event.h>
 #include <spine/AnimationStateData.h>
@@ -43,6 +44,8 @@
 #include <spine/AttachmentTimeline.h>
 #include <spine/DrawOrderTimeline.h>
 #include <spine/EventTimeline.h>
+
+#include <float.h>
 
 using namespace spine;
 
@@ -914,7 +917,7 @@ TrackEntry *AnimationState::newTrackEntry(size_t trackIndex, Animation *animatio
 	entry._trackTime = 0;
 	entry._trackLast = -1;
 	entry._nextTrackLast = -1; // nextTrackLast == -1 signifies a TrackEntry that wasn't applied yet.
-	entry._trackEnd = std::numeric_limits<float>::max(); // loop ? float.MaxValue : animation.Duration;
+	entry._trackEnd = FLT_MAX; // loop ? float.MaxValue : animation.Duration;
 	entry._timeScale = 1;
 
 	entry._alpha = 1;

--- a/spine-cpp/spine-cpp/src/spine/EventTimeline.cpp
+++ b/spine-cpp/spine-cpp/src/spine/EventTimeline.cpp
@@ -43,6 +43,8 @@
 #include <spine/EventData.h>
 #include <spine/ContainerUtil.h>
 
+#include <float.h>
+
 using namespace spine;
 
 RTTI_IMPL(EventTimeline, Timeline)
@@ -67,7 +69,7 @@ void EventTimeline::apply(Skeleton &skeleton, float lastTime, float time, Vector
 
 	if (lastTime > time) {
 		// Fire events after last time for looped animations.
-		apply(skeleton, lastTime, std::numeric_limits<float>::max(), pEvents, alpha, blend, direction);
+		apply(skeleton, lastTime, FLT_MAX, pEvents, alpha, blend, direction);
 		lastTime = -1.0f;
 	} else if (lastTime >= _frames[frameCount - 1]) {
 		// Last time is after last frame.

--- a/spine-cpp/spine-cpp/src/spine/MathUtil.cpp
+++ b/spine-cpp/spine-cpp/src/spine/MathUtil.cpp
@@ -32,7 +32,6 @@
 
 #include <spine/MathUtil.h>
 #include <math.h>
-#include <random>
 #include <stdlib.h>
 
 // Required for division by 0 in _isNaN on MSVC

--- a/spine-cpp/spine-cpp/src/spine/RTTI.cpp
+++ b/spine-cpp/spine-cpp/src/spine/RTTI.cpp
@@ -32,17 +32,16 @@
 #endif
 
 #include <spine/RTTI.h>
-#include <spine/SpineString.h>
 
 using namespace spine;
 
-RTTI::RTTI(const std::string &className) : _className(className), _pBaseRTTI(NULL) {
+RTTI::RTTI(const StringImpl &className) : _className(className), _pBaseRTTI(NULL) {
 }
 
-RTTI::RTTI(const std::string &className, const RTTI &baseRTTI) : _className(className), _pBaseRTTI(&baseRTTI) {
+RTTI::RTTI(const StringImpl &className, const RTTI &baseRTTI) : _className(className), _pBaseRTTI(&baseRTTI) {
 }
 
-const std::string &RTTI::getClassName() const {
+const StringImpl &RTTI::getClassName() const {
 	return _className;
 }
 

--- a/spine-cpp/spine-cpp/src/spine/Skeleton.cpp
+++ b/spine-cpp/spine-cpp/src/spine/Skeleton.cpp
@@ -53,6 +53,8 @@
 
 #include <spine/ContainerUtil.h>
 
+#include <float.h>
+
 using namespace spine;
 
 Skeleton::Skeleton(SkeletonData *skeletonData) :
@@ -417,10 +419,10 @@ void Skeleton::update(float delta) {
 }
 
 void Skeleton::getBounds(float &outX, float &outY, float &outWidth, float &outHeight, Vector<float> &outVertexBuffer) {
-	float minX = std::numeric_limits<float>::max();
-	float minY = std::numeric_limits<float>::max();
-	float maxX = std::numeric_limits<float>::min();
-	float maxY = std::numeric_limits<float>::min();
+	float minX = FLT_MAX;
+	float minY = FLT_MAX;
+	float maxX = FLT_MIN;
+	float maxY = FLT_MIN;
 
 	for (size_t i = 0; i < _drawOrder.size(); ++i) {
 		Slot *slot = _drawOrder[i];

--- a/spine-cpp/spine-cpp/src/spine/SkeletonBounds.cpp
+++ b/spine-cpp/spine-cpp/src/spine/SkeletonBounds.cpp
@@ -39,6 +39,8 @@
 
 #include <spine/Slot.h>
 
+#include <float.h>
+
 using namespace spine;
 
 SkeletonBounds::SkeletonBounds() : _minX(0), _minY(0), _maxX(0), _maxY(0) {
@@ -87,10 +89,10 @@ void SkeletonBounds::update(Skeleton &skeleton, bool updateAabb) {
 	if (updateAabb)
 		aabbCompute();
 	else {
-		_minX = std::numeric_limits<float>::min();
-		_minY = std::numeric_limits<float>::min();
-		_maxX = std::numeric_limits<float>::max();
-		_maxY = std::numeric_limits<float>::max();
+		_minX = FLT_MIN;
+		_minY = FLT_MIN;
+		_maxX = FLT_MAX;
+		_maxY = FLT_MAX;
 	}
 }
 
@@ -197,10 +199,10 @@ float SkeletonBounds::getHeight() {
 }
 
 void SkeletonBounds::aabbCompute() {
-	float minX = std::numeric_limits<float>::min();
-	float minY = std::numeric_limits<float>::min();
-	float maxX = std::numeric_limits<float>::max();
-	float maxY = std::numeric_limits<float>::max();
+	float minX = FLT_MIN;
+	float minY = FLT_MIN;
+	float maxX = FLT_MAX;
+	float maxY = FLT_MAX;
 
 	for (size_t i = 0, n = _polygons.size(); i < n; ++i) {
 		Polygon *polygon = _polygons[i];


### PR DESCRIPTION
This pull request removes some uses of the STL that are not necessary.

Most of them were just includes left there in error.

`std::swap` was used for real in Vector.h.
It is replaced in a simple way, but needs the c++ version to be pushed-up to `c++11`, though.

Removing these STL includes translates to smaller compilation times for large projects, since the size of the preprocessed source is much smaller.
