### PR TITLE
Fix for Linux build: conversion from 'long long int' to 'const Variant' is ambiguous

### DIFF
--- a/spine-godot/spine_godot/SpineAnimation.cpp
+++ b/spine-godot/spine_godot/SpineAnimation.cpp
@@ -93,7 +93,7 @@ bool SpineAnimation::has_timeline(Array ids) {
 	property_ids.setSize(ids.size(), 0);
 
 	for (int i = 0; i < (int) property_ids.size(); ++i) {
-		property_ids[i] = (spine::PropertyId) ids[i];
+		property_ids[i] = (int64_t) ids[i];
 	}
 	return get_spine_object()->hasTimeline(property_ids);
 }

--- a/spine-godot/spine_godot/SpineTimeline.cpp
+++ b/spine-godot/spine_godot/SpineTimeline.cpp
@@ -88,7 +88,7 @@ Array SpineTimeline::get_property_ids() {
 	auto &ids = get_spine_object()->getPropertyIds();
 	result.resize((int) ids.size());
 	for (int i = 0; i < result.size(); ++i) {
-		result[i] = (spine::PropertyId) ids[i];
+		result[i] = (int64_t) ids[i];
 	}
 	return result;
 }


### PR DESCRIPTION
Was getting build error on Linux/GCC:

```
spine-runtimes/spine-godot/spine_godot/SpineTimeline.cpp:91:40: error: conversion from 'long long int' to 'const Variant' is ambiguous
   91 |   result[i] = (spine::PropertyId) ids[i];
```

I'm not really a C++ dev so not sure if what I've done here is correct, but this resolves my build issue.

GCC version:
`gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0`
