### PR TITLE
[godot] Update parse_property signature for Godot 4

### DIFF
--- a/spine-godot/spine_godot/SpineEditorPlugin.cpp
+++ b/spine-godot/spine_godot/SpineEditorPlugin.cpp
@@ -115,7 +115,7 @@ bool SpineSkeletonDataResourceInspectorPlugin::can_handle(Object *object) {
 }
 
 #if VERSION_MAJOR > 3
-bool SpineSkeletonDataResourceInspectorPlugin::parse_property(Object *object, const Variant::Type type, const String &path, const PropertyHint hint, const String &hint_text, const uint32_t usage, const bool wide) {
+bool SpineSkeletonDataResourceInspectorPlugin::parse_property(Object *object, const Variant::Type type, const String &path, const PropertyHint hint, const String &hint_text, const BitField<PropertyUsageFlags> usage, const bool wide) {
 #else
 bool SpineSkeletonDataResourceInspectorPlugin::parse_property(Object *object, Variant::Type type, const String &path,
 															  PropertyHint hint, const String &hint_text, int usage) {

--- a/spine-godot/spine_godot/SpineEditorPlugin.h
+++ b/spine-godot/spine_godot/SpineEditorPlugin.h
@@ -165,7 +165,7 @@ class SpineSkeletonDataResourceInspectorPlugin : public EditorInspectorPlugin {
 public:
 	bool can_handle(Object *object) override;
 #if VERSION_MAJOR > 3
-	bool parse_property(Object *object, Variant::Type type, const String &path, PropertyHint hint, const String &hint_text, uint32_t usage, bool wide) override;
+	bool parse_property(Object *object, Variant::Type type, const String &path, PropertyHint hint, const String &hint_text, const BitField<PropertyUsageFlags> usage, bool wide) override;
 #else
 	bool parse_property(Object *object, Variant::Type type, const String &path, PropertyHint hint, const String &hint_text, int usage) override;
 #endif


### PR DESCRIPTION
This gets the Godot 4 plugin building correctly again after a signature change.