### PR TITLE
[Unity] Sprite Mesh Type Tight causes issues when used to replace attachments

### DIFF
--- a/spine-unity/Assets/Spine/Runtime/spine-unity/Utility/AtlasUtilities.cs
+++ b/spine-unity/Assets/Spine/Runtime/spine-unity/Utility/AtlasUtilities.cs
@@ -198,13 +198,14 @@ namespace Spine.Unity.AttachmentTools {
 			Vector2 boundsMin = bounds.min, boundsMax = bounds.max;
 
 			// Texture space/pixel units
-			Rect spineRect = s.rect.SpineUnityFlipRect(s.texture.height);
+			Rect spineRect = s.textureRect.SpineUnityFlipRect(s.texture.height);
+			Rect originalRect = s.rect;
 			region.width = (int)spineRect.width;
-			region.originalWidth = (int)spineRect.width;
+			region.originalWidth = (int)originalRect.width;
 			region.height = (int)spineRect.height;
-			region.originalHeight = (int)spineRect.height;
-			region.offsetX = spineRect.width * (0.5f - InverseLerp(boundsMin.x, boundsMax.x, 0));
-			region.offsetY = spineRect.height * (0.5f - InverseLerp(boundsMin.y, boundsMax.y, 0));
+			region.originalHeight = (int)originalRect.height;
+			region.offsetX = s.textureRectOffset.x;
+			region.offsetY = s.textureRectOffset.y;
 
 			if (isolatedTexture) {
 				region.u = 0;


### PR DESCRIPTION
Fixes #1884