### PR TITLE
[ts] Made AnimationStateListener functions optional

### DIFF
--- a/spine-ts/spine-core/src/AnimationState.ts
+++ b/spine-ts/spine-core/src/AnimationState.ts
@@ -1095,24 +1095,24 @@ export enum EventType {
  * {@link AnimationState#addListener()}. */
 export interface AnimationStateListener {
 	/** Invoked when this entry has been set as the current entry. */
-	start (entry: TrackEntry): void;
+	start? (entry: TrackEntry): void;
 
 	/** Invoked when another entry has replaced this entry as the current entry. This entry may continue being applied for
 	 * mixing. */
-	interrupt (entry: TrackEntry): void;
+	interrupt? (entry: TrackEntry): void;
 
 	/** Invoked when this entry is no longer the current entry and will never be applied again. */
-	end (entry: TrackEntry): void;
+	end? (entry: TrackEntry): void;
 
 	/** Invoked when this entry will be disposed. This may occur without the entry ever being set as the current entry.
 	 * References to the entry should not be kept after dispose is called, as it may be destroyed or reused. */
-	dispose (entry: TrackEntry): void;
+	dispose? (entry: TrackEntry): void;
 
 	/** Invoked every time this entry's animation completes a loop. */
-	complete (entry: TrackEntry): void;
+	complete? (entry: TrackEntry): void;
 
 	/** Invoked when this entry's animation triggers an event. */
-	event (entry: TrackEntry, event: Event): void;
+	event? (entry: TrackEntry, event: Event): void;
 }
 
 export abstract class AnimationStateAdapter implements AnimationStateListener {


### PR DESCRIPTION
All functions in AnimationStateListener are now optional - I believe this better reflects it's intended usage.

I've verified that the code checks for the existence of the functions before running them: https://github.com/EsotericSoftware/spine-runtimes/blob/4.0/spine-ts/spine-core/src/AnimationState.ts#L1042-L1075.

In addition, I've done some tests on some of our projects using pixi-spine, and everything works as expected.