### PR TITLE
Optimization of reuse of empty deform buffer

### DIFF
--- a/spine-csharp/src/SkeletonBinary.cs
+++ b/spine-csharp/src/SkeletonBinary.cs
@@ -64,6 +64,8 @@ namespace Spine {
 		private AttachmentLoader attachmentLoader;
 		private List<SkeletonJson.LinkedMesh> linkedMeshes = new List<SkeletonJson.LinkedMesh>();
 
+		private static readonly Dictionary<int, float[]> emptyFloatBuffer = new Dictionary<int, float[]>();
+
 		public SkeletonBinary (params Atlas[] atlasArray)
 			: this(new AtlasAttachmentLoader(atlasArray)) {
 		}
@@ -574,6 +576,17 @@ namespace Spine {
 			return array;
 		}
 
+		private static float[] GetEmptyFloatBuffer(int size)
+		{
+			if (emptyFloatBuffer.TryGetValue(size, out var result))
+				return result;
+
+			result = new float[size];
+			emptyFloatBuffer.Add(size, result);
+
+			return result;
+		}
+
 		private Animation ReadAnimation (String name, SkeletonInput input, SkeletonData skeletonData) {
 			var timelines = new ExposedList<Timeline>(32);
 			float scale = Scale;
@@ -778,7 +791,7 @@ namespace Spine {
 							float[] deform;
 							int end = input.ReadInt(true);
 							if (end == 0)
-								deform = weighted ? new float[deformLength] : vertices;
+								deform = weighted ? GetEmptyFloatBuffer(deformLength) : vertices;
 							else {
 								deform = new float[deformLength];
 								int start = input.ReadInt(true);


### PR DESCRIPTION
If there is no vertex information in the deform timeline, and weights are used, a new float[deformLength] with an empty value is used and the value is not updated later. The goal is to reuse it and optimize it.

Below is a screenshot of profiling when initializing SkeletonData for one character in the current project.
In the case of a lot of Animation information, we could reduce GC of 10MB by reusing the buffer. (It's still too big, so we need a lot of optimization)

![before](https://user-images.githubusercontent.com/3849915/85399284-871e0b80-b591-11ea-9870-4b09e2c2289f.png)
![after](https://user-images.githubusercontent.com/3849915/85399289-8b4a2900-b591-11ea-9e74-72a09559775c.png)