### PR TITLE
Feature4.1/godot performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,7 +171,9 @@ spine-godot/spine_godot/spine-cpp
 spine-godot/spine_godot/__pycache__
 spine-godot/example/.import
 spine-godot/spine_godot/*.obj
+*.obj
 *.bc
+*.o
 spine-godot/example/.godot
 spine-godot/example-v4/.godot
 spine-cocos2dx/example/build-macos

--- a/spine-cpp/spine-cpp/include/spine/SpineString.h
+++ b/spine-cpp/spine-cpp/include/spine/SpineString.h
@@ -39,10 +39,11 @@
 namespace spine {
 	class SP_API String : public SpineObject {
 	public:
-		String() : _length(0), _buffer(NULL) {
+		String() : _length(0), _buffer(NULL), _tempowner(true) {
 		}
 
-		String(const char *chars, bool own = false) {
+		String(const char *chars, bool own = false, bool tofree = true) {
+			_tempowner = tofree;
 			if (!chars) {
 				_length = 0;
 				_buffer = NULL;
@@ -58,6 +59,7 @@ namespace spine {
 		}
 
 		String(const String &other) {
+			_tempowner = true;
 			if (!other._buffer) {
 				_length = 0;
 				_buffer = NULL;
@@ -82,7 +84,7 @@ namespace spine {
 
 		void own(const String &other) {
 			if (this == &other) return;
-			if (_buffer) {
+			if (_buffer && _tempowner) {
 				SpineExtension::free(_buffer, __FILE__, __LINE__);
 			}
 			_length = other._length;
@@ -93,7 +95,7 @@ namespace spine {
 
 		void own(const char *chars) {
 			if (_buffer == chars) return;
-			if (_buffer) {
+			if (_buffer && _tempowner) {
 				SpineExtension::free(_buffer, __FILE__, __LINE__);
 			}
 
@@ -113,7 +115,7 @@ namespace spine {
 
 		String &operator=(const String &other) {
 			if (this == &other) return *this;
-			if (_buffer) {
+			if (_buffer && _tempowner) {
 				SpineExtension::free(_buffer, __FILE__, __LINE__);
 			}
 			if (!other._buffer) {
@@ -129,7 +131,7 @@ namespace spine {
 
 		String &operator=(const char *chars) {
 			if (_buffer == chars) return *this;
-			if (_buffer) {
+			if (_buffer && _tempowner) {
 				SpineExtension::free(_buffer, __FILE__, __LINE__);
 			}
 			if (!chars) {
@@ -200,7 +202,7 @@ namespace spine {
 		}
 
 		~String() {
-			if (_buffer) {
+			if (_buffer && _tempowner) {
 				SpineExtension::free(_buffer, __FILE__, __LINE__);
 			}
 		}
@@ -208,6 +210,7 @@ namespace spine {
 	private:
 		mutable size_t _length;
 		mutable char *_buffer;
+		mutable bool _tempowner;
 	};
 }
 

--- a/spine-godot/spine_godot/SpineAnimationTrack.cpp
+++ b/spine-godot/spine_godot/SpineAnimationTrack.cpp
@@ -114,9 +114,9 @@ void SpineAnimationTrack::_notification(int what) {
 			sprite = Object::cast_to<SpineSprite>(get_parent());
 			if (sprite)
 #if VERSION_MAJOR > 3
-				sprite->connect("before_animation_state_update", callable_mp(this, &SpineAnimationTrack::update_animation_state));
+				sprite->connect(SNAME("before_animation_state_update"), callable_mp(this, &SpineAnimationTrack::update_animation_state));
 #else
-				sprite->connect("before_animation_state_update", this, "update_animation_state");
+				sprite->connect(SNAME("before_animation_state_update"), this, SNAME("update_animation_state"));
 #endif
 			NOTIFY_PROPERTY_LIST_CHANGED();
 			break;
@@ -128,9 +128,9 @@ void SpineAnimationTrack::_notification(int what) {
 		case NOTIFICATION_UNPARENTED: {
 			if (sprite) {
 #if VERSION_MAJOR > 3
-				sprite->disconnect("before_animation_state_update", callable_mp(this, &SpineAnimationTrack::update_animation_state));
+				sprite->disconnect(SNAME("before_animation_state_update"), callable_mp(this, &SpineAnimationTrack::update_animation_state));
 #else
-				sprite->disconnect("before_animation_state_update", this, "update_animation_state");
+				sprite->disconnect(SNAME("before_animation_state_update"), this, SNAME("update_animation_state"));
 #endif
 				sprite = nullptr;
 			}

--- a/spine-godot/spine_godot/SpineBoneNode.cpp
+++ b/spine-godot/spine_godot/SpineBoneNode.cpp
@@ -59,9 +59,9 @@ void SpineBoneNode::_notification(int what) {
 			SpineSprite *sprite = find_parent_sprite();
 			if (sprite) {
 #if VERSION_MAJOR > 3
-				sprite->connect("world_transforms_changed", callable_mp(this, &SpineBoneNode::on_world_transforms_changed));
+				sprite->connect(SNAME("world_transforms_changed"), callable_mp(this, &SpineBoneNode::on_world_transforms_changed));
 #else
-				sprite->connect("world_transforms_changed", this, "_on_world_transforms_changed");
+				sprite->connect(SNAME("world_transforms_changed"), this, SNAME("_on_world_transforms_changed"));
 #endif
 				update_transform(sprite);
 #if VERSION_MAJOR == 3
@@ -83,9 +83,9 @@ void SpineBoneNode::_notification(int what) {
 			SpineSprite *sprite = find_parent_sprite();
 			if (sprite) {
 #if VERSION_MAJOR > 3
-				sprite->disconnect("world_transforms_changed", callable_mp(this, &SpineBoneNode::on_world_transforms_changed));
+				sprite->disconnect(SNAME("world_transforms_changed"), callable_mp(this, &SpineBoneNode::on_world_transforms_changed));
 #else
-				sprite->disconnect("world_transforms_changed", this, "_on_world_transforms_changed");
+				sprite->disconnect(SNAME("world_transforms_changed"), this, SNAME("_on_world_transforms_changed"));
 #endif
 			}
 			break;

--- a/spine-godot/spine_godot/SpineCommon.h
+++ b/spine-godot/spine_godot/SpineCommon.h
@@ -56,6 +56,9 @@
 #define VARIANT_FLOAT Variant::REAL
 #define GDREGISTER_CLASS(x) ClassDB::register_class<x>()
 #define GEOMETRY2D Geometry
+#ifndef SNAME
+#define SNAME(m_arg) ([]() -> const StringName & { static StringName sname = _scs_create(m_arg); return sname; })()
+#endif
 #endif
 
 #define SPINE_CHECK(obj, ret)                      \
@@ -65,6 +68,7 @@
 	}
 
 #define SPINE_STRING(x) spine::String((x).utf8())
+#define SPINE_STRING_TMP(x) spine::String((x).utf8(), true, false)
 
 // Can't do template classes with Godot's object model :(
 class SpineObjectWrapper : public REFCOUNTED {
@@ -81,9 +85,9 @@ protected:
 	void spine_objects_invalidated() {
 		spine_object = nullptr;
 #if VERSION_MAJOR > 3
-		spine_owner->disconnect("_internal_spine_objects_invalidated", callable_mp(this, &SpineObjectWrapper::spine_objects_invalidated));
+		spine_owner->disconnect(SNAME("_internal_spine_objects_invalidated"), callable_mp(this, &SpineObjectWrapper::spine_objects_invalidated));
 #else
-		spine_owner->disconnect("_internal_spine_objects_invalidated", this, "_internal_spine_objects_invalidated");
+		spine_owner->disconnect(SNAME("_internal_spine_objects_invalidated"), this, SNAME("_internal_spine_objects_invalidated"));
 #endif
 	}
 
@@ -108,9 +112,9 @@ protected:
 		spine_owner = (Object *) _owner;
 		spine_object = _object;
 #if VERSION_MAJOR > 3
-		spine_owner->connect("_internal_spine_objects_invalidated", callable_mp(this, &SpineObjectWrapper::spine_objects_invalidated));
+		spine_owner->connect(SNAME("_internal_spine_objects_invalidated"), callable_mp(this, &SpineObjectWrapper::spine_objects_invalidated));
 #else
-		spine_owner->connect("_internal_spine_objects_invalidated", this, "_internal_spine_objects_invalidated");
+		spine_owner->connect(SNAME("_internal_spine_objects_invalidated"), this, SNAME("_internal_spine_objects_invalidated"));
 #endif
 	}
 

--- a/spine-godot/spine_godot/SpineEditorPlugin.cpp
+++ b/spine-godot/spine_godot/SpineEditorPlugin.cpp
@@ -220,18 +220,18 @@ void SpineEditorPropertyAnimationMixes::update_property() {
 		hbox->add_child(delete_button);
 		delete_button->set_text("Remove");
 #if VERSION_MAJOR > 3
-		delete_button->connect("pressed", callable_mp(this, &SpineEditorPropertyAnimationMixes::delete_mix).bind(varray(i)));
+		delete_button->connect(SNAME("pressed"), callable_mp(this, &SpineEditorPropertyAnimationMixes::delete_mix).bind(varray(i)));
 #else
-		delete_button->connect("pressed", this, "delete_mix", varray(i));
+		delete_button->connect(SNAME("pressed"), this, SNAME("delete_mix"), varray(i));
 #endif
 	}
 
 	auto add_mix_button = memnew(Button);
 	add_mix_button->set_text("Add mix");
 #if VERSION_MAJOR > 3
-	add_mix_button->connect("pressed", callable_mp(this, &SpineEditorPropertyAnimationMixes::add_mix));
+	add_mix_button->connect(SNAME("pressed"), callable_mp(this, &SpineEditorPropertyAnimationMixes::add_mix));
 #else
-	add_mix_button->connect("pressed", this, "add_mix");
+	add_mix_button->connect(SNAME("pressed"), this, SNAME("add_mix"));
 #endif
 	container->add_child(add_mix_button);
 
@@ -312,9 +312,9 @@ void SpineEditorPropertyAnimationMix::update_property() {
 	from_enum->set_object_and_property(mix, "from");
 	from_enum->update_property();
 #if VERSION_MAJOR > 3
-	from_enum->connect("property_changed", callable_mp(this, &SpineEditorPropertyAnimationMix::data_changed));
+	from_enum->connect(SNAME("property_changed"), callable_mp(this, &SpineEditorPropertyAnimationMix::data_changed));
 #else
-	from_enum->connect("property_changed", this, "data_changed");
+	from_enum->connect(SNAME("property_changed"), this, SNAME("data_changed"));
 #endif
 	container->add_child(from_enum);
 
@@ -326,9 +326,9 @@ void SpineEditorPropertyAnimationMix::update_property() {
 	to_enum->set_object_and_property(mix, "to");
 	to_enum->update_property();
 #if VERSION_MAJOR > 3
-	to_enum->connect("property_changed", callable_mp(this, &SpineEditorPropertyAnimationMix::data_changed));
+	to_enum->connect(SNAME("property_changed"), callable_mp(this, &SpineEditorPropertyAnimationMix::data_changed));
 #else
-	to_enum->connect("property_changed", this, "data_changed");
+	to_enum->connect(SNAME("property_changed"), this, SNAME("data_changed"));
 #endif
 	container->add_child(to_enum);
 
@@ -340,9 +340,9 @@ void SpineEditorPropertyAnimationMix::update_property() {
 	mix_float->set_object_and_property(mix, "mix");
 	mix_float->update_property();
 #if VERSION_MAJOR > 3
-	mix_float->connect("property_changed", callable_mp(this, &SpineEditorPropertyAnimationMix::data_changed));
+	mix_float->connect(SNAME("property_changed"), callable_mp(this, &SpineEditorPropertyAnimationMix::data_changed));
 #else
-	mix_float->connect("property_changed", this, "data_changed");
+	mix_float->connect(SNAME("property_changed"), this, SNAME("data_changed"));
 #endif
 	container->add_child(mix_float);
 

--- a/spine-godot/spine_godot/SpineSkeleton.cpp
+++ b/spine-godot/spine_godot/SpineSkeleton.cpp
@@ -113,26 +113,34 @@ void SpineSkeleton::set_slots_to_setup_pose() {
 Ref<SpineBone> SpineSkeleton::find_bone(const String &name) {
 	SPINE_CHECK(skeleton, nullptr)
 	if (EMPTY(name)) return nullptr;
-	auto bone = skeleton->findBone(SPINE_STRING(name));
+	auto bone = skeleton->findBone(SPINE_STRING_TMP(name));
 	if (!bone) return nullptr;
+	if (_cached_bones.count(bone) > 0 ) {
+		return _cached_bones[bone];
+	}
 	Ref<SpineBone> bone_ref(memnew(SpineBone));
 	bone_ref->set_spine_object(sprite, bone);
+	_cached_bones[bone] = bone_ref;
 	return bone_ref;
 }
 
 Ref<SpineSlot> SpineSkeleton::find_slot(const String &name) {
 	SPINE_CHECK(skeleton, nullptr)
 	if (EMPTY(name)) return nullptr;
-	auto slot = skeleton->findSlot(SPINE_STRING(name));
+	auto slot = skeleton->findSlot(SPINE_STRING_TMP(name));
 	if (!slot) return nullptr;
+	if (_cached_slots.count(slot) > 0 ) {
+		return _cached_slots[slot];
+	}
 	Ref<SpineSlot> slot_ref(memnew(SpineSlot));
 	slot_ref->set_spine_object(sprite, slot);
+	_cached_slots[slot] = slot_ref;
 	return slot_ref;
 }
 
 void SpineSkeleton::set_skin_by_name(const String &skin_name) {
 	SPINE_CHECK(skeleton, )
-	skeleton->setSkin(SPINE_STRING(skin_name));
+	skeleton->setSkin(SPINE_STRING_TMP(skin_name));
 }
 
 void SpineSkeleton::set_skin(Ref<SpineSkin> new_skin) {
@@ -144,7 +152,7 @@ void SpineSkeleton::set_skin(Ref<SpineSkin> new_skin) {
 
 Ref<SpineAttachment> SpineSkeleton::get_attachment_by_slot_name(const String &slot_name, const String &attachment_name) {
 	SPINE_CHECK(skeleton, nullptr)
-	auto attachment = skeleton->getAttachment(SPINE_STRING(slot_name), SPINE_STRING(attachment_name));
+	auto attachment = skeleton->getAttachment(SPINE_STRING_TMP(slot_name), SPINE_STRING_TMP(attachment_name));
 	if (!attachment) return nullptr;
 	Ref<SpineAttachment> attachment_ref(memnew(SpineAttachment));
 	attachment_ref->set_spine_object(*sprite->get_skeleton_data_res(), attachment);
@@ -153,7 +161,7 @@ Ref<SpineAttachment> SpineSkeleton::get_attachment_by_slot_name(const String &sl
 
 Ref<SpineAttachment> SpineSkeleton::get_attachment_by_slot_index(int slot_index, const String &attachment_name) {
 	SPINE_CHECK(skeleton, nullptr)
-	auto attachment = skeleton->getAttachment(slot_index, SPINE_STRING(attachment_name));
+	auto attachment = skeleton->getAttachment(slot_index, SPINE_STRING_TMP(attachment_name));
 	if (!attachment) return nullptr;
 	Ref<SpineAttachment> attachment_ref(memnew(SpineAttachment));
 	attachment_ref->set_spine_object(*sprite->get_skeleton_data_res(), attachment);
@@ -168,7 +176,7 @@ void SpineSkeleton::set_attachment(const String &slot_name, const String &attach
 Ref<SpineIkConstraint> SpineSkeleton::find_ik_constraint(const String &constraint_name) {
 	SPINE_CHECK(skeleton, nullptr)
 	if (EMPTY(constraint_name)) return nullptr;
-	auto constraint = skeleton->findIkConstraint(SPINE_STRING(constraint_name));
+	auto constraint = skeleton->findIkConstraint(SPINE_STRING_TMP(constraint_name));
 	if (!constraint) return nullptr;
 	Ref<SpineIkConstraint> constraint_ref(memnew(SpineIkConstraint));
 	constraint_ref->set_spine_object(sprite, constraint);
@@ -178,7 +186,7 @@ Ref<SpineIkConstraint> SpineSkeleton::find_ik_constraint(const String &constrain
 Ref<SpineTransformConstraint> SpineSkeleton::find_transform_constraint(const String &constraint_name) {
 	SPINE_CHECK(skeleton, nullptr)
 	if (EMPTY(constraint_name)) return nullptr;
-	auto constraint = skeleton->findTransformConstraint(SPINE_STRING(constraint_name));
+	auto constraint = skeleton->findTransformConstraint(SPINE_STRING_TMP(constraint_name));
 	if (!constraint) return nullptr;
 	Ref<SpineTransformConstraint> constraint_ref(memnew(SpineTransformConstraint));
 	constraint_ref->set_spine_object(sprite, constraint);
@@ -188,7 +196,7 @@ Ref<SpineTransformConstraint> SpineSkeleton::find_transform_constraint(const Str
 Ref<SpinePathConstraint> SpineSkeleton::find_path_constraint(const String &constraint_name) {
 	SPINE_CHECK(skeleton, nullptr)
 	if (EMPTY(constraint_name)) return nullptr;
-	auto constraint = skeleton->findPathConstraint(SPINE_STRING(constraint_name));
+	auto constraint = skeleton->findPathConstraint(SPINE_STRING_TMP(constraint_name));
 	if (!constraint) return nullptr;
 	Ref<SpinePathConstraint> constraint_ref(memnew(SpinePathConstraint));
 	constraint_ref->set_spine_object(sprite, constraint);

--- a/spine-godot/spine_godot/SpineSkeleton.h
+++ b/spine-godot/spine_godot/SpineSkeleton.h
@@ -37,6 +37,8 @@
 #include "SpineTransformConstraint.h"
 #include "SpinePathConstraint.h"
 
+#include <unordered_map>
+
 class SpineSprite;
 
 class SpineSkeleton : public REFCOUNTED {
@@ -65,6 +67,9 @@ private:
 	SpineSprite *sprite;
 	spine::Vector<float> bounds_vertex_buffer;
 	Ref<SpineSkin> last_skin;
+
+	std::unordered_map<spine::Bone*, Ref<SpineBone>> _cached_bones;
+	std::unordered_map<spine::Slot*, Ref<SpineSlot>> _cached_slots;
 
 public:
 	SpineSkeleton();

--- a/spine-godot/spine_godot/SpineSkeletonDataResource.cpp
+++ b/spine-godot/spine_godot/SpineSkeletonDataResource.cpp
@@ -147,12 +147,12 @@ void SpineSkeletonDataResource::update_skeleton_data() {
 		animation_state_data = nullptr;
 	}
 
-	emit_signal("_internal_spine_objects_invalidated");
+	emit_signal(SNAME("_internal_spine_objects_invalidated"));
 
 	if (atlas_res.is_valid() && skeleton_file_res.is_valid()) {
 		load_resources(atlas_res->get_spine_atlas(), skeleton_file_res->get_json(), skeleton_file_res->get_binary());
 	}
-	emit_signal("skeleton_data_changed");
+	emit_signal(SNAME("skeleton_data_changed"));
 #ifdef TOOLS_ENABLED
 	NOTIFY_PROPERTY_LIST_CHANGED();
 #endif
@@ -295,7 +295,7 @@ void SpineSkeletonDataResource::update_mixes() {
 Ref<SpineAnimation> SpineSkeletonDataResource::find_animation(const String &animation_name) const {
 	SPINE_CHECK(skeleton_data, nullptr)
 	if (EMPTY(animation_name)) return nullptr;
-	auto animation = skeleton_data->findAnimation(SPINE_STRING(animation_name));
+	auto animation = skeleton_data->findAnimation(SPINE_STRING_TMP(animation_name));
 	if (!animation) return nullptr;
 	Ref<SpineAnimation> animation_ref(memnew(SpineAnimation));
 	animation_ref->set_spine_object(this, animation);
@@ -305,7 +305,7 @@ Ref<SpineAnimation> SpineSkeletonDataResource::find_animation(const String &anim
 Ref<SpineBoneData> SpineSkeletonDataResource::find_bone(const String &bone_name) const {
 	SPINE_CHECK(skeleton_data, nullptr)
 	if (EMPTY(bone_name)) return nullptr;
-	auto bone = skeleton_data->findBone(SPINE_STRING(bone_name));
+	auto bone = skeleton_data->findBone(SPINE_STRING_TMP(bone_name));
 	if (!bone) return nullptr;
 	Ref<SpineBoneData> bone_ref(memnew(SpineBoneData));
 	bone_ref->set_spine_object(this, bone);
@@ -315,7 +315,7 @@ Ref<SpineBoneData> SpineSkeletonDataResource::find_bone(const String &bone_name)
 Ref<SpineSlotData> SpineSkeletonDataResource::find_slot(const String &slot_name) const {
 	SPINE_CHECK(skeleton_data, nullptr)
 	if (EMPTY(slot_name)) return nullptr;
-	auto slot = skeleton_data->findSlot(SPINE_STRING(slot_name));
+	auto slot = skeleton_data->findSlot(SPINE_STRING_TMP(slot_name));
 	if (!slot) return nullptr;
 	Ref<SpineSlotData> slot_ref(memnew(SpineSlotData));
 	slot_ref->set_spine_object(this, slot);
@@ -325,7 +325,7 @@ Ref<SpineSlotData> SpineSkeletonDataResource::find_slot(const String &slot_name)
 Ref<SpineSkin> SpineSkeletonDataResource::find_skin(const String &skin_name) const {
 	SPINE_CHECK(skeleton_data, nullptr)
 	if (EMPTY(skin_name)) return nullptr;
-	auto skin = skeleton_data->findSkin(SPINE_STRING(skin_name));
+	auto skin = skeleton_data->findSkin(SPINE_STRING_TMP(skin_name));
 	if (!skin) return nullptr;
 	Ref<SpineSkin> skin_ref(memnew(SpineSkin));
 	skin_ref->set_spine_object(this, skin);
@@ -335,7 +335,7 @@ Ref<SpineSkin> SpineSkeletonDataResource::find_skin(const String &skin_name) con
 Ref<SpineEventData> SpineSkeletonDataResource::find_event(const String &event_data_name) const {
 	SPINE_CHECK(skeleton_data, nullptr)
 	if (EMPTY(event_data_name)) return nullptr;
-	auto event = skeleton_data->findEvent(SPINE_STRING(event_data_name));
+	auto event = skeleton_data->findEvent(SPINE_STRING_TMP(event_data_name));
 	if (!event) return nullptr;
 	Ref<SpineEventData> event_ref(memnew(SpineEventData));
 	event_ref->set_spine_object(this, event);
@@ -345,7 +345,7 @@ Ref<SpineEventData> SpineSkeletonDataResource::find_event(const String &event_da
 Ref<SpineIkConstraintData> SpineSkeletonDataResource::find_ik_constraint(const String &constraint_name) const {
 	SPINE_CHECK(skeleton_data, nullptr)
 	if (EMPTY(constraint_name)) return nullptr;
-	auto constraint = skeleton_data->findIkConstraint(SPINE_STRING(constraint_name));
+	auto constraint = skeleton_data->findIkConstraint(SPINE_STRING_TMP(constraint_name));
 	if (!constraint) return nullptr;
 	Ref<SpineIkConstraintData> constraint_ref(memnew(SpineIkConstraintData));
 	constraint_ref->set_spine_object(this, constraint);
@@ -355,7 +355,7 @@ Ref<SpineIkConstraintData> SpineSkeletonDataResource::find_ik_constraint(const S
 Ref<SpineTransformConstraintData> SpineSkeletonDataResource::find_transform_constraint(const String &constraint_name) const {
 	SPINE_CHECK(skeleton_data, nullptr)
 	if (EMPTY(constraint_name)) return nullptr;
-	auto constraint = skeleton_data->findTransformConstraint(SPINE_STRING(constraint_name));
+	auto constraint = skeleton_data->findTransformConstraint(SPINE_STRING_TMP(constraint_name));
 	if (!constraint) return nullptr;
 	Ref<SpineTransformConstraintData> constraint_ref(memnew(SpineTransformConstraintData));
 	constraint_ref->set_spine_object(this, constraint);
@@ -364,7 +364,7 @@ Ref<SpineTransformConstraintData> SpineSkeletonDataResource::find_transform_cons
 Ref<SpinePathConstraintData> SpineSkeletonDataResource::find_path_constraint(const String &constraint_name) const {
 	SPINE_CHECK(skeleton_data, nullptr)
 	if (EMPTY(constraint_name)) return nullptr;
-	auto constraint = skeleton_data->findPathConstraint(SPINE_STRING(constraint_name));
+	auto constraint = skeleton_data->findPathConstraint(SPINE_STRING_TMP(constraint_name));
 	if (constraint == nullptr) return nullptr;
 	Ref<SpinePathConstraintData> constraint_ref(memnew(SpinePathConstraintData));
 	constraint_ref->set_spine_object(this, constraint);

--- a/spine-godot/spine_godot/SpineSlot.cpp
+++ b/spine-godot/spine_godot/SpineSlot.cpp
@@ -59,18 +59,30 @@ void SpineSlot::set_to_setup_pose() {
 
 Ref<SpineSlotData> SpineSlot::get_data() {
 	SPINE_CHECK(get_spine_object(), nullptr)
-	auto &slot_data = get_spine_object()->getData();
-	Ref<SpineSlotData> slot_data_ref(memnew(SpineSlotData));
-	slot_data_ref->set_spine_object(*get_spine_owner()->get_skeleton_data_res(), &slot_data);
-	return slot_data_ref;
+	if(_data.is_valid()) {
+		return _data;
+	}
+	else {
+		auto &slot_data = get_spine_object()->getData();
+		Ref<SpineSlotData> slot_data_ref(memnew(SpineSlotData));
+		slot_data_ref->set_spine_object(*get_spine_owner()->get_skeleton_data_res(), &slot_data);
+		_data = slot_data_ref;
+		return slot_data_ref;
+	}
 }
 
 Ref<SpineBone> SpineSlot::get_bone() {
 	SPINE_CHECK(get_spine_object(), nullptr)
-	auto &bone = get_spine_object()->getBone();
-	Ref<SpineBone> bone_ref(memnew(SpineBone));
-	bone_ref->set_spine_object(get_spine_owner(), &bone);
-	return bone_ref;
+	if(_bone.is_valid()) {
+		return _data;
+	}
+	else {
+		auto &bone = get_spine_object()->getBone();
+		Ref<SpineBone> bone_ref(memnew(SpineBone));
+		bone_ref->set_spine_object(get_spine_owner(), &bone);
+		_bone = bone_ref;
+		return bone_ref;
+	}
 }
 
 Color SpineSlot::get_color() {

--- a/spine-godot/spine_godot/SpineSlot.h
+++ b/spine-godot/spine_godot/SpineSlot.h
@@ -40,6 +40,10 @@ class SpineSprite;
 class SpineSlot : public SpineSpriteOwnedObject<spine::Slot> {
 	GDCLASS(SpineSlot, SpineObjectWrapper)
 
+private:
+	Ref<SpineBone> _bone;
+	Ref<SpineSlotData> _data;
+
 protected:
 	static void _bind_methods();
 

--- a/spine-godot/spine_godot/SpineSlotData.cpp
+++ b/spine-godot/spine_godot/SpineSlotData.cpp
@@ -104,7 +104,7 @@ String SpineSlotData::get_attachment_name() {
 }
 void SpineSlotData::set_attachment_name(const String &v) {
 	SPINE_CHECK(get_spine_object(), )
-	get_spine_object()->setAttachmentName(SPINE_STRING(v));
+	get_spine_object()->setAttachmentName(SPINE_STRING_TMP(v));
 }
 
 SpineConstant::BlendMode SpineSlotData::get_blend_mode() {

--- a/spine-godot/spine_godot/SpineSlotNode.cpp
+++ b/spine-godot/spine_godot/SpineSlotNode.cpp
@@ -62,9 +62,9 @@ void SpineSlotNode::_notification(int what) {
 			SpineSprite *sprite = cast_to<SpineSprite>(get_parent());
 			if (sprite) {
 #if VERSION_MAJOR > 3
-				sprite->connect("world_transforms_changed", callable_mp(this, &SpineSlotNode::on_world_transforms_changed));
+				sprite->connect(SNAME("world_transforms_changed"), callable_mp(this, &SpineSlotNode::on_world_transforms_changed));
 #else
-				sprite->connect("world_transforms_changed", this, "_on_world_transforms_changed");
+				sprite->connect(SNAME("world_transforms_changed"), this, SNAME("_on_world_transforms_changed"));
 #endif
 				update_transform(sprite);
 #if VERSION_MAJOR == 3
@@ -86,9 +86,9 @@ void SpineSlotNode::_notification(int what) {
 			SpineSprite *sprite = cast_to<SpineSprite>(get_parent());
 			if (sprite) {
 #if VERSION_MAJOR > 3
-				sprite->disconnect("world_transforms_changed", callable_mp(this, &SpineSlotNode::on_world_transforms_changed));
+				sprite->disconnect(SNAME("world_transforms_changed"), callable_mp(this, &SpineSlotNode::on_world_transforms_changed));
 #else
-				sprite->disconnect("world_transforms_changed", this, "_on_world_transforms_changed");
+				sprite->disconnect(SNAME("world_transforms_changed"), this, SNAME("_on_world_transforms_changed"));
 #endif
 			}
 			break;

--- a/spine-godot/spine_godot/SpineSprite.cpp
+++ b/spine-godot/spine_godot/SpineSprite.cpp
@@ -415,15 +415,15 @@ void SpineSprite::on_skeleton_data_changed() {
 	remove_meshes();
 	skeleton.unref();
 	animation_state.unref();
-	emit_signal("_internal_spine_objects_invalidated");
+	emit_signal(SNAME("_internal_spine_objects_invalidated"));
 
 	if (skeleton_data_res.is_valid()) {
 #if VERSION_MAJOR > 3
-		if (!skeleton_data_res->is_connected("skeleton_data_changed", callable_mp(this, &SpineSprite::on_skeleton_data_changed)))
-			skeleton_data_res->connect("skeleton_data_changed", callable_mp(this, &SpineSprite::on_skeleton_data_changed));
+		if (!skeleton_data_res->is_connected(SNAME("skeleton_data_changed"), callable_mp(this, &SpineSprite::on_skeleton_data_changed)))
+			skeleton_data_res->connect(SNAME("skeleton_data_changed"), callable_mp(this, &SpineSprite::on_skeleton_data_changed));
 #else
-		if (!skeleton_data_res->is_connected("skeleton_data_changed", this, "on_skeleton_data_changed"))
-			skeleton_data_res->connect("skeleton_data_changed", this, "on_skeleton_data_changed");
+		if (!skeleton_data_res->is_connected(SNAME("skeleton_data_changed"), this, SNAME("on_skeleton_data_changed")))
+			skeleton_data_res->connect(SNAME("skeleton_data_changed"), this, SNAME("on_skeleton_data_changed"));
 #endif
 	}
 
@@ -665,15 +665,15 @@ void SpineSprite::update_skeleton(float delta) {
 		!animation_state->get_spine_object())
 		return;
 
-	emit_signal("before_animation_state_update", this);
+	emit_signal(SNAME("before_animation_state_update"), this);
 	animation_state->update(delta);
 	if (!is_visible_in_tree()) return;
-	emit_signal("before_animation_state_apply", this);
+	emit_signal(SNAME("before_animation_state_apply"), this);
 	animation_state->apply(skeleton);
-	emit_signal("before_world_transforms_change", this);
+	emit_signal(SNAME("before_world_transforms_change"), this);
 	skeleton->update_world_transform();
 	modified_bones = false;
-	emit_signal("world_transforms_changed", this);
+	emit_signal(SNAME("world_transforms_changed"), this);
 	if (modified_bones) skeleton->update_world_transform();
 	sort_slot_nodes();
 	update_meshes(skeleton);
@@ -1001,7 +1001,7 @@ void SpineSprite::draw() {
 #if VERSION_MAJOR > 3
 	default_font = control->get_theme_default_font();
 #else
-	default_font = control->get_font("font", "Label");
+	default_font = control->get_font(SNAME("font"), SNAME("Label"));
 #endif
 	memfree(control);
 
@@ -1073,22 +1073,22 @@ void SpineSprite::callback(spine::AnimationState *state, spine::EventType type, 
 
 	switch (type) {
 		case spine::EventType_Start:
-			emit_signal("animation_started", this, animation_state, entry_ref);
+			emit_signal(SNAME("animation_started"), this, animation_state, entry_ref);
 			break;
 		case spine::EventType_Interrupt:
-			emit_signal("animation_interrupted", this, animation_state, entry_ref);
+			emit_signal(SNAME("animation_interrupted"), this, animation_state, entry_ref);
 			break;
 		case spine::EventType_End:
-			emit_signal("animation_ended", this, animation_state, entry_ref);
+			emit_signal(SNAME("animation_ended"), this, animation_state, entry_ref);
 			break;
 		case spine::EventType_Complete:
-			emit_signal("animation_completed", this, animation_state, entry_ref);
+			emit_signal(SNAME("animation_completed"), this, animation_state, entry_ref);
 			break;
 		case spine::EventType_Dispose:
-			emit_signal("animation_disposed", this, animation_state, entry_ref);
+			emit_signal(SNAME("animation_disposed"), this, animation_state, entry_ref);
 			break;
 		case spine::EventType_Event:
-			emit_signal("animation_event", this, animation_state, entry_ref, event_ref);
+			emit_signal(SNAME("animation_event"), this, animation_state, entry_ref, event_ref);
 			break;
 	}
 }


### PR DESCRIPTION
Improvement addressing a bunch of perf limitations we hit wrt https://github.com/EsotericSoftware/spine-runtimes/issues/2331

A quick summary:

 -  Godot 'Objects/References' are generally quite heavy.  (post and pre initialize hooks, string allocations, map entries (registry into a global `ObjectDB`, etc.  Creating them on the fly as temporaries in hot lanes really hits hard.  

<img width="1187" alt="Screen Shot 2023-08-03 at 3 59 20 PM" src="https://github.com/EsotericSoftware/spine-runtimes/assets/323868/81db42fa-77e7-47d9-8107-9da0f92d304d">

We hit these a lot on find_bone and find_slot.   Improved a lot here by just adding a caching layer to these spots.

 - Updated many of the calls into godot functions that take a `const StringName&` to use a StringName instead of `const char*`, this is much more performant as promoting a `const char*` argument to StringName causes a StringName constructor which ends up locking a global mutex and an allocation/free cycle.   I'm not 100% up to date on whats going on in godot `master` branch, but iirc they expose the `SNAME` macro in master, it's just not backported to the `3.x` branch.

- And lastly, there's a bunch of allocations and memcopy for temporary strings in the `find*` which constructs a `spine::string` from a Godot string, but is really only used a stack temporary.  This was a little tricker to optimize as it required api support in spine's string class to take 'ownership' of a string buffer (i.e. omit the memcpy), but actually not free the buffer on destruction.  More or less a string view impl...     This isn't the prettiest solution here, as a string view class or subclass is probably bettter, but open to suggestions here.
   