### PR TITLE
[unity] Fix skleton mesh "Identifier uniqueness violation" warning

### DIFF
--- a/spine-unity/Assets/Spine/Editor/spine-unity/Editor/Utility/SpineEditorUtilities.cs
+++ b/spine-unity/Assets/Spine/Editor/spine-unity/Editor/Utility/SpineEditorUtilities.cs
@@ -110,6 +110,7 @@ namespace Spine.Unity.Editor {
 
 		public static bool SetupSpinePrefabMesh(GameObject g, UnityEditor.AssetImporters.AssetImportContext context)
 		{
+			Dictionary<string, int> nameUsageCount = new Dictionary<string, int>();
 			bool wasModified = false;
 			var skeletonRenderers = g.GetComponentsInChildren<SkeletonRenderer>(true);
 			foreach (SkeletonRenderer renderer in skeletonRenderers) {
@@ -125,6 +126,12 @@ namespace Spine.Unity.Editor {
 				if (mesh == null) continue;
 				
 				string meshName = string.Format("Skeleton Prefab Mesh \"{0}\"", renderer.name);
+				if (nameUsageCount.ContainsKey(meshName)) {
+					nameUsageCount[meshName]++;
+					meshName = string.Format("Skeleton Prefab Mesh \"{0} ({1})\"", renderer.name, nameUsageCount[meshName]);
+				} else {
+					nameUsageCount.Add(meshName, 0);
+				}
 				mesh.name = meshName;
 				mesh.hideFlags = HideFlags.None;
 				if (context != null)


### PR DESCRIPTION
To remove the warning a new unique name is created for each mesh, where
an index is added after the renderer name.

Closes #1973