### PR TITLE
Fixing compiling errors for Godot 4

### DIFF
--- a/spine-godot/spine_godot/SpineAtlasResource.cpp
+++ b/spine-godot/spine_godot/SpineAtlasResource.cpp
@@ -254,10 +254,15 @@ bool SpineAtlasResourceFormatLoader::handles_type(const String &type) const {
 	return type == "SpineAtlasResource" || ClassDB::is_parent_class(type, "SpineAtlasResource");
 }
 
+#if VERSION_MAJOR > 3
+Error SpineAtlasResourceFormatSaver::save(const Ref<Resource> &resource, const String &path, uint32_t p_flags) {
+#else
 Error SpineAtlasResourceFormatSaver::save(const String &path, const RES &resource, uint32_t flags) {
+#endif
 	Ref<SpineAtlasResource> res = resource;
 	return res->save_to_file(path);
 }
+
 
 void SpineAtlasResourceFormatSaver::get_recognized_extensions(const RES &resource, List<String> *extensions) const {
 	if (Object::cast_to<SpineAtlasResource>(*resource))

--- a/spine-godot/spine_godot/SpineAtlasResource.h
+++ b/spine-godot/spine_godot/SpineAtlasResource.h
@@ -97,7 +97,11 @@ class SpineAtlasResourceFormatSaver : public ResourceFormatSaver {
 	GDCLASS(SpineAtlasResourceFormatSaver, ResourceFormatSaver)
 
 public:
+#if VERSION_MAJOR > 3
+	Error save(const Ref<Resource> &resource, const String &path, uint32_t p_flags = 0) override;
+#else
 	Error save(const String &path, const RES &resource, uint32_t flags) override;
+#endif
 
 	void get_recognized_extensions(const RES &resource, List<String> *extensions) const override;
 

--- a/spine-godot/spine_godot/SpineEditorPlugin.cpp
+++ b/spine-godot/spine_godot/SpineEditorPlugin.cpp
@@ -42,7 +42,12 @@ Error SpineAtlasResourceImportPlugin::import(const String &source_file, const St
 	atlas->load_from_atlas_file(source_file);
 
 	String file_name = vformat("%s.%s", save_path, get_save_extension());
+	#if VERSION_MAJOR > 3
+	auto error = ResourceSaver::save(atlas, file_name);
+	#else
 	auto error = ResourceSaver::save(file_name, atlas);
+	#endif
+	
 	return error;
 }
 
@@ -70,7 +75,13 @@ Error SpineJsonResourceImportPlugin::import(const String &source_file, const Str
 	skeleton_file_res->load_from_file(source_file);
 
 	String file_name = vformat("%s.%s", save_path, get_save_extension());
+
+	#if VERSION_MAJOR > 3
+	auto error = ResourceSaver::save(skeleton_file_res, file_name);
+	#else
 	auto error = ResourceSaver::save(file_name, skeleton_file_res);
+	#endif
+	
 	return error;
 }
 
@@ -83,7 +94,12 @@ Error SpineBinaryResourceImportPlugin::import(const String &source_file, const S
 	skeleton_file_res->load_from_file(source_file);
 
 	String file_name = vformat("%s.%s", save_path, get_save_extension());
+	#if VERSION_MAJOR > 3
+	auto error = ResourceSaver::save(skeleton_file_res, file_name);
+	#else
 	auto error = ResourceSaver::save(file_name, skeleton_file_res);
+	#endif
+
 	return error;
 }
 
@@ -205,7 +221,7 @@ void SpineEditorPropertyAnimationMixes::update_property() {
 		hbox->add_child(delete_button);
 		delete_button->set_text("Remove");
 #if VERSION_MAJOR > 3
-		delete_button->connect("pressed", callable_mp(this, &SpineEditorPropertyAnimationMixes::delete_mix), varray(i));
+		delete_button->connect("pressed", callable_mp(this, &SpineEditorPropertyAnimationMixes::delete_mix).bind(varray(i)));
 #else
 		delete_button->connect("pressed", this, "delete_mix", varray(i));
 #endif

--- a/spine-godot/spine_godot/SpineSkeletonFileResource.cpp
+++ b/spine-godot/spine_godot/SpineSkeletonFileResource.cpp
@@ -94,7 +94,11 @@ bool SpineSkeletonFileResourceFormatLoader::handles_type(const String &type) con
 	return type == "SpineSkeletonFileResource" || ClassDB::is_parent_class(type, "SpineSkeletonFileResource");
 }
 
+#if VERSION_MAJOR > 3
+Error SpineSkeletonFileResourceFormatSaver::save(const Ref<Resource> &resource, const String &path, uint32_t p_flags) {
+#else
 Error SpineSkeletonFileResourceFormatSaver::save(const String &path, const RES &resource, uint32_t flags) {
+#endif
 	Ref<SpineSkeletonFileResource> res = resource;
 	Error error = res->save_to_file(path);
 	return error;

--- a/spine-godot/spine_godot/SpineSkeletonFileResource.h
+++ b/spine-godot/spine_godot/SpineSkeletonFileResource.h
@@ -75,7 +75,11 @@ class SpineSkeletonFileResourceFormatSaver : public ResourceFormatSaver {
 	GDCLASS(SpineSkeletonFileResourceFormatSaver, ResourceFormatSaver);
 
 public:
+#if VERSION_MAJOR > 3
+	Error save(const Ref<Resource> &resource, const String &path, uint32_t p_flags = 0) override;
+#else
 	Error save(const String &path, const RES &resource, uint32_t flags) override;
+#endif
 
 	void get_recognized_extensions(const RES &resource, List<String> *p_extensions) const override;
 


### PR DESCRIPTION
Calling convention for ResourceFormatSaver::save() and Object::connect() have changed in the past days, this PR will allow Godot 4 to compile again.