### PR TITLE
Fix command pipeline state uniform location mismatch

### DIFF
--- a/spine-cocos2dx/src/spine/v4/SkeletonBatch.cpp
+++ b/spine-cocos2dx/src/spine/v4/SkeletonBatch.cpp
@@ -61,9 +61,8 @@ SkeletonBatch::SkeletonBatch () {
 
     auto program = backend::Program::getBuiltinProgram(backend::ProgramType::POSITION_TEXTURE_COLOR);
 	_programState = new backend::ProgramState(program); // new default program state
-	updateProgramStateLayout(_programState);
     for (unsigned int i = 0; i < INITIAL_SIZE; i++) {
-        _commandsPool.push_back(createNewTrianglesCommand());
+        _commandsPool.push_back(newCommand());
     }
     reset();
     // callback after drawing is finished so we can clear out the batch state
@@ -81,25 +80,30 @@ SkeletonBatch::~SkeletonBatch () {
 		delete _commandsPool[i];
 		_commandsPool[i] = nullptr;
 	}
-
 	CC_SAFE_RELEASE(_programState);
 }
 
-void SkeletonBatch::updateProgramStateLayout(cocos2d::backend::ProgramState* programState)
+backend::ProgramState* SkeletonBatch::updateCommandPipelinePS(SkeletonCommand* command, backend::ProgramState* programState)
 {
-	auto vertexLayout = programState->getVertexLayout();
+	auto& currentState = command->getPipelineDescriptor().programState;
+	if(currentState == nullptr || currentState->getProgram() != programState->getProgram()) {
+		CC_SAFE_RELEASE(currentState);
+		currentState = programState->clone();
+		
+		auto vertexLayout = currentState->getVertexLayout();
+		auto locPosition = currentState->getAttributeLocation("a_position");
+		auto locTexcoord = currentState->getAttributeLocation("a_texCoord");
+		auto locColor = currentState->getAttributeLocation("a_color");
+		vertexLayout->setAttribute("a_position", locPosition, backend::VertexFormat::FLOAT3, offsetof(V3F_C4B_T2F, vertices), false);
+		vertexLayout->setAttribute("a_color", locColor, backend::VertexFormat::UBYTE4, offsetof(V3F_C4B_T2F, colors), true);
+		vertexLayout->setAttribute("a_texCoord", locTexcoord, backend::VertexFormat::FLOAT2, offsetof(V3F_C4B_T2F, texCoords), false);
+		vertexLayout->setLayout(sizeof(_vertices[0]));
 
-	auto locPosition = programState->getAttributeLocation("a_position");
-	auto locTexcoord = programState->getAttributeLocation("a_texCoord");
-	auto locColor = programState->getAttributeLocation("a_color");
-	vertexLayout->setAttribute("a_position", locPosition, backend::VertexFormat::FLOAT3, offsetof(V3F_C4B_T2F, vertices), false);
-	vertexLayout->setAttribute("a_color", locColor, backend::VertexFormat::UBYTE4, offsetof(V3F_C4B_T2F, colors), true);
-	vertexLayout->setAttribute("a_texCoord", locTexcoord, backend::VertexFormat::FLOAT2, offsetof(V3F_C4B_T2F, texCoords), false);
-	vertexLayout->setLayout(sizeof(_vertices[0]));
 
-
-	_locMVP = programState->getUniformLocation("u_MVPMatrix");
-	_locTexture = programState->getUniformLocation("u_texture");
+		command->_locMVP = currentState->getUniformLocation("u_MVPMatrix");
+		command->_locTexture = currentState->getUniformLocation("u_texture");
+	}
+	return currentState;
 }
 
 void SkeletonBatch::update (float delta) {
@@ -112,8 +116,8 @@ cocos2d::V3F_C4B_T2F* SkeletonBatch::allocateVertices(uint32_t numVertices) {
 		_vertices.resize((_vertices.size() + numVertices) * 2 + 1);
 		cocos2d::V3F_C4B_T2F* newData = _vertices.data();
 		for (uint32_t i = 0; i < this->_nextFreeCommand; i++) {
-			TrianglesCommand* command = _commandsPool[i];
-			cocos2d::TrianglesCommand::Triangles& triangles = (cocos2d::TrianglesCommand::Triangles&)command->getTriangles();
+			SkeletonCommand* command = _commandsPool[i];
+			SkeletonCommand::Triangles& triangles = (SkeletonCommand::Triangles&)command->getTriangles();
 			triangles.verts = newData + (triangles.verts - oldData);
 		}
 	}
@@ -135,8 +139,8 @@ unsigned short* SkeletonBatch::allocateIndices(uint32_t numIndices) {
 		_indices.ensureCapacity(_indices.size() + numIndices);
 		unsigned short* newData = _indices.buffer();
 		for (uint32_t i = 0; i < this->_nextFreeCommand; i++) {
-			TrianglesCommand* command = _commandsPool[i];
-			cocos2d::TrianglesCommand::Triangles& triangles = (cocos2d::TrianglesCommand::Triangles&)command->getTriangles();
+			SkeletonCommand* command = _commandsPool[i];
+			SkeletonCommand::Triangles& triangles = (SkeletonCommand::Triangles&)command->getTriangles();
 			if (triangles.indices >= oldData && triangles.indices < oldData + oldSize) {
 				triangles.indices = newData + (triangles.indices - oldData);
 			}
@@ -154,7 +158,7 @@ void SkeletonBatch::deallocateIndices(uint32_t numIndices) {
 
 
 cocos2d::TrianglesCommand* SkeletonBatch::addCommand(cocos2d::Renderer* renderer, float globalOrder, cocos2d::Texture2D* texture, backend::ProgramState* programState, cocos2d::BlendFunc blendType, const cocos2d::TrianglesCommand::Triangles& triangles, const cocos2d::Mat4& mv, uint32_t flags) {
-	TrianglesCommand* command = nextFreeCommand();
+	SkeletonCommand* command = nextFreeCommand();
     const cocos2d::Mat4& projectionMat = Director::getInstance()->getMatrix(MATRIX_STACK_TYPE::MATRIX_STACK_PROJECTION);    
 
 	if (programState == nullptr)
@@ -162,17 +166,10 @@ cocos2d::TrianglesCommand* SkeletonBatch::addCommand(cocos2d::Renderer* renderer
 
 	CCASSERT(programState, "programState should not be null");
 
-	auto& pipelinePS = command->getPipelineDescriptor().programState;
-	if (pipelinePS == nullptr || pipelinePS->getProgram() != programState->getProgram()) 
-	{
-		CC_SAFE_RELEASE(pipelinePS);
-		pipelinePS = programState->clone();
-
-		updateProgramStateLayout(pipelinePS);
-	}
+	auto pipelinePS = updateCommandPipelinePS(command, programState);
 	
-	pipelinePS->setUniform(_locMVP, projectionMat.m, sizeof(projectionMat.m));
-	pipelinePS->setTexture(_locTexture, 0, texture->getBackendTexture());
+	pipelinePS->setUniform(command->_locMVP, projectionMat.m, sizeof(projectionMat.m));
+	pipelinePS->setTexture(command->_locTexture, 0, texture->getBackendTexture());
 
 	command->init(globalOrder, texture, blendType, triangles, mv, flags);
 	renderer->addCommand(command);
@@ -185,19 +182,19 @@ void SkeletonBatch::reset() {
 	_indices.setSize(0, 0);
 }
 
-cocos2d::TrianglesCommand* SkeletonBatch::nextFreeCommand() {
+SkeletonCommand* SkeletonBatch::nextFreeCommand() {
     if (_commandsPool.size() <= _nextFreeCommand) {
         unsigned int newSize = _commandsPool.size() * 2 + 1;
         for (int i = _commandsPool.size(); i < newSize; i++) {
-            _commandsPool.push_back(createNewTrianglesCommand());
+            _commandsPool.push_back(newCommand());
         }
     }
     auto* command = _commandsPool[_nextFreeCommand++];
     return command;
 }
 
-cocos2d::TrianglesCommand *SkeletonBatch::createNewTrianglesCommand() {
-    auto* command = new TrianglesCommand();
+SkeletonCommand* SkeletonBatch::newCommand() {
+    auto* command = new SkeletonCommand();
     return command;
 }
 }

--- a/spine-cocos2dx/src/spine/v4/SkeletonBatch.cpp
+++ b/spine-cocos2dx/src/spine/v4/SkeletonBatch.cpp
@@ -86,7 +86,11 @@ SkeletonBatch::~SkeletonBatch () {
 backend::ProgramState* SkeletonBatch::updateCommandPipelinePS(SkeletonCommand* command, backend::ProgramState* programState)
 {
 	auto& currentState = command->getPipelineDescriptor().programState;
+#if defined(ADXE_VERSION)
+	if(currentState == nullptr || currentState->getProgram() != programState->getProgram() || currentState->getUniformID() != programState->getUniformID()) {
+#else
 	if(currentState == nullptr || currentState->getProgram() != programState->getProgram()) {
+#endif
 		CC_SAFE_RELEASE(currentState);
 		currentState = programState->clone();
 		

--- a/spine-cocos2dx/src/spine/v4/SkeletonBatch.h
+++ b/spine-cocos2dx/src/spine/v4/SkeletonBatch.h
@@ -39,6 +39,11 @@
 
 namespace spine {
     
+	struct SkeletonCommand : public cocos2d::TrianglesCommand {
+		cocos2d::backend::UniformLocation _locMVP;
+        cocos2d::backend::UniformLocation _locTexture;
+	};
+	
     class SkeletonBatch {
     public:
         static SkeletonBatch* getInstance ();
@@ -53,7 +58,7 @@ namespace spine {
 		void deallocateIndices(uint32_t numVertices);
 		cocos2d::TrianglesCommand* addCommand(cocos2d::Renderer* renderer, float globalOrder, cocos2d::Texture2D* texture, cocos2d::backend::ProgramState* programState, cocos2d::BlendFunc blendType, const cocos2d::TrianglesCommand::Triangles& triangles, const cocos2d::Mat4& mv, uint32_t flags);
         
-		void updateProgramStateLayout(cocos2d::backend::ProgramState* programState);
+		cocos2d::backend::ProgramState* updateCommandPipelinePS(SkeletonCommand* command, cocos2d::backend::ProgramState* programState);
 
     protected:
         SkeletonBatch ();
@@ -61,17 +66,14 @@ namespace spine {
 		
 		void reset ();
 		
-		cocos2d::TrianglesCommand* nextFreeCommand ();
+		SkeletonCommand* nextFreeCommand ();
 
-        cocos2d::TrianglesCommand* createNewTrianglesCommand();
+        SkeletonCommand* newCommand();
+	
+		cocos2d::backend::ProgramState*                     _programState; // The default program state
 
-        // the default program state for batch draw
-        cocos2d::backend::ProgramState*                     _programState = nullptr;
-        cocos2d::backend::UniformLocation                   _locMVP;
-        cocos2d::backend::UniformLocation                   _locTexture;
-		
 		// pool of commands
-		std::vector<cocos2d::TrianglesCommand*>             _commandsPool;
+		std::vector<SkeletonCommand*>                       _commandsPool;
 		uint32_t                                            _nextFreeCommand;
 		
 		// pool of vertices

--- a/spine-cocos2dx/src/spine/v4/SkeletonBatch.h
+++ b/spine-cocos2dx/src/spine/v4/SkeletonBatch.h
@@ -41,7 +41,7 @@ namespace spine {
     
 	struct SkeletonCommand : public cocos2d::TrianglesCommand {
 		cocos2d::backend::UniformLocation _locMVP;
-        cocos2d::backend::UniformLocation _locTexture;
+		cocos2d::backend::UniformLocation _locTexture;
 	};
 	
     class SkeletonBatch {
@@ -61,14 +61,14 @@ namespace spine {
 		cocos2d::backend::ProgramState* updateCommandPipelinePS(SkeletonCommand* command, cocos2d::backend::ProgramState* programState);
 
     protected:
-        SkeletonBatch ();
-        virtual ~SkeletonBatch ();
+		SkeletonBatch ();
+		virtual ~SkeletonBatch ();
 		
 		void reset ();
 		
 		SkeletonCommand* nextFreeCommand ();
 
-        SkeletonCommand* newCommand();
+		SkeletonCommand* newCommand();
 	
 		cocos2d::backend::ProgramState*                     _programState; // The default program state
 


### PR DESCRIPTION
This is a critical bug when there are more than 1 spine animations with different shader, please take a look