### PR TITLE
[spine-cpp] remove usage of nullptr

### DIFF
--- a/spine-cpp/spine-cpp/src/spine/Json.cpp
+++ b/spine-cpp/spine-cpp/src/spine/Json.cpp
@@ -120,7 +120,7 @@ Json::Json(const char *value) :
 }
 
 Json::~Json() {
-    spine::Json* curr = nullptr;
+    spine::Json* curr = NULL;
     spine::Json* next = _child;
     do {
         curr = next;

--- a/spine-cpp/spine-cpp/src/spine/SkeletonBinary.cpp
+++ b/spine-cpp/spine-cpp/src/spine/SkeletonBinary.cpp
@@ -380,7 +380,7 @@ char *SkeletonBinary::readString(DataInput *input) {
 
 char* SkeletonBinary::readStringRef(DataInput* input, SkeletonData* skeletonData) {
 	int index = readVarint(input, true);
-	return index == 0 ? nullptr : skeletonData->_strings[index - 1];
+	return index == 0 ? NULL : skeletonData->_strings[index - 1];
 }
 
 float SkeletonBinary::readFloat(DataInput *input) {


### PR DESCRIPTION
spine-cpp does not compile on linux because `nullptr` is not defined for -std=c++03. This pull request simply replaces it with `NULL`