### PR TITLE
[unity] Remove redundant SerializeField

### DIFF
--- a/spine-unity/Assets/Spine/Runtime/spine-unity/Components/Following/BoneFollower.cs
+++ b/spine-unity/Assets/Spine/Runtime/spine-unity/Components/Following/BoneFollower.cs
@@ -58,7 +58,7 @@ namespace Spine.Unity {
 
 		/// <summary>If a bone isn't set in code, boneName is used to find the bone at the beginning. For runtime switching by name, use SetBoneByName. You can also set the BoneFollower.bone field directly.</summary>
 		[SpineBone(dataField: "skeletonRenderer")]
-		[SerializeField] public string boneName;
+		public string boneName;
 
 		public bool followXYPosition = true;
 		public bool followZPosition = true;

--- a/spine-unity/Assets/Spine/Runtime/spine-unity/Components/Following/BoneFollowerGraphic.cs
+++ b/spine-unity/Assets/Spine/Runtime/spine-unity/Components/Following/BoneFollowerGraphic.cs
@@ -57,7 +57,7 @@ namespace Spine.Unity {
 
 		/// <summary>If a bone isn't set in code, boneName is used to find the bone at the beginning. For runtime switching by name, use SetBoneByName. You can also set the BoneFollower.bone field directly.</summary>
 		[SpineBone(dataField: "skeletonGraphic")]
-		[SerializeField] public string boneName;
+		public string boneName;
 
 		public bool followBoneRotation = true;
 		[Tooltip("Follows the skeleton's flip state by controlling this Transform's local scale.")]

--- a/spine-unity/Assets/Spine/Runtime/spine-unity/Components/Following/PointFollower.cs
+++ b/spine-unity/Assets/Spine/Runtime/spine-unity/Components/Following/PointFollower.cs
@@ -44,7 +44,7 @@ namespace Spine.Unity {
 	[HelpURL("http://esotericsoftware.com/spine-unity#PointFollower")]
 	public class PointFollower : MonoBehaviour, IHasSkeletonRenderer, IHasSkeletonComponent {
 
-		[SerializeField] public SkeletonRenderer skeletonRenderer;
+		public SkeletonRenderer skeletonRenderer;
 		public SkeletonRenderer SkeletonRenderer { get { return this.skeletonRenderer; } }
 		public ISkeletonComponent SkeletonComponent { get { return skeletonRenderer as ISkeletonComponent; } }
 


### PR DESCRIPTION
The `SerializeField` attribute is redundant for public fields, as detected by [Microsoft Analyzers for Unity: UNT0013 ](https://github.com/microsoft/Microsoft.Unity.Analyzers/blob/main/doc/UNT0013.md)