### PR TITLE
fix error C4146 in MSVS UWP

### DIFF
--- a/spine-c/spine-c/src/spine/SkeletonBinary.c
+++ b/spine-c/spine-c/src/spine/SkeletonBinary.c
@@ -128,7 +128,7 @@ static int readVarint(_dataInput *input, int /*bool*/ optimizePositive) {
 			}
 		}
 	}
-	if (!optimizePositive) value = (((unsigned int) value >> 1) ^ -(value & 1));
+	if (!optimizePositive) value = (((unsigned int) value >> 1) ^ -((int)value & 1));
 	return (int) value;
 }
 


### PR DESCRIPTION
Hello

I have strange error in Visual Studio 2019 v16.11.18
sometimes it constantly reproduced, sometimes go away

but anyway it's code look like really risky
Can you pls check this moment, maybe we have a bug here

For temporary fix I just restore (int) from v4.0

here is compile error, problem in -(value & 1)
lib\spine\SkeletonBinary.c(131,64): error C4146: unary minus operator applied to unsigned type, result still unsigned

Best regards,
Dmitriy Sechin | Programmer