### PR TITLE
[BUGFIX]: mesh attachment squashing

### DIFF
--- a/spine-ts/core/src/Animation.ts
+++ b/spine-ts/core/src/Animation.ts
@@ -1455,7 +1455,7 @@ module spine {
 		}
 
 		setAttachment(skeleton: Skeleton, slot: Slot, attachmentName: string) {
-			slot.attachment = attachmentName == null ? null : skeleton.getAttachment(this.slotIndex, attachmentName);
+			slot.setAttachment(attachmentName == null ? null : skeleton.getAttachment(this.slotIndex, attachmentName));
 		}
 	}
 

--- a/spine-ts/core/src/AnimationState.ts
+++ b/spine-ts/core/src/AnimationState.ts
@@ -270,7 +270,7 @@ module spine {
 				var slot = slots[i];
 				if (slot.attachmentState == setupState) {
 					var attachmentName = slot.data.attachmentName;
-					slot.attachment = (attachmentName == null ? null : skeleton.getAttachment(slot.data.index, attachmentName));
+					slot.setAttachment(attachmentName == null ? null : skeleton.getAttachment(slot.data.index, attachmentName));
 				}
 			}
 			this.unkeyedState += 2; // Increasing after each use avoids the need to reset attachmentState for every slot.
@@ -390,7 +390,7 @@ module spine {
 		}
 
 		setAttachment (skeleton: Skeleton, slot: Slot, attachmentName: string, attachments: boolean) {
-			slot.attachment = attachmentName == null ? null : skeleton.getAttachment(slot.data.index, attachmentName);
+			slot.setAttachment(attachmentName == null ? null : skeleton.getAttachment(slot.data.index, attachmentName));
 			if (attachments) slot.attachmentState = this.unkeyedState + AnimationState.CURRENT;
 		}
 


### PR DESCRIPTION
I have a bug with squashing mesh attachments when try to change animation state. it reproduced with

> animations made with spine v3.8.99
> pixi.js: 6.0.2
> pixi-spine: >= 2.1.10

So, i compared 2.1.10 and 2.1.11 versions of pixi-spine plugin and i think that found and fixed source of this bug.

**BUG representation:**

_expectation - 2.1.10 package and build with my fixes_
![good](https://user-images.githubusercontent.com/43529529/115856886-b31a4f80-a435-11eb-867e-5cedd8b49545.gif)

_reality - >= 2.1.10 packages_
![bad](https://user-images.githubusercontent.com/43529529/115856902-b8779a00-a435-11eb-99f5-185ffe64453d.gif)