### PR TITLE
[unity] Add option to not pause spine with timeline

### DIFF
--- a/spine-unity/Modules/com.esotericsoftware.spine.timeline/Editor/SpineAnimationStateDrawer.cs
+++ b/spine-unity/Modules/com.esotericsoftware.spine.timeline/Editor/SpineAnimationStateDrawer.cs
@@ -50,6 +50,7 @@ public class SpineAnimationStateDrawer : PropertyDrawer {
 		SerializedProperty useBlendDurationProp = property.FindPropertyRelative("useBlendDuration");
 		SerializedProperty mixDurationProp = property.FindPropertyRelative("mixDuration");
 		SerializedProperty holdPreviousProp = property.FindPropertyRelative("holdPrevious");
+		SerializedProperty dontPauseWithDirectorProp = property.FindPropertyRelative("dontPauseWithDirector");
 		SerializedProperty eventProp = property.FindPropertyRelative("eventThreshold");
 		SerializedProperty attachmentProp = property.FindPropertyRelative("attachmentThreshold");
 		SerializedProperty drawOrderProp = property.FindPropertyRelative("drawOrderThreshold");
@@ -90,6 +91,9 @@ public class SpineAnimationStateDrawer : PropertyDrawer {
 
 		singleFieldRect.y += lineHeightWithSpacing;
 		EditorGUI.PropertyField(singleFieldRect, holdPreviousProp);
+
+		singleFieldRect.y += lineHeightWithSpacing;
+		EditorGUI.PropertyField(singleFieldRect, dontPauseWithDirectorProp);
 
 		singleFieldRect.y += lineHeightWithSpacing;
 		EditorGUI.PropertyField(singleFieldRect, eventProp);

--- a/spine-unity/Modules/com.esotericsoftware.spine.timeline/Runtime/SpineAnimationState/SpineAnimationStateBehaviour.cs
+++ b/spine-unity/Modules/com.esotericsoftware.spine.timeline/Runtime/SpineAnimationState/SpineAnimationStateBehaviour.cs
@@ -53,6 +53,7 @@ namespace Spine.Unity.Playables {
 		#pragma warning restore 414
 		public float mixDuration = 0.1f;
 		public bool holdPrevious = false;
+		public bool dontPauseWithDirector = false;
 
 		[Range(0, 1f)]
 		public float attachmentThreshold = 0.5f;

--- a/spine-unity/Modules/com.esotericsoftware.spine.timeline/Runtime/SpineAnimationState/SpineAnimationStateMixerBehaviour.cs
+++ b/spine-unity/Modules/com.esotericsoftware.spine.timeline/Runtime/SpineAnimationState/SpineAnimationStateMixerBehaviour.cs
@@ -41,14 +41,17 @@ namespace Spine.Unity.Playables {
 		public int trackIndex;
 
 		IAnimationStateComponent animationStateComponent;
+		bool dontPauseWithDirector = true;
 		bool isPaused = false;
 		TrackEntry pausedTrackEntry;
 		float previousTimeScale = 1;
 
 		public override void OnBehaviourPause (Playable playable, FrameData info) {
-			if (!isPaused)
-				HandlePause(playable);
-			isPaused = true;
+			if (!dontPauseWithDirector) {
+				if (!isPaused)
+					HandlePause(playable);
+				isPaused = true;
+			}
 		}
 
 		public override void OnBehaviourPlay (Playable playable, FrameData info) {
@@ -118,6 +121,8 @@ namespace Spine.Unity.Playables {
 				if (trackStarted) {
 					ScriptPlayable<SpineAnimationStateBehaviour> inputPlayable = (ScriptPlayable<SpineAnimationStateBehaviour>)playable.GetInput(i);
 					SpineAnimationStateBehaviour clipData = inputPlayable.GetBehaviour();
+
+					dontPauseWithDirector = clipData.dontPauseWithDirector;
 
 					if (clipData.animationReference == null) {
 						float mixDuration = clipData.customDuration ? clipData.mixDuration : state.Data.DefaultMix;


### PR DESCRIPTION
There is already an option with hold the animation, but there is no
option to not pause the animation while the Timeline director is paused.

An example use-case where this option is important is when the timeline
is paused while waiting for an user input, but there is still a need to
play an idle loop animation on a spine skeleton.

Forum thread: http://en.esotericsoftware.com/forum/Timeline-and-Director-pause-change-16150