### PR TITLE
use std::function when compiler support c++11

### DIFF
--- a/spine-cpp/spine-cpp/include/spine/AnimationState.h
+++ b/spine-cpp/spine-cpp/include/spine/AnimationState.h
@@ -37,7 +37,7 @@
 #include <spine/SpineString.h>
 #include <spine/HasRendererObject.h>
 
-#ifdef SPINE_USE_STD_FUNCTION
+#if __cplusplus >= 201103L // c++11
 #include <functional>
 #endif
 
@@ -60,7 +60,7 @@ namespace spine {
 	class Skeleton;
 	class RotateTimeline;
 
-#ifdef SPINE_USE_STD_FUNCTION
+#if __cplusplus >= 201103L
 	typedef std::function<void (AnimationState* state, EventType type, TrackEntry* entry, Event* event)> AnimationStateListener;
 #else
 	typedef void (*AnimationStateListener) (AnimationState* state, EventType type, TrackEntry* entry, Event* event);


### PR DESCRIPTION
Since c++11, std::function is supported, so maybe better use '__cplusplus >= 201103L' instead of define 'SPINE_USE_STD_FUNCTION' macro