### PR TITLE
[spine-c] Fixed floating point exception - division by zero

### DIFF
--- a/spine-c/spine-c/include/spine/extension.h
+++ b/spine-c/spine-c/include/spine/extension.h
@@ -110,6 +110,7 @@
 #define SQRT(A) sqrtf(A)
 #define ACOS(A) acosf(A)
 #define POW(A,B) pow(A, B)
+#define ISNAN(A) (int)isnan(A)
 #else
 #define FMOD(A,B) (float)fmod(A, B)
 #define ATAN2(A,B) (float)atan2(A, B)
@@ -118,6 +119,7 @@
 #define SQRT(A) (float)sqrt(A)
 #define ACOS(A) (float)acos(A)
 #define POW(A,B) (float)pow(A, B)
+#define ISNAN(A) (int)isnan(A)
 #endif
 
 #define SIN_DEG(A) SIN((A) * DEG_RAD)

--- a/spine-c/spine-c/src/spine/PathConstraint.c
+++ b/spine-c/spine-c/src/spine/PathConstraint.c
@@ -212,18 +212,12 @@ static void _addAfterPosition (float p, float* temp, int i, float* out, int o) {
 	out[o + 2] = r;
 }
 
-/* Need to pass 0 as an argument, so VC++ doesn't error with C2124 */
-static int _isNan(float value, float zero) {
-	float _nan = (float)0.0 / zero;
-	return 0 == memcmp((void*)&value, (void*)&_nan, sizeof(value));
-}
-
 static void _addCurvePosition (float p, float x1, float y1, float cx1, float cy1, float cx2, float cy2, float x2, float y2,
 		float* out, int o, int/*bool*/tangents) {
 	float tt, ttt, u, uu, uuu;
 	float ut, ut3, uut3, utt3;
 	float x, y;
-	if (p == 0 || _isNan(p, 0)) {
+	if (p == 0 || ISNAN(p)) {
 		out[o] = x1;
 		out[o + 1] = y1;
 		out[o + 2] = ATAN2(cy1 - y1, cx1 - x1);


### PR DESCRIPTION
_isNan throws exception when FP exceptions (FE_DIVBYZERO) are enabled.