### PR TITLE
[libgdx] fix setting the color format of packedColor and packedDarkColor in TwoColorPolygonBatch. 

### DIFF
--- a/spine-libgdx/spine-libgdx/src/com/esotericsoftware/spine/utils/TwoColorPolygonBatch.java
+++ b/spine-libgdx/spine-libgdx/src/com/esotericsoftware/spine/utils/TwoColorPolygonBatch.java
@@ -165,7 +165,7 @@ public class TwoColorPolygonBatch implements PolygonBatch {
 
 	@Override
 	public void setPackedColor (float packedColor) {
-		Color.rgba8888ToColor(light, NumberUtils.floatToIntColor(packedColor));
+		Color.abgr8888ToColor(light, packedColor);
 		lightPacked = packedColor;
 	}
 
@@ -190,7 +190,7 @@ public class TwoColorPolygonBatch implements PolygonBatch {
 	}
 
 	public void setPackedDarkColor (float packedColor) {
-		Color.rgba8888ToColor(dark, NumberUtils.floatToIntColor(packedColor));
+		Color.abgr8888ToColor(dark, packedColor);
 		this.darkPacked = packedColor;
 	}
 


### PR DESCRIPTION
The color format of packedColor and packedDarkColor is abgr8888, not rgba888.