### PR TITLE
[c] Ignore unused result from fread

### DIFF
--- a/spine-c/spine-c/src/spine/extension.c
+++ b/spine-c/spine-c/src/spine/extension.c
@@ -92,7 +92,8 @@ char* _spReadFile (const char* path, int* length) {
 	fseek(file, 0, SEEK_SET);
 
 	data = MALLOC(char, *length);
-	fread(data, 1, *length, file);
+	size_t result = fread(data, 1, *length, file);
+	UNUSED(result);
 	fclose(file);
 
 	return data;


### PR DESCRIPTION
```
src/spine/extension.c:95:2: warning: ignoring return value of ‘fread’, declared with attribute warn_unused_result [-Wunused-result]
   95 |  fread(data, 1, *length, file);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```