### PR TITLE
add function AnimationState:getLast (trackEntry)

### DIFF
--- a/spine-lua/AnimationState.lua
+++ b/spine-lua/AnimationState.lua
@@ -977,6 +977,14 @@ function AnimationState:getCurrent (trackIndex)
 	return self.tracks[trackIndex]
 end
 
+function AnimationState:getLast (trackIndex)
+	local lastEntry = self.tracks[trackIndex]
+	while lastEntry.next do
+		lastEntry = lastEntry.next
+	end
+	return lastEntry
+end
+
 function AnimationState:clearListeners ()
 	self.onStart = nil
 	self.onInterrupt = nil


### PR DESCRIPTION
I found usefull to have function that returns trackEntry for last animation queued.

I use this to get duration of last animation queued to adjust delay to be from END of the last animation instead of its START to get its duration.