### PR TITLE
[cpp] Fix AABB calculation

### DIFF
--- a/spine-cpp/spine-cpp/src/spine/SkeletonBounds.cpp
+++ b/spine-cpp/spine-cpp/src/spine/SkeletonBounds.cpp
@@ -198,10 +198,10 @@ float SkeletonBounds::getHeight() {
 }
 
 void SkeletonBounds::aabbCompute() {
-	float minX = FLT_MIN;
-	float minY = FLT_MIN;
-	float maxX = FLT_MAX;
-	float maxY = FLT_MAX;
+	float minX = FLT_MAX;
+	float minY = FLT_MAX;
+	float maxX = FLT_MIN;
+	float maxY = FLT_MIN;
 
 	for (size_t i = 0, n = _polygons.size(); i < n; ++i) {
 		spine::Polygon *polygon = _polygons[i];


### PR DESCRIPTION
The AABB calculation uses the wrong initial values, so the bounds are not calculated at all because new values are never bigger/lower than the initial values.