### PR TITLE
Fix SkeletonMecanim handling of negative normalizedTime value.

### DIFF
--- a/spine-unity/Assets/Spine/Runtime/spine-unity/Components/SkeletonMecanim.cs
+++ b/spine-unity/Assets/Spine/Runtime/spine-unity/Components/SkeletonMecanim.cs
@@ -473,8 +473,14 @@ namespace Spine.Unity {
 				return (clipLength - time < EndSnapEpsilon) ? clipLength : time; // return a time snapped to clipLength;
 			}
 
-			static float AnimationTime (float normalizedTime, float clipLength, bool reversed) {
-				if (reversed)
+			static float AnimationTime(float normalizedTime, float clipLength, bool reversed)
+			{
+				bool isTimePositive = (normalizedTime >= 0);
+
+				if (!isTimePositive)
+					normalizedTime *= (-1);
+
+				if (reversed == isTimePositive) // if time is positive and we are reversed, OR if it is negative and we are not reversed
 					normalizedTime = (1 - normalizedTime + (int)normalizedTime) + (int)normalizedTime;
 
 				return normalizedTime * clipLength;


### PR DESCRIPTION
This is a fix for ticket: #1784.

The AnimationTime needs to also handle negative values for the current clip's **normalizedTime**.
This can happen if someone uses a negative value for the animation's speed multiplier in order to
play the animation in reverse.

Can be rewritten in some other form.
