### PR TITLE
fix IKConstraint apply error in spine-cpp

### DIFF
--- a/spine-cpp/spine-cpp/src/spine/IkConstraint.cpp
+++ b/spine-cpp/spine-cpp/src/spine/IkConstraint.cpp
@@ -44,11 +44,11 @@ using namespace spine;
 RTTI_IMPL(IkConstraint, Updatable)
 
 void IkConstraint::apply(Bone &bone, float targetX, float targetY, bool compress, bool stretch, bool uniform, float alpha) {
+	if (!bone._appliedValid) bone.updateAppliedTransform();
 	Bone *p = bone.getParent();
 	float pa = p->_a, pb = p->_b, pc = p->_c, pd = p->_d;
 	float rotationIK = -bone._ashearX - bone._arotation;
 	float tx = 0, ty = 0;
-    if (!bone._appliedValid) bone.updateAppliedTransform();
 
 	switch(bone._data.getTransformMode()) {
         case TransformMode_OnlyTranslation:


### PR DESCRIPTION
#2198  Compare ts and cpp version, this line is different, the issue is fixed after we swap this line.

![image](https://user-images.githubusercontent.com/4241137/203496899-41f027d3-c7a2-42c3-993c-91a4d0aa1cab.png)

This is fixed by [@kenshin](https://forum.cocos.org/u/huanxinyin/summary) at forum.cocos.org