### PR TITLE
[TS] Fixed that items in a pool were replaced when calling `freeAll`

### DIFF
--- a/spine-ts/core/src/Utils.ts
+++ b/spine-ts/core/src/Utils.ts
@@ -313,8 +313,7 @@ module spine {
 
 		freeAll (items: ArrayLike<T>) {
 			for (let i = 0; i < items.length; i++) {
-				if ((items[i] as any).reset) (items[i] as any).reset();
-				this.items[i] = items[i];
+				this.free(items[i]);
 			}
 		}
 


### PR DESCRIPTION
A call to free all would replace items currently in the pool. This change calls `free` instead which adds the items to the pool instead.