### PR TITLE
[spine-cpp] Improve RTTI compare performance when compiler string pooling enabled

### DIFF
--- a/spine-cpp/spine-cpp/src/spine/RTTI.cpp
+++ b/spine-cpp/spine-cpp/src/spine/RTTI.cpp
@@ -36,6 +36,22 @@
 
 using namespace spine;
 
+static bool checkCompilerStringPooling() {
+	const char* l1 = "rtti";
+	const char* l2 = "rtti";
+	return l1 == l2;
+}
+
+static bool addressEqual(const char* lhs, const char* rhs) {
+	return lhs == rhs;
+};
+
+static bool stringEqual(const char* lhs, const char* rhs) {
+	return !strcmp(lhs, rhs);
+};
+
+static auto classNameEqual = checkCompilerStringPooling() ? &addressEqual : &stringEqual;
+
 RTTI::RTTI(const char *className) : _className(className), _pBaseRTTI(NULL) {
 }
 
@@ -47,13 +63,13 @@ const char *RTTI::getClassName() const {
 }
 
 bool RTTI::isExactly(const RTTI &rtti) const {
-	return !strcmp(this->_className, rtti._className);
+	return classNameEqual(_className, rtti._className);
 }
 
 bool RTTI::instanceOf(const RTTI &rtti) const {
 	const RTTI *pCompare = this;
 	while (pCompare) {
-		if (!strcmp(pCompare->_className, rtti._className)) return true;
+		if (pCompare->isExactly(rtti)) return true;
 		pCompare = pCompare->_pBaseRTTI;
 	}
 	return false;


### PR DESCRIPTION
This patch will avoid string compare when compiler string pooling enabled, such msvc compiler flag: `/GF`