### PR TITLE
Fix problems when play animation in reverse

### DIFF
--- a/spine-csharp/src/AnimationState.cs
+++ b/spine-csharp/src/AnimationState.cs
@@ -1032,9 +1032,12 @@ namespace Spine {
 				if (loop) {
 					float duration = animationEnd - animationStart;
 					if (duration == 0) return animationStart;
-					return (trackTime % duration) + animationStart;
+					if (trackTime < 0)
+						return ((trackTime % duration) + duration) + animationStart;
+					else
+						return (trackTime % duration) + animationStart;
 				}
-				return Math.Min(trackTime + animationStart, animationEnd);
+				return Math.Max(Math.Min(trackTime + animationStart, animationEnd), animationStart);
 			}
 		}
 


### PR DESCRIPTION
Problems are: non-looping reverse play will stop at T-Pose, not the first frame as expected; looping reverse play won't loop and stopped at first round