### PR TITLE
Add support for webgl2 context

### DIFF
--- a/spine-ts/webgl/src/WebGL.ts
+++ b/spine-ts/webgl/src/WebGL.ts
@@ -36,7 +36,7 @@ module spine.webgl {
 		constructor(canvasOrContext: HTMLCanvasElement | WebGLRenderingContext, contextConfig: any = { alpha: "true" }) {
 			if (canvasOrContext instanceof HTMLCanvasElement) {
 				let canvas = canvasOrContext;
-				this.gl = <WebGLRenderingContext> (canvas.getContext("webgl", contextConfig) || canvas.getContext("experimental-webgl", contextConfig));
+				this.gl = <WebGLRenderingContext> (canvas.getContext("webgl2", contextConfig) || canvas.getContext("webgl", contextConfig) || canvas.getContext("experimental-webgl", contextConfig));
 				this.canvas = canvas;
 				canvas.addEventListener("webglcontextlost", (e: any) => {
 					let event = <WebGLContextEvent>e;


### PR DESCRIPTION
Add support for webgl2 context, needed for integration with rendering in Construct 3 gl context (C3 defaults to a webgl2 context if available.) C3 users are creating a C3 plugin using Spine-TS, WIP, the basics working.