### PR TITLE
[libgdx] Fix skeletons not being rendered properly to FBOs due to blend functions.

### DIFF
--- a/spine-libgdx/spine-libgdx/src/com/esotericsoftware/spine/BlendMode.java
+++ b/spine-libgdx/spine-libgdx/src/com/esotericsoftware/spine/BlendMode.java
@@ -33,26 +33,38 @@ import com.badlogic.gdx.graphics.GL20;
 
 /** Determines how images are blended with existing pixels when drawn. */
 public enum BlendMode {
-	normal(GL20.GL_SRC_ALPHA, GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA), //
-	additive(GL20.GL_SRC_ALPHA, GL20.GL_ONE, GL20.GL_ONE), //
-	multiply(GL20.GL_DST_COLOR, GL20.GL_DST_COLOR, GL20.GL_ONE_MINUS_SRC_ALPHA), //
-	screen(GL20.GL_ONE, GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_COLOR), //
+	normal(GL20.GL_SRC_ALPHA, GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA, GL20.GL_SRC_ALPHA, GL20.GL_ONE, GL20.GL_ONE), //
+	additive(GL20.GL_SRC_ALPHA, GL20.GL_ONE, GL20.GL_ONE, GL20.GL_SRC_ALPHA, GL20.GL_ONE, GL20.GL_ONE), //
+	multiply(GL20.GL_DST_COLOR, GL20.GL_DST_COLOR, GL20.GL_ONE_MINUS_SRC_ALPHA, GL20.GL_DST_COLOR, GL20.GL_DST_COLOR, GL20.GL_ONE_MINUS_SRC_ALPHA), //
+	screen(GL20.GL_ONE, GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_COLOR, GL20.GL_ONE, GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_COLOR), //
 	;
 
-	int source, sourcePMA, dest;
+	int sourceColor, sourceColorPMA, destColor;
+	int sourceAlpha, sourceAlphaPMA, destAlpha;
 
-	BlendMode (int source, int sourcePremultipledAlpha, int dest) {
-		this.source = source;
-		this.sourcePMA = sourcePremultipledAlpha;
-		this.dest = dest;
+	BlendMode (int sourceColor, int sourceColorPremultipledAlpha, int destColor, int sourceAlpha, int sourceAlphaPremultipliedAlpha, int destAlpha) {
+		this.sourceColor = sourceColor;
+		this.sourceColorPMA = sourceColorPremultipledAlpha;
+		this.destColor = destColor;
+		this.sourceAlpha = sourceAlpha;
+		this.sourceAlphaPMA = sourceAlphaPremultipliedAlpha;
+		this.destAlpha = destAlpha;
 	}
 
 	public int getSource (boolean premultipliedAlpha) {
-		return premultipliedAlpha ? sourcePMA : source;
+		return premultipliedAlpha ? sourceColorPMA : sourceColor;
 	}
 
 	public int getDest () {
-		return dest;
+		return destColor;
+	}
+
+	public int getSourceAlpha (boolean premultipliedAlpha) {
+		return premultipliedAlpha ? sourceAlphaPMA : sourceAlpha;
+	}
+
+	public int getDestAlpha () {
+		return destAlpha;
 	}
 
 	static public final BlendMode[] values = values();

--- a/spine-libgdx/spine-libgdx/src/com/esotericsoftware/spine/SkeletonRenderer.java
+++ b/spine-libgdx/spine-libgdx/src/com/esotericsoftware/spine/SkeletonRenderer.java
@@ -107,7 +107,8 @@ public class SkeletonRenderer {
 						alpha = 0;
 					}
 					blendMode = slotBlendMode;
-					batch.setBlendFunction(blendMode.getSource(premultipliedAlpha), blendMode.getDest());
+					batch.setBlendFunctionSeparate(blendMode.getSource(premultipliedAlpha), blendMode.getDest(),
+						blendMode.getSourceAlpha(premultipliedAlpha), blendMode.getDestAlpha());
 				}
 
 				float c = NumberUtils.intToFloatColor(((int)alpha << 24) //
@@ -217,7 +218,8 @@ public class SkeletonRenderer {
 						alpha = 0;
 					}
 					blendMode = slotBlendMode;
-					batch.setBlendFunction(blendMode.getSource(premultipliedAlpha), blendMode.getDest());
+					batch.setBlendFunctionSeparate(blendMode.getSource(premultipliedAlpha), blendMode.getDest(),
+						blendMode.getSourceAlpha(premultipliedAlpha), blendMode.getDestAlpha());
 				}
 
 				float c = NumberUtils.intToFloatColor(((int)alpha << 24) //
@@ -341,7 +343,8 @@ public class SkeletonRenderer {
 						alpha = 0;
 					}
 					blendMode = slotBlendMode;
-					batch.setBlendFunction(blendMode.getSource(premultipliedAlpha), blendMode.getDest());
+					batch.setBlendFunctionSeparate(blendMode.getSource(premultipliedAlpha), blendMode.getDest(),
+						blendMode.getSourceAlpha(premultipliedAlpha), blendMode.getDestAlpha());
 				}
 
 				float red = r * color.r * multiplier;


### PR DESCRIPTION
When drawing skeletons to a FBO with BlendMode.normal, transparency is created when drawing a image with transparency on top of an opaque one. Depending on the background this artificial transparency looks like artifacts.

This happens because SkeletonRenderer uses a combined blend function. Switching to separate blend functions and adjusting BlendMode to use GL_ONE instead of GL_ONE_MINUS_SRC_ALPHA on dstAlpha fixes the issue.

![blending_bug](https://user-images.githubusercontent.com/2331058/68060718-532f6680-fce0-11e9-8a1f-59ff147a6e0e.png)

![image](https://user-images.githubusercontent.com/2331058/68064813-466e3b00-fcff-11e9-9589-32a34dd2d9b6.png)

The same issue is also present throughout libGDX, which results in FBOs never working properly out of the box.
