### PR TITLE
Initial support for prefab preview thumbnails

### DIFF
--- a/spine-unity/Assets/Spine/Editor/spine-unity/Editor/Utility/SpineEditorUtilities.cs
+++ b/spine-unity/Assets/Spine/Editor/spine-unity/Editor/Utility/SpineEditorUtilities.cs
@@ -95,6 +95,22 @@ namespace Spine.Unity.Editor {
 			texturesWithoutMetaFile.Clear();
 		}
 
+		// Post process prefabs to set setupPose as a mesh
+		void OnPostprocessPrefab(GameObject g)
+		{
+			var skeletonRenderers = g.GetComponentsInChildren<SkeletonRenderer>(true);
+
+			// generate new meshes
+			foreach (var r in skeletonRenderers) {
+				var meshFilter = r.GetComponent<MeshFilter>();
+				r.Initialize(true, true);
+				r.LateUpdateMesh();
+				var mesh = meshFilter.sharedMesh;
+				mesh.name = "Skeleton Mesh for Prefab " + r.gameObject.name;
+				context.AddObjectToAsset(mesh.name, mesh);
+			}
+		}
+
 #region Initialization
 		static SpineEditorUtilities () {
 			EditorApplication.delayCall += Initialize; // delayed so that AssetDatabase is ready.

--- a/spine-unity/Assets/Spine/Runtime/spine-unity/Components/SkeletonRenderer.cs
+++ b/spine-unity/Assets/Spine/Runtime/spine-unity/Components/SkeletonRenderer.cs
@@ -391,6 +391,10 @@ namespace Spine.Unity {
 
 			if (updateMode != UpdateMode.FullUpdate) return;
 
+			LateUpdateMesh();
+		}
+
+		public virtual void LateUpdateMesh() {
 			#if SPINE_OPTIONAL_RENDEROVERRIDE
 			bool doMeshOverride = generateMeshOverride != null;
 			if ((!meshRenderer.enabled)	&& !doMeshOverride) return;


### PR DESCRIPTION
This is an early (WIP) request for comment on preliminary (and very limited) support for prefab thumbnails ( #1722 ).

Currently the prefab assets don't include any visual hint that there are any spine skeletons in them.
The reason for this is basically that when saving a asset results in MeshFilter's sharedMesh being invalid. This can be caused by one of the following reasons (depending on the current state of the SkeleonRenderer object): 
- Mesh being a scene only object (it cannot be used in for asset preview) and 
- Mesh being destroyed after prefab is saved (by disposing the double buffered meshes)
- Mesh is null

The fact that the dynamic mesh is scene only object results in type mismatch mesh (partially handled by #1387 ) which then results in null mesh on the subsequent prefab modifications.

<del>This change introduces an extra asset next to SkeletonData asset, that holds the a mesh in SetupPose which is attached to the sharedMesh when prefab is being saved. This way a thumbnail is generated with the default setup pose for every spine skeleton inside a prefab. </del>

This pull request is more of an initial proof-of-concept and a scream for help

Known things that needs to be completed (and verified):
- [x] Skins support - currently only default skin's mesh is generated (could work in some cases)
- [x] Dynamic mesh save support when editing prefab and attaching it instead of the setup pose mesh
- [ ] Fix player build with mesh.hideFlags = HideFlags.DontSaveInBuild
- [ ] Split mesh and multiple atlas support (what is this actually?)
- [ ] Skeleton Graphics support (is it even possible to have prefab preview for canvas?)
- [ ] Check unity compatibility (and possibly hide everything behind a define)
- [ ] Reimport prefab inconsistent warning
- [ ] What other stuff needs to be supported to prevent random editor failures

<del> While I haven't check a lot of possible scenarios, the simple change presented here seems to work in the most simple use-case. I don't know if it could create any fatal error, but I guess it can have a corner case where an error is logged to the console while saving a prefab. At least on the spine examples I imported nothing broke during the import.</del>

<del>What I mostly want to do as a next step is to enable dynamic mesh save support (I believe this will also fix skin support?)
I imagine this to happen by adding the mesh to the prefab asset (using AssetDatabase.AddObjectToAsset(mesh, prefab) and updating it when changed. I tried to do that by scraping out the double buffer and pointing the mesh to an asset. 
What I failed to achieve here is two thing:
- to detect when actually a spine skeleton is edited inside a prefab. I believe [Experimental.SceneManagement.PrefabStage.IsPartOfPrefabContents()](https://docs.unity3d.com/2018.3/Documentation/ScriptReference/Experimental.SceneManagement.PrefabStage.IsPartOfPrefabContents.html) is a good start, but unfortunately It fails to run while called in Awake or OnEnable and I am uncertain how can to handle the mesh substitution after that.
- to detect prefab creating and substitute the buffer with proper data
</del>

<del>Another issue with the above approach I see is how to handle the embedded mesh assets inside the prefab. I haven't come up yet with an idea how to clean up the garbage (for example when a skeleton is deleted from a prefab), how to resolve name collisions (with multiple skeletons inside a prefab), nor how to handle nested prefabs. </del>

Any suggestions on how to proceed further with this are welcome (also any comment on the above checks too)

