### PR TITLE
Corrected Tint black

### DIFF
--- a/spine-cpp/spine-cpp/src/spine/SkeletonJson.cpp
+++ b/spine-cpp/spine-cpp/src/spine/SkeletonJson.cpp
@@ -967,7 +967,7 @@ Animation *SkeletonJson::readAnimation(Json *root, SkeletonData *skeletonData) {
 				toColor(color2, Json::getString(keyMap, "dark", 0), false);
 
 				for (frame = 0, bezier = 0;; ++frame) {
-					timeline->setFrame(frame, time, color.r, color.g, color.b, color.a, color2.g, color2.g, color2.b);
+					timeline->setFrame(frame, time, color.r, color.g, color.b, color.a, color2.r, color2.g, color2.b);
 					nextMap = keyMap->_next;
 					if (!nextMap) {
 						// timeline.shrink(); // BOZO


### PR DESCRIPTION
I was using spine with Godot and the tint black property in the Godot Editor wasn't working correctly because the red channel was discarded and the green channel was being used instead.

This is the result color before the fix.
![before](https://user-images.githubusercontent.com/36154612/180039973-6647214b-7d32-46b0-b9ac-880c188a24cf.PNG)

And this is the result color after the fix.
![after](https://user-images.githubusercontent.com/36154612/180040146-54be9c49-afb4-4e1f-b7ee-e219cd059c2c.PNG)

