### PR TITLE
Fix cocos2dx project and use of premultiplied alpha

### DIFF
--- a/spine-cocos2dx/example/proj.win32/spine-cocos2d-x.vcxproj
+++ b/spine-cocos2dx/example/proj.win32/spine-cocos2d-x.vcxproj
@@ -153,7 +153,7 @@ xcopy "$(ProjectDir)..\Resources" "$(OutDir)" /D /E /I /F /Y
     <ClCompile Include="..\..\..\spine-cpp\spine-cpp\src\spine\BoundingBoxAttachment.cpp" />
     <ClCompile Include="..\..\..\spine-cpp\spine-cpp\src\spine\ClippingAttachment.cpp" />
     <ClCompile Include="..\..\..\spine-cpp\spine-cpp\src\spine\ColorTimeline.cpp" />
-    <ClCompile Include="..\..\..\spine-cpp\spine-cpp\src\spine\Constraint.cpp" />
+    <ClCompile Include="..\..\..\spine-cpp\spine-cpp\src\spine\ConstraintData.cpp" />
     <ClCompile Include="..\..\..\spine-cpp\spine-cpp\src\spine\CurveTimeline.cpp" />
     <ClCompile Include="..\..\..\spine-cpp\spine-cpp\src\spine\DeformTimeline.cpp" />
     <ClCompile Include="..\..\..\spine-cpp\spine-cpp\src\spine\DrawOrderTimeline.cpp" />
@@ -211,6 +211,7 @@ xcopy "$(ProjectDir)..\Resources" "$(OutDir)" /D /E /I /F /Y
     <ClCompile Include="..\Classes\BatchingExample.cpp" />
     <ClCompile Include="..\Classes\CoinExample.cpp" />
     <ClCompile Include="..\Classes\GoblinsExample.cpp" />
+    <ClCompile Include="..\Classes\MixAndMatchExample.cpp" />
     <ClCompile Include="..\Classes\RaptorExample.cpp" />
     <ClCompile Include="..\Classes\SkeletonRendererSeparatorExample.cpp" />
     <ClCompile Include="..\Classes\SpineboyExample.cpp" />
@@ -234,7 +235,6 @@ xcopy "$(ProjectDir)..\Resources" "$(OutDir)" /D /E /I /F /Y
     <ClInclude Include="..\..\..\spine-cpp\spine-cpp\include\spine\ClippingAttachment.h" />
     <ClInclude Include="..\..\..\spine-cpp\spine-cpp\include\spine\Color.h" />
     <ClInclude Include="..\..\..\spine-cpp\spine-cpp\include\spine\ColorTimeline.h" />
-    <ClInclude Include="..\..\..\spine-cpp\spine-cpp\include\spine\Constraint.h" />
     <ClInclude Include="..\..\..\spine-cpp\spine-cpp\include\spine\ContainerUtil.h" />
     <ClInclude Include="..\..\..\spine-cpp\spine-cpp\include\spine\CurveTimeline.h" />
     <ClInclude Include="..\..\..\spine-cpp\spine-cpp\include\spine\Debug.h" />
@@ -309,6 +309,7 @@ xcopy "$(ProjectDir)..\Resources" "$(OutDir)" /D /E /I /F /Y
     <ClInclude Include="..\Classes\BatchingExample.h" />
     <ClInclude Include="..\Classes\CoinExample.h" />
     <ClInclude Include="..\Classes\GoblinsExample.h" />
+    <ClInclude Include="..\Classes\MixAndMatchExample.h" />
     <ClInclude Include="..\Classes\RaptorExample.h" />
     <ClInclude Include="..\Classes\SkeletonRendererSeparatorExample.h" />
     <ClInclude Include="..\Classes\SpineboyExample.h" />

--- a/spine-cocos2dx/example/proj.win32/spine-cocos2d-x.vcxproj.filters
+++ b/spine-cocos2dx/example/proj.win32/spine-cocos2d-x.vcxproj.filters
@@ -78,9 +78,6 @@
     <ClCompile Include="..\..\..\spine-cpp\spine-cpp\src\spine\ColorTimeline.cpp">
       <Filter>spine</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\spine-cpp\spine-cpp\src\spine\Constraint.cpp">
-      <Filter>spine</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\..\spine-cpp\spine-cpp\src\spine\CurveTimeline.cpp">
       <Filter>spine</Filter>
     </ClCompile>
@@ -246,6 +243,12 @@
     <ClCompile Include="..\Classes\TankExample.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\spine-cpp\spine-cpp\src\spine\ConstraintData.cpp">
+      <Filter>spine</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Classes\MixAndMatchExample.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="main.h">
@@ -342,9 +345,6 @@
       <Filter>spine</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\spine-cpp\spine-cpp\include\spine\ColorTimeline.h">
-      <Filter>spine</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\..\spine-cpp\spine-cpp\include\spine\Constraint.h">
       <Filter>spine</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\spine-cpp\spine-cpp\include\spine\ContainerUtil.h">
@@ -535,6 +535,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\spine-cpp\spine-cpp\include\spine\Vertices.h">
       <Filter>spine</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Classes\MixAndMatchExample.h">
+      <Filter>src</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/spine-cocos2dx/src/spine/SkeletonRenderer.cpp
+++ b/spine-cocos2dx/src/spine/SkeletonRenderer.cpp
@@ -434,7 +434,8 @@ namespace spine {
 
 			const cocos2d::Color4B color4B = ColorToColor4B(color);
 			const cocos2d::Color4B darkColor4B = ColorToColor4B(darkColor);
-			const BlendFunc blendFunc = makeBlendFunc(slot->getData().getBlendMode(), _premultipliedAlpha);
+			const BlendFunc blendFunc = makeBlendFunc(slot->getData().getBlendMode(), attachmentVertices->_texture->hasPremultipliedAlpha());
+			_blendFunc = blendFunc;
 
 			if (hasSingleTint) {
 				if (_clipper->isClipping()) {


### PR DESCRIPTION
This PR contains a couple of fixes:
1. It fixes the spine-cocos2d-x.vcxprox Visual Studio project
2. In cocos2dx ```SkeletonRenderer```, take into account whether a texture is encoded with premultiplied alpha when setting the blending mode.