### PR TITLE
feat (loadTextureAtlas) add option to use file alias

### DIFF
--- a/spine-ts/package-lock.json
+++ b/spine-ts/package-lock.json
@@ -7949,41 +7949,41 @@
     },
     "spine-canvas": {
       "name": "@esotericsoftware/spine-canvas",
-      "version": "4.0.16",
+      "version": "4.0.17",
       "license": "LicenseRef-LICENSE",
       "dependencies": {
-        "@esotericsoftware/spine-core": "^4.0.15"
+        "@esotericsoftware/spine-core": "^4.0.17"
       }
     },
     "spine-core": {
       "name": "@esotericsoftware/spine-core",
-      "version": "4.0.16",
+      "version": "4.0.17",
       "license": "LicenseRef-LICENSE"
     },
     "spine-player": {
       "name": "@esotericsoftware/spine-player",
-      "version": "4.0.16",
+      "version": "4.0.17",
       "license": "LicenseRef-LICENSE",
       "dependencies": {
-        "@esotericsoftware/spine-webgl": "^4.0.15"
+        "@esotericsoftware/spine-webgl": "^4.0.17"
       }
     },
     "spine-threejs": {
       "name": "@esotericsoftware/spine-threejs",
-      "version": "4.0.16",
+      "version": "4.0.17",
       "license": "LicenseRef-LICENSE",
       "dependencies": {
-        "@esotericsoftware/spine-core": "^4.0.15",
+        "@esotericsoftware/spine-core": "^4.0.17",
         "@types/three": "^0.133.1",
         "three": "^0.133.1"
       }
     },
     "spine-webgl": {
       "name": "@esotericsoftware/spine-webgl",
-      "version": "4.0.16",
+      "version": "4.0.17",
       "license": "LicenseRef-LICENSE",
       "dependencies": {
-        "@esotericsoftware/spine-core": "^4.0.16"
+        "@esotericsoftware/spine-core": "^4.0.17"
       }
     }
   },
@@ -7991,7 +7991,7 @@
     "@esotericsoftware/spine-canvas": {
       "version": "file:spine-canvas",
       "requires": {
-        "@esotericsoftware/spine-core": "^4.0.15"
+        "@esotericsoftware/spine-core": "^4.0.17"
       }
     },
     "@esotericsoftware/spine-core": {
@@ -8000,13 +8000,13 @@
     "@esotericsoftware/spine-player": {
       "version": "file:spine-player",
       "requires": {
-        "@esotericsoftware/spine-webgl": "^4.0.15"
+        "@esotericsoftware/spine-webgl": "^4.0.17"
       }
     },
     "@esotericsoftware/spine-threejs": {
       "version": "file:spine-threejs",
       "requires": {
-        "@esotericsoftware/spine-core": "^4.0.15",
+        "@esotericsoftware/spine-core": "^4.0.17",
         "@types/three": "^0.133.1",
         "three": "^0.133.1"
       }
@@ -8014,7 +8014,7 @@
     "@esotericsoftware/spine-webgl": {
       "version": "file:spine-webgl",
       "requires": {
-        "@esotericsoftware/spine-core": "^4.0.16"
+        "@esotericsoftware/spine-core": "^4.0.17"
       }
     },
     "@types/offscreencanvas": {

--- a/spine-ts/spine-core/src/AssetManagerBase.ts
+++ b/spine-ts/spine-core/src/AssetManagerBase.ts
@@ -138,7 +138,8 @@ export class AssetManagerBase implements Disposable {
 
 	loadTextureAtlas (path: string,
 		success: (path: string, atlas: TextureAtlas) => void = null,
-		error: (path: string, message: string) => void = null
+		error: (path: string, message: string) => void = null,
+		fileAlias: {[keyword:string] : string} = null
 	) {
 		let index = path.lastIndexOf("/");
 		let parent = index >= 0 ? path.substring(0, index + 1) : "";
@@ -149,7 +150,7 @@ export class AssetManagerBase implements Disposable {
 				let atlas = new TextureAtlas(atlasText);
 				let toLoad = atlas.pages.length, abort = false;
 				for (let page of atlas.pages) {
-					this.loadTexture(parent + page.name,
+					this.loadTexture(fileAlias == null ? parent + page.name : fileAlias[page.name],
 						(imagePath: string, texture: Texture) => {
 							if (!abort) {
 								page.setTexture(texture);


### PR DESCRIPTION
For Construct 3, in preview mode, the texture file names are changed to blobs with completely different filenames than what is listed in the atlas. So, loadTextureAtalas will not work because the blob file names don't match the page.name.  When Construct 3 is not in preview mode, the normal file names will match the page.name.

To get around this issue, I added an optional parameter to loadTextureAtlas, the object fileAlias, this will allow the Construct 3 plug-in to create a fileAlias object which maps between page.name and the C3 project file names, whether they are aliased or not. If this is not needed, the function performs as it did before.