### PR TITLE
 [unity] Fixed excessive UnloadingUnusedAssetsImmediate during build.

### DIFF
--- a/spine-unity/Assets/Spine/Editor/spine-unity/Editor/Utility/SpineBuildProcessor.cs
+++ b/spine-unity/Assets/Spine/Editor/spine-unity/Editor/Utility/SpineBuildProcessor.cs
@@ -98,8 +98,8 @@ namespace Spine.Unity.Editor {
 #endif
 						prefabsToRestore.Add(assetPath);
 					}
-					EditorUtility.UnloadUnusedAssetsImmediate();
 				}
+				EditorUtility.UnloadUnusedAssetsImmediate();
 				AssetDatabase.StopAssetEditing();
 #if !HAS_SAVE_ASSET_IF_DIRTY
 				if (prefabAssets.Length > 0)


### PR DESCRIPTION
Instead of calling `EditorUtility.UnloadUnusedAssetsImmediate()` for each prefab in the project, it is now only called once. 


In our project this reduced build times by ~3 minutes, and it was also the main culprit for long build times (iOS export). We have around 2300+ prefabs.

In my testing this resulted in the same build as calling it for each prefab.

Before:
![image](https://user-images.githubusercontent.com/26636673/192511278-a5ee2716-e6e8-439d-843b-2c386adc575c.png)
After:
<img width="791" alt="image" src="https://user-images.githubusercontent.com/26636673/192511248-9a205da6-6a0c-49d3-8af9-8c64c6c996fd.png">
