### PR TITLE
[spine-c] Fixed path constraint json name

### DIFF
--- a/spine-c/spine-c/src/spine/SkeletonJson.c
+++ b/spine-c/spine-c/src/spine/SkeletonJson.c
@@ -152,7 +152,7 @@ static spAnimation* _spSkeletonJson_readAnimation (spSkeletonJson* self, Json* r
 	Json* slots = Json_getItem(root, "slots");
 	Json* ik = Json_getItem(root, "ik");
 	Json* transform = Json_getItem(root, "transform");
-	Json* paths = Json_getItem(root, "paths");
+	Json* paths = Json_getItem(root, "path");
 	Json* deformJson = Json_getItem(root, "deform");
 	Json* drawOrderJson = Json_getItem(root, "drawOrder");
 	Json* events = Json_getItem(root, "events");


### PR DESCRIPTION
spine-c uses wrong json key for path constraints.