### PR TITLE
Update main.cpp

### DIFF
--- a/spine-sfml/cpp/example/main.cpp
+++ b/spine-sfml/cpp/example/main.cpp
@@ -612,9 +612,8 @@ void test (SkeletonData* skeletonData, Atlas* atlas) {
 
 int main () {
 	DebugExtension dbgExtension(SpineExtension::getInstance());
-	SpineExtension::setInstance(&dbgExtension);
 
-    testcase(ikDemo, "data/spineboy-pro.json", "data/spineboy-pro.skel", "data/spineboy-pma.atlas", 0.6f);
+        testcase(ikDemo, "data/spineboy-pro.json", "data/spineboy-pro.skel", "data/spineboy-pma.atlas", 0.6f);
 	testcase(mixAndMatch, "data/mix-and-match-pro.json", "data/mix-and-match-pro.skel", "data/mix-and-match-pma.atlas", 0.5f);
 	testcase(goblins, "data/goblins-pro.json", "data/goblins-pro.skel", "data/goblins-pma.atlas", 1.4f);
 	testcase(owl, "data/owl-pro.json", "data/owl-pro.skel", "data/owl-pma.atlas", 0.5f);


### PR DESCRIPTION
Otherwise "use after free" happens. When global `RTTI::~RTTI` calls 

SpineObject::~SpineObject() {
	SpineExtension::beforeFree(this);
}

But `dbgExtension` is dead at that time already. So call to `getInstance()` in `beforeFree()` returns pointer to garbage.