### PR TITLE
[c] Fixed JSON parsing of PathConstraint spacing mode (#2065).

### DIFF
--- a/spine-c/spine-c/src/spine/SkeletonJson.c
+++ b/spine-c/spine-c/src/spine/SkeletonJson.c
@@ -1196,6 +1196,8 @@ spSkeletonData *spSkeletonJson_readSkeletonData(spSkeletonJson *self, const char
 				data->spacingMode = SP_SPACING_MODE_FIXED;
 			else if (strcmp(item, "percent") == 0)
 				data->spacingMode = SP_SPACING_MODE_PERCENT;
+			else
+				data->spacingMode = SP_SPACING_MODE_PROPORTIONAL;
 
 			item = Json_getString(constraintMap, "rotateMode", "tangent");
 			if (strcmp(item, "tangent") == 0) data->rotateMode = SP_ROTATE_MODE_TANGENT;


### PR DESCRIPTION
See 4ec3290b987230a0b71d67c34269ba50f4e5e57f

(#2065 was fixed in spine-cpp, but not spine-c)