### PR TITLE
[spine cpp] Add object release hook

### DIFF
--- a/spine-cpp/spine-cpp/include/spine/Extension.h
+++ b/spine-cpp/spine-cpp/include/spine/Extension.h
@@ -61,6 +61,11 @@ public:
 		getInstance()->_free((void *) ptr, file, line);
 	}
 
+	template<typename T>
+	static void beforeFree(T *ptr) {
+		getInstance()->_beforeFree((void *) ptr);
+	}
+	
 	static char *readFile(const String &path, int *length) {
 		return getInstance()->_readFile(path, length);
 	}
@@ -82,6 +87,8 @@ public:
 	virtual void _free(void *mem, const char *file, int line) = 0;
 
 	virtual char *_readFile(const String &path, int *length) = 0;
+
+	virtual void _beforeFree(void *ptr) {}
 
 protected:
 	SpineExtension();

--- a/spine-cpp/spine-cpp/src/spine/SpineObject.cpp
+++ b/spine-cpp/spine-cpp/src/spine/SpineObject.cpp
@@ -63,4 +63,5 @@ void SpineObject::operator delete(void *p) {
 }
 
 SpineObject::~SpineObject() {
+	SpineExtension::beforeFree(this);
 }


### PR DESCRIPTION
In our application, a `SpineObject` can be connected to a JavaScript Object, it need to be unconnected when destroyed. So I need get notification before destroy. 