### PR TITLE
[spine-c] Fix crash when skeleton `hash` or `spine` doesn't exist in JSON file

### DIFF
--- a/spine-c/spine-c/src/spine/SkeletonJson.c
+++ b/spine-c/spine-c/src/spine/SkeletonJson.c
@@ -984,8 +984,8 @@ spSkeletonData *spSkeletonJson_readSkeletonData(spSkeletonJson *self, const char
 
 	skeleton = Json_getItem(root, "skeleton");
 	if (skeleton) {
-		MALLOC_STR(skeletonData->hash, Json_getString(skeleton, "hash", 0));
-		MALLOC_STR(skeletonData->version, Json_getString(skeleton, "spine", 0));
+		MALLOC_STR(skeletonData->hash, Json_getString(skeleton, "hash", "0"));
+		MALLOC_STR(skeletonData->version, Json_getString(skeleton, "spine", "0"));
 		if (!string_starts_with(skeletonData->version, SPINE_VERSION_STRING)) {
 			char errorMsg[255];
 			sprintf(errorMsg, "Skeleton version %s does not match runtime version %s", skeletonData->version, SPINE_VERSION_STRING);


### PR DESCRIPTION
If String value doesn't exist, `Json_getString(Json *json, const char *name, const char *defaultValue)`  returns `defaultValue` which is `const char*`. 
In such case, using `0` like here

```
Json_getString(skeleton, "hash", 0);
```
`Json_getString()` will return `null` pointer, which will crash in `MALLOC_STR(TO, FROM)` macros on `strlen(FROM)`.

To avoid it, here should be used a default string value, like `"0"`.

(I've sent CLA)