### PR TITLE
[spine-c] Fixed uninitialized variable timeline

### DIFF
--- a/spine-c/spine-c/src/spine/AnimationState.c
+++ b/spine-c/spine-c/src/spine/AnimationState.c
@@ -385,6 +385,7 @@ int spAnimationState_apply (spAnimationState* self, spSkeleton* skeleton) {
 		timelines = current->animation->timelines;
 		if ((i == 0 && mix == 1) || blend == SP_MIX_BLEND_ADD) {
 			for (ii = 0; ii < timelineCount; ii++) {
+				timeline = timelines[ii];
 			    if (timeline->type == SP_TIMELINE_ATTACHMENT) {
                     _spAnimationState_applyAttachmentTimeline(self, timeline, skeleton, animationTime, blend, -1);
 			    } else {


### PR DESCRIPTION
c runtime crashes because of uninitialized variable timeline.