### PR TITLE
[ts] Fix wrong null check on ShapeRenderer polygon and curve functions

### DIFF
--- a/spine-ts/spine-webgl/src/ShapeRenderer.ts
+++ b/spine-ts/spine-webgl/src/ShapeRenderer.ts
@@ -184,7 +184,7 @@ export class ShapeRenderer implements Disposable {
 	polygon (polygonVertices: ArrayLike<number>, offset: number, count: number, color?: Color) {
 		if (count < 3) throw new Error("Polygon must contain at least 3 vertices");
 		this.check(ShapeType.Line, count * 2);
-		if (color) color = this.color;
+		if (!color) color = this.color;
 		let vertices = this.mesh.getVertices();
 		let idx = this.vertexIndex;
 
@@ -258,7 +258,7 @@ export class ShapeRenderer implements Disposable {
 
 	curve (x1: number, y1: number, cx1: number, cy1: number, cx2: number, cy2: number, x2: number, y2: number, segments: number, color?: Color) {
 		this.check(ShapeType.Line, segments * 2 + 2);
-		if (color) color = this.color;
+		if (!color) color = this.color;
 
 		// Algorithm from: http://www.antigrain.com/research/bezier_interpolation/index.html#PAGE_BEZIER_INTERPOLATION
 		let subdiv_step = 1 / segments;


### PR DESCRIPTION
I was playing with the WebGL demos and I found that when Strict Mode was enabled during [this commit](https://github.com/EsotericSoftware/spine-runtimes/commit/e4372e5329f9fe66b7b97e939d2fa800b04ce99a#diff-9b2ef4add9c3f30d741a3184c535e675cfdfc37b9d0e1975416099cc1070ad37L261-R261) a pair of null check was not translated correctly in 

This lead vine and tank examples to crash when the checkbox to show the paths is checked. The fix should solve the problem.