### PR TITLE
[ts] Fixed bug of reading Unicode from binary data

### DIFF
--- a/spine-ts/spine-core/src/SkeletonBinary.ts
+++ b/spine-ts/spine-core/src/SkeletonBinary.ts
@@ -1022,7 +1022,7 @@ export class BinaryInput {
 		let chars = "";
 		let charCount = 0;
 		for (let i = 0; i < byteCount;) {
-			let b = this.readByte();
+			let b = this.readUnsignedByte();
 			switch (b >> 4) {
 				case 12:
 				case 13:


### PR DESCRIPTION
In file `spine-ts/spine-core/src/SkeletonBinary.ts`, line `1025`:

```typescript
let b = this.readByte();
switch (b >> 4) {
    ...
}
```

When dealing with Korean or Chinese, `b` can be some thing like `0xe4`, which is regarded as a negative number.
Thus, `b>>4` equals to `-2` instead of `14`, causing error `Region not found in atlas: *** (mesh attachment:  ***)`.