### PR TITLE
remove strdup(), use common MALLOC_STR instead, for better tracking m…

### DIFF
--- a/spine-c/spine-c/src/spine/SkeletonBinary.c
+++ b/spine-c/spine-c/src/spine/SkeletonBinary.c
@@ -1189,7 +1189,7 @@ spSkeletonData *spSkeletonBinary_readSkeletonData(spSkeletonBinary *self, const 
 	highHash = readInt(input);
 	sprintf(buffer, "%x%x", highHash, lowHash);
 	buffer[31] = 0;
-	skeletonData->hash = strdup(buffer);
+	MALLOC_STR(skeletonData->hash, buffer);
 
 	skeletonData->version = readString(input);
 	if (!strlen(skeletonData->version)) {

--- a/spine-c/spine-c/src/spine/SkeletonJson.c
+++ b/spine-c/spine-c/src/spine/SkeletonJson.c
@@ -34,10 +34,6 @@
 #include <spine/extension.h>
 #include <stdio.h>
 
-#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
-#define strdup _strdup
-#endif
-
 typedef struct {
 	const char *parent;
 	const char *skin;
@@ -930,6 +926,8 @@ spSkeletonData *spSkeletonJson_readSkeletonData(spSkeletonJson *self, const char
 
 	skeleton = Json_getItem(root, "skeleton");
 	if (skeleton) {
+		const char *imagesPath, *audioPath;
+
 		MALLOC_STR(skeletonData->hash, Json_getString(skeleton, "hash", 0));
 		MALLOC_STR(skeletonData->version, Json_getString(skeleton, "spine", 0));
 		skeletonData->x = Json_getFloat(skeleton, "x", 0);
@@ -937,10 +935,16 @@ spSkeletonData *spSkeletonJson_readSkeletonData(spSkeletonJson *self, const char
 		skeletonData->width = Json_getFloat(skeleton, "width", 0);
 		skeletonData->height = Json_getFloat(skeleton, "height", 0);
 		skeletonData->fps = Json_getFloat(skeleton, "fps", 30);
-		skeletonData->imagesPath = Json_getString(skeleton, "images", 0);
-		if (skeletonData->imagesPath) skeletonData->imagesPath = strdup(skeletonData->imagesPath);
-		skeletonData->audioPath = Json_getString(skeleton, "audio", 0);
-		if (skeletonData->audioPath) skeletonData->audioPath = strdup(skeletonData->audioPath);
+
+		imagesPath = Json_getString(skeleton, "images", 0);
+		if (imagesPath) MALLOC_STR(skeletonData->imagesPath, imagesPath);
+		else
+			skeletonData->imagesPath = imagesPath;
+
+		audioPath = Json_getString(skeleton, "audio", 0);
+		if (audioPath) MALLOC_STR(skeletonData->audioPath, audioPath);
+		else
+			skeletonData->audioPath = audioPath;
 	}
 
 	/* Bones. */

--- a/spine-cpp/spine-cpp/src/spine/SkeletonJson.cpp
+++ b/spine-cpp/spine-cpp/src/spine/SkeletonJson.cpp
@@ -73,10 +73,6 @@
 #include <spine/TranslateTimeline.h>
 #include <spine/Vertices.h>
 
-#if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
-#define strdup _strdup
-#endif
-
 using namespace spine;
 
 static float toColor(const char *value, size_t index) {


### PR DESCRIPTION
Hi, I try use my custom memory allocator for spine-c/spine-cpp runtimes and found this old strdup() function. 

The problem with strdup is create untracked memory block inside strdup(), but we still need use FREE(self->hash); later and have problem with custom MALLOC/FREE, cause mismatch strdup()/custom FREE

I rewrite this probably old core, to use common MALLOC_STR



