### PR TITLE
[ts] Use existing, explicit atlas data instead of relying on an image's current width/height

### DIFF
--- a/spine-ts/spine-core/src/attachments/MeshAttachment.ts
+++ b/spine-ts/spine-core/src/attachments/MeshAttachment.ts
@@ -93,8 +93,8 @@ export class MeshAttachment extends VertexAttachment implements HasTextureRegion
 		let n = this.uvs.length;
 		let u = this.region.u, v = this.region.v, width = 0, height = 0;
 		if (this.region instanceof TextureAtlasRegion) {
-			let region = this.region, image = region.page!.texture!.getImage();
-			let textureWidth = image.width, textureHeight = image.height;
+			let region = this.region, page = region.page;
+			let textureWidth = page.width, textureHeight = page.height;
 			switch (region.degrees) {
 				case 90:
 					u -= (region.originalHeight - region.offsetY - region.height) / textureWidth;


### PR DESCRIPTION
This fixes a bug where UVs would sometimes be wrong if an image's size is not the same as when originally exported.  This could happen in the wild to _any_ project, due to mobile ISPs/browsers that proxy requests and resize images before sending them to clients.
Fixing this also allows `spine-core` to work with engines that:
* use embedded, low-res textures while waiting for high res textures to load
* automatically provide lower resolution textures to low-end devices or low-resolution displays (assuming care is taken with atlas padding upon export)

The issue can be trivially reproduced by resizing `spine-ts/spine-webgl/example/assets/spineboy-pma.png` (down or up, for example to 512x128), and running the WebGL example.  With this fix, the spine runtime generates the same texture coordinates regardless of what size of image the browser happens to load.

Question: I saw references to "non-essential data", is there any chance this data is not available in some circumstances?  I tried all examples and it seems to work fine (as well as fix the actual bug I was encountering while integrating it into my engine).

Possible improvement (though my TypeScript-fu is weak): Probably don't need to declare `getImage()` in `abstract class Texture` in `Texture.d.ts`, nor `_image` nor passing an HTMLImageElement to the constructor, however all of the official consumers of spine-core seem to use these, so maybe best to leave it alone.