### PR TITLE
[unity] Added depth normal pass to sprite shader required by version below URP 12.0.0.

### DIFF
--- a/spine-unity/Modules/com.esotericsoftware.spine.urp-shaders/Shaders/Include/Spine-Sprite-DepthNormalPass-URP.hlsl
+++ b/spine-unity/Modules/com.esotericsoftware.spine.urp-shaders/Shaders/Include/Spine-Sprite-DepthNormalPass-URP.hlsl
@@ -1,0 +1,45 @@
+#ifndef SPRITES_DEPTH_NORMAL_PASS_URP_INCLUDED
+#define SPRITES_DEPTH_NORMAL_PASS_URP_INCLUDED
+
+#include "Include/Spine-Sprite-Common-URP.hlsl"
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+struct AttributesSprite
+{
+	float4 positionOS   : POSITION;
+	float3 normalOS     : NORMAL;
+	float4 vertexColor : COLOR;
+	float2 texcoord     : TEXCOORD0;
+	UNITY_VERTEX_INPUT_INSTANCE_ID
+};
+
+struct VaryingsSprite
+{
+	float4 positionCS   : SV_POSITION;
+	float4 texcoordAndAlpha: TEXCOORD0;
+	float3 normalWS     : TEXCOORD1;
+	UNITY_VERTEX_INPUT_INSTANCE_ID
+	UNITY_VERTEX_OUTPUT_STEREO
+};
+
+VaryingsSprite DepthNormalVertexSprite(AttributesSprite input)
+{
+	VaryingsSprite output = (VaryingsSprite)0;
+	UNITY_SETUP_INSTANCE_ID(input);
+	UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+	output.texcoordAndAlpha.xyz = float3(TRANSFORM_TEX(input.texcoord, _MainTex).xy, 0);
+	output.texcoordAndAlpha.a = input.vertexColor.a * _Color.a;
+	output.positionCS = TransformObjectToHClip(input.positionOS.xyz);
+	output.normalWS = NormalizeNormalPerVertex(input.normalOS);
+	return output;
+}
+
+half4 DepthNormalFragmentSprite(VaryingsSprite input) : SV_TARGET
+{
+	fixed4 texureColor = tex2D(_MainTex, input.texcoordAndAlpha.xy);
+	clip(texureColor.a * input.texcoordAndAlpha.a - _Cutoff);
+	return half4(PackNormalOctRectEncode(TransformWorldToViewDir(input.normalWS, true)), 0.0, 0.0);
+}
+
+#endif

--- a/spine-unity/Modules/com.esotericsoftware.spine.urp-shaders/Shaders/Include/Spine-Sprite-DepthNormalPass-URP.hlsl.meta
+++ b/spine-unity/Modules/com.esotericsoftware.spine.urp-shaders/Shaders/Include/Spine-Sprite-DepthNormalPass-URP.hlsl.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d056e751c0a21b446bd1120602271812
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/spine-unity/Modules/com.esotericsoftware.spine.urp-shaders/Shaders/Spine-Sprite-URP.shader
+++ b/spine-unity/Modules/com.esotericsoftware.spine.urp-shaders/Shaders/Spine-Sprite-URP.shader
@@ -202,6 +202,41 @@ Shader "Universal Render Pipeline/Spine/Sprite"
 			#include "Include/Spine-Sprite-DepthOnlyPass-URP.hlsl"
 			ENDHLSL
 		}
+		
+		Pass
+		{
+			Name "DepthNormals"
+			Tags{"LightMode" = "DepthNormals"}
+
+			ZWrite On
+			Cull Off
+
+			HLSLPROGRAM
+			// Required to compile gles 2.0 with standard srp library
+			#pragma prefer_hlslcc gles
+			#pragma exclude_renderers d3d11_9x
+
+			#pragma vertex DepthNormalVertexSprite
+			#pragma fragment DepthNormalFragmentSprite
+
+			// -------------------------------------
+			// Material Keywords
+			#pragma shader_feature _NORMALMAP
+			#pragma shader_feature _ALPHATEST_ON
+			#pragma shader_feature _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+
+			//--------------------------------------
+			// GPU Instancing
+			#pragma multi_compile_instancing
+
+			#define USE_URP
+			#define fixed4 half4
+			#define fixed3 half3
+			#define fixed half
+			#include "Include/Spine-Input-Sprite-URP.hlsl"
+			#include "Include/Spine-Sprite-DepthNormalPass-URP.hlsl"
+			ENDHLSL
+		}
 
 		Pass
 		{


### PR DESCRIPTION
In versions below URP 12.0.0, `DepthNormals` pass must also be applied to properly apply some post-processing effects. ([URP 12.0.0 changelog](https://docs.unity3d.com/Packages/com.unity.render-pipelines.universal@12.1/changelog/CHANGELOG.html#changed-2))

Currently, this Unity URP package has a URP dependency written under 12.0.0, so I think it should render normally even in previous versions. 
I fixed the Spine Sprite shader that can be involved in the depth values.