### PR TITLE
Fix compiler warning

### DIFF
--- a/spine-cpp/spine-cpp/include/spine/Extension.h
+++ b/spine-cpp/spine-cpp/include/spine/Extension.h
@@ -104,15 +104,15 @@ namespace spine {
 		virtual ~DefaultSpineExtension();
 
 	protected:
-		virtual void *_alloc(size_t size, const char *file, int line);
+		virtual void *_alloc(size_t size, const char *file, int line) override;
 
-		virtual void *_calloc(size_t size, const char *file, int line);
+		virtual void *_calloc(size_t size, const char *file, int line) override;
 
-		virtual void *_realloc(void *ptr, size_t size, const char *file, int line);
+		virtual void *_realloc(void *ptr, size_t size, const char *file, int line) override;
 
-		virtual void _free(void *mem, const char *file, int line);
+		virtual void _free(void *mem, const char *file, int line) override;
 
-		virtual char *_readFile(const String &path, int *length);
+		virtual char *_readFile(const String &path, int *length) override;
 	};
 
 // This function is to be implemented by engine specific runtimes to provide


### PR DESCRIPTION
Fix compiler warning: 'inconsistent-missing-override'