### PR TITLE
fix: [ts] Skin.attachAll: empty skin placeholders wont be reattached after a skin change

### DIFF
--- a/spine-ts/core/src/Skin.ts
+++ b/spine-ts/core/src/Skin.ts
@@ -194,6 +194,12 @@ module spine {
 							break;
 						}
 					}
+				} else {
+					let attachmentName = slot.data.attachmentName; 
+					if (attachmentName != null) {
+						let attachment = this.getAttachment(slotIndex, attachmentName);
+						if (attachment != null) slot.setAttachment(attachment);
+					}
 				}
 				slotIndex++;
 			}


### PR DESCRIPTION
Exactly what title says
Steps to reproduce:
Spine with at least two skins
Skin A: skin placeholder with no attachement
Skin B: above skin placeholder, but with attachement
```
setSkinByName('Skin A')
setSkinByName('Skin B')
```
Skin attachement will not be attached and will not be visible


