### PR TITLE
[spine-ts] Fix screen blendmode 

### DIFF
--- a/spine-ts/spine-webgl/src/PolygonBatcher.ts
+++ b/spine-ts/spine-webgl/src/PolygonBatcher.ts
@@ -44,7 +44,8 @@ export class PolygonBatcher implements Disposable {
 	private indicesLength = 0;
 	private srcColorBlend: number;
 	private srcAlphaBlend: number;
-	private dstBlend: number;
+	private dstColorBlend: number;
+	private dstAlphaBlend: number;
 
 	constructor (context: ManagedWebGLRenderingContext | WebGLRenderingContext, twoColorTint: boolean = true, maxVertices: number = 10920) {
 		if (maxVertices > 10920) throw new Error("Can't have more than 10920 triangles per batch: " + maxVertices);
@@ -56,7 +57,8 @@ export class PolygonBatcher implements Disposable {
 		let gl = this.context.gl;
 		this.srcColorBlend = gl.SRC_ALPHA;
 		this.srcAlphaBlend = gl.ONE;
-		this.dstBlend = gl.ONE_MINUS_SRC_ALPHA;
+		this.dstColorBlend = gl.ONE_MINUS_SRC_ALPHA;
+		this.dstAlphaBlend = gl.ONE_MINUS_SRC_ALPHA;
 	}
 
 	begin (shader: Shader) {
@@ -68,18 +70,19 @@ export class PolygonBatcher implements Disposable {
 
 		let gl = this.context.gl;
 		gl.enable(gl.BLEND);
-		gl.blendFuncSeparate(this.srcColorBlend, this.dstBlend, this.srcAlphaBlend, this.dstBlend);
+		gl.blendFuncSeparate(this.srcColorBlend, this.dstColorBlend, this.srcAlphaBlend, this.dstAlphaBlend);
 	}
 
-	setBlendMode (srcColorBlend: number, srcAlphaBlend: number, dstBlend: number) {
-		if (this.srcColorBlend == srcColorBlend && this.srcAlphaBlend == srcAlphaBlend && this.dstBlend == dstBlend) return;
+	setBlendMode (srcColorBlend: number, srcAlphaBlend: number, dstColorBlend: number, dstAlphaBlend = dstColorBlend) {
+		if (this.srcColorBlend == srcColorBlend && this.srcAlphaBlend == srcAlphaBlend && this.dstColorBlend == dstColorBlend && this.dstAlphaBlend == dstAlphaBlend) return;
 		this.srcColorBlend = srcColorBlend;
 		this.srcAlphaBlend = srcAlphaBlend;
-		this.dstBlend = dstBlend;
+		this.dstColorBlend = dstColorBlend;
+		this.dstAlphaBlend = dstAlphaBlend;
 		if (this.isDrawing) {
 			this.flush();
 			let gl = this.context.gl;
-			gl.blendFuncSeparate(srcColorBlend, dstBlend, srcAlphaBlend, dstBlend);
+			gl.blendFuncSeparate(srcColorBlend, dstColorBlend, srcAlphaBlend, dstAlphaBlend);
 		}
 	}
 

--- a/spine-ts/spine-webgl/src/PolygonBatcher.ts
+++ b/spine-ts/spine-webgl/src/PolygonBatcher.ts
@@ -73,7 +73,7 @@ export class PolygonBatcher implements Disposable {
 		gl.blendFuncSeparate(this.srcColorBlend, this.dstColorBlend, this.srcAlphaBlend, this.dstAlphaBlend);
 	}
 
-	setBlendMode (srcColorBlend: number, srcAlphaBlend: number, dstColorBlend: number, dstAlphaBlend = dstColorBlend) {
+	setBlendMode (srcColorBlend: number, srcAlphaBlend: number, dstColorBlend: number, dstAlphaBlend: number = dstColorBlend) {
 		if (this.srcColorBlend == srcColorBlend && this.srcAlphaBlend == srcAlphaBlend && this.dstColorBlend == dstColorBlend && this.dstAlphaBlend == dstAlphaBlend) return;
 		this.srcColorBlend = srcColorBlend;
 		this.srcAlphaBlend = srcAlphaBlend;

--- a/spine-ts/spine-webgl/src/ShapeRenderer.ts
+++ b/spine-ts/spine-webgl/src/ShapeRenderer.ts
@@ -43,7 +43,8 @@ export class ShapeRenderer implements Disposable {
 	private tmp = new Vector2();
 	private srcColorBlend: number;
 	private srcAlphaBlend: number;
-	private dstBlend: number;
+	private dstColorBlend: number;
+	private dstAlphaBlend: number;
 
 	constructor (context: ManagedWebGLRenderingContext | WebGLRenderingContext, maxVertices: number = 10920) {
 		if (maxVertices > 10920) throw new Error("Can't have more than 10920 triangles per batch: " + maxVertices);
@@ -51,8 +52,8 @@ export class ShapeRenderer implements Disposable {
 		this.mesh = new Mesh(context, [new Position2Attribute(), new ColorAttribute()], maxVertices, 0);
 		let gl = this.context.gl;
 		this.srcColorBlend = gl.SRC_ALPHA;
-		this.srcAlphaBlend = gl.ONE;
-		this.dstBlend = gl.ONE_MINUS_SRC_ALPHA;
+		this.dstColorBlend = gl.ONE_MINUS_SRC_ALPHA;
+		this.dstAlphaBlend = gl.ONE_MINUS_SRC_ALPHA;
 	}
 
 	begin (shader: Shader) {
@@ -63,17 +64,19 @@ export class ShapeRenderer implements Disposable {
 
 		let gl = this.context.gl;
 		gl.enable(gl.BLEND);
-		gl.blendFuncSeparate(this.srcColorBlend, this.dstBlend, this.srcAlphaBlend, this.dstBlend);
+		gl.blendFuncSeparate(this.srcColorBlend, this.dstColorBlend, this.srcAlphaBlend, this.dstAlphaBlend);
 	}
 
-	setBlendMode (srcColorBlend: number, srcAlphaBlend: number, dstBlend: number) {
+	setBlendMode (srcColorBlend: number, srcAlphaBlend: number, dstColorBlend: number, dstAlphaBlend = dstColorBlend) {
+		if (this.srcColorBlend == srcColorBlend && this.srcAlphaBlend == srcAlphaBlend && this.dstColorBlend == dstColorBlend && this.dstAlphaBlend == dstAlphaBlend) return;
 		this.srcColorBlend = srcColorBlend;
 		this.srcAlphaBlend = srcAlphaBlend;
-		this.dstBlend = dstBlend;
+		this.dstColorBlend = dstColorBlend;
+		this.dstAlphaBlend = dstAlphaBlend;
 		if (this.isDrawing) {
 			this.flush();
 			let gl = this.context.gl;
-			gl.blendFuncSeparate(srcColorBlend, dstBlend, srcAlphaBlend, dstBlend);
+			gl.blendFuncSeparate(srcColorBlend, dstColorBlend, srcAlphaBlend, dstAlphaBlend);
 		}
 	}
 

--- a/spine-ts/spine-webgl/src/ShapeRenderer.ts
+++ b/spine-ts/spine-webgl/src/ShapeRenderer.ts
@@ -68,7 +68,7 @@ export class ShapeRenderer implements Disposable {
 		gl.blendFuncSeparate(this.srcColorBlend, this.dstColorBlend, this.srcAlphaBlend, this.dstAlphaBlend);
 	}
 
-	setBlendMode (srcColorBlend: number, srcAlphaBlend: number, dstColorBlend: number, dstAlphaBlend = dstColorBlend) {
+	setBlendMode (srcColorBlend: number, srcAlphaBlend: number, dstColorBlend: number, dstAlphaBlend: number = dstColorBlend) {
 		if (this.srcColorBlend == srcColorBlend && this.srcAlphaBlend == srcAlphaBlend && this.dstColorBlend == dstColorBlend && this.dstAlphaBlend == dstAlphaBlend) return;
 		this.srcColorBlend = srcColorBlend;
 		this.srcAlphaBlend = srcAlphaBlend;

--- a/spine-ts/spine-webgl/src/ShapeRenderer.ts
+++ b/spine-ts/spine-webgl/src/ShapeRenderer.ts
@@ -52,6 +52,7 @@ export class ShapeRenderer implements Disposable {
 		this.mesh = new Mesh(context, [new Position2Attribute(), new ColorAttribute()], maxVertices, 0);
 		let gl = this.context.gl;
 		this.srcColorBlend = gl.SRC_ALPHA;
+		this.srcAlphaBlend = gl.ONE;
 		this.dstColorBlend = gl.ONE_MINUS_SRC_ALPHA;
 		this.dstAlphaBlend = gl.ONE_MINUS_SRC_ALPHA;
 	}

--- a/spine-ts/spine-webgl/src/SkeletonRenderer.ts
+++ b/spine-ts/spine-webgl/src/SkeletonRenderer.ts
@@ -168,7 +168,8 @@ export class SkeletonRenderer {
 					batcher.setBlendMode(
 						WebGLBlendModeConverter.getSourceColorGLBlendMode(blendMode, premultipliedAlpha),
 						WebGLBlendModeConverter.getSourceAlphaGLBlendMode(blendMode),
-						WebGLBlendModeConverter.getDestGLBlendMode(blendMode));
+						WebGLBlendModeConverter.getDestColorGLBlendMode(blendMode),
+						WebGLBlendModeConverter.getDestAlphaGLBlendMode(blendMode));
 				}
 
 				if (clipper.isClipping()) {

--- a/spine-ts/spine-webgl/src/WebGL.ts
+++ b/spine-ts/spine-webgl/src/WebGL.ts
@@ -75,7 +75,17 @@ const ONE_MINUS_DST_ALPHA = 0x0305;
 const DST_COLOR = 0x0306;
 
 export class WebGLBlendModeConverter {
-	static getDestGLBlendMode (blendMode: BlendMode) {
+	static getDestColorGLBlendMode (blendMode: BlendMode) {
+		switch (blendMode) {
+			case BlendMode.Normal: return ONE_MINUS_SRC_ALPHA;
+			case BlendMode.Additive: return ONE;
+			case BlendMode.Multiply: return ONE_MINUS_SRC_ALPHA;
+			case BlendMode.Screen: return ONE;
+			default: throw new Error("Unknown blend mode: " + blendMode);
+		}
+	}
+
+	static getDestAlphaGLBlendMode (blendMode: BlendMode) {
 		switch (blendMode) {
 			case BlendMode.Normal: return ONE_MINUS_SRC_ALPHA;
 			case BlendMode.Additive: return ONE;
@@ -90,7 +100,7 @@ export class WebGLBlendModeConverter {
 			case BlendMode.Normal: return premultipliedAlpha ? ONE : SRC_ALPHA;
 			case BlendMode.Additive: return premultipliedAlpha ? ONE : SRC_ALPHA;
 			case BlendMode.Multiply: return DST_COLOR;
-			case BlendMode.Screen: return ONE;
+			case BlendMode.Screen: return SRC_ALPHA;
 			default: throw new Error("Unknown blend mode: " + blendMode);
 		}
 	}
@@ -100,7 +110,7 @@ export class WebGLBlendModeConverter {
 			case BlendMode.Normal: return ONE;
 			case BlendMode.Additive: return ONE;
 			case BlendMode.Multiply: return ONE_MINUS_SRC_ALPHA;
-			case BlendMode.Screen: return ONE_MINUS_SRC_COLOR;
+			case BlendMode.Screen: return SRC_ALPHA;
 			default: throw new Error("Unknown blend mode: " + blendMode);
 		}
 	}


### PR DESCRIPTION
I had an issue with the screen blendmode

In spine it looked like this
![Screenshot from 2022-01-20 11-01-53](https://user-images.githubusercontent.com/2932769/150319341-217e4a01-6d93-4509-9c4f-909431018968.png)

And in webgl it looked like this
![Screenshot from 2022-01-20 11-04-49](https://user-images.githubusercontent.com/2932769/150319294-5e9b8978-3b29-43c7-bfb4-a22c5392ac11.png)

Searching around i found this answer
https://stackoverflow.com/a/23306083

It needed a split of the destination color and alpha blendfunc and resulted in this
![Screenshot from 2022-01-20 11-02-01](https://user-images.githubusercontent.com/2932769/150322018-4f8b33fd-df69-441f-ad2b-b0d0bd9b5df5.png)

which seems more like what is shown in spine