### PR TITLE
[Phaser] Adds Asset Pack support

### DIFF
--- a/spine-ts/spine-phaser/src/SpinePlugin.ts
+++ b/spine-ts/spine-phaser/src/SpinePlugin.ts
@@ -259,13 +259,13 @@ class SpineSkeletonDataFile extends Phaser.Loader.MultiFile {
 	constructor (loader: Phaser.Loader.LoaderPlugin, key: string, url: string, public fileType: SpineSkeletonDataFileType, xhrSettings: Phaser.Types.Loader.XHRSettingsObject) {
 		
 		if (Phaser.Utils.Objects.IsPlainObject(key as any)) {
-            const config = key as any;
-            key = Phaser.Utils.Objects.GetFastValue(config, "key");
-            url = Phaser.Utils.Objects.GetFastValue(config, "url");
+            		const config = key as any;
+            		key = Phaser.Utils.Objects.GetFastValue(config, "key");
+            		url = Phaser.Utils.Objects.GetFastValue(config, "url");
 			const type = Phaser.Utils.Objects.GetFastValue(config, "type");
 			fileType = type === "spineJson" ? SpineSkeletonDataFileType.json : SpineSkeletonDataFileType.binary;
-            xhrSettings = Phaser.Utils.Objects.GetFastValue(config, "xhrSettings");
-        }
+            		xhrSettings = Phaser.Utils.Objects.GetFastValue(config, "xhrSettings");
+        	}
 		
 		let file = null;
 		let isJson = fileType == SpineSkeletonDataFileType.json;
@@ -300,12 +300,12 @@ class SpineAtlasFile extends Phaser.Loader.MultiFile {
 	constructor (loader: Phaser.Loader.LoaderPlugin, key: string, url: string, public premultipliedAlpha: boolean = true, xhrSettings: Phaser.Types.Loader.XHRSettingsObject) {
 		
 		if (Phaser.Utils.Objects.IsPlainObject(key as any)) {
-            const config = key as any;
-            key = Phaser.Utils.Objects.GetFastValue(config, "key");
-            url = Phaser.Utils.Objects.GetFastValue(config, "url");
+            		const config = key as any;
+            		key = Phaser.Utils.Objects.GetFastValue(config, "key");
+            		url = Phaser.Utils.Objects.GetFastValue(config, "url");
 			premultipliedAlpha = Phaser.Utils.Objects.GetFastValue(config, "premultipliedAlpha", true);
-            xhrSettings = Phaser.Utils.Objects.GetFastValue(config, "xhrSettings");
-        }
+            		xhrSettings = Phaser.Utils.Objects.GetFastValue(config, "xhrSettings");
+        	}
 
 		super(loader, SPINE_ATLAS_FILE_TYPE, key, [
 			new Phaser.Loader.FileTypes.TextFile(loader, {

--- a/spine-ts/spine-phaser/src/SpinePlugin.ts
+++ b/spine-ts/spine-phaser/src/SpinePlugin.ts
@@ -255,16 +255,22 @@ enum SpineSkeletonDataFileType {
 	binary
 }
 
+interface SpineSkeletonDataFileConfig {
+	key: string;
+	url: string;
+	type: "spineJson" | "spineBinary";
+	xhrSettings?: Phaser.Types.Loader.XHRSettingsObject
+}
+
 class SpineSkeletonDataFile extends Phaser.Loader.MultiFile {
-	constructor (loader: Phaser.Loader.LoaderPlugin, key: string, url: string, public fileType: SpineSkeletonDataFileType, xhrSettings: Phaser.Types.Loader.XHRSettingsObject) {
+	constructor (loader: Phaser.Loader.LoaderPlugin, key: string | SpineSkeletonDataFileConfig, url?: string, public fileType?: SpineSkeletonDataFileType, xhrSettings?: Phaser.Types.Loader.XHRSettingsObject) {
 		
-		if (Phaser.Utils.Objects.IsPlainObject(key as any)) {
-            		const config = key as any;
-            		key = Phaser.Utils.Objects.GetFastValue(config, "key");
-            		url = Phaser.Utils.Objects.GetFastValue(config, "url");
-			const type = Phaser.Utils.Objects.GetFastValue(config, "type");
-			fileType = type === "spineJson" ? SpineSkeletonDataFileType.json : SpineSkeletonDataFileType.binary;
-            		xhrSettings = Phaser.Utils.Objects.GetFastValue(config, "xhrSettings");
+		if (typeof key !== "string") {
+            		const config = key;
+            		key = config.key;
+            		url = config.url;
+			fileType = config.type === "spineJson" ? SpineSkeletonDataFileType.json : SpineSkeletonDataFileType.binary;
+            		xhrSettings = config.xhrSettings;
         	}
 		
 		let file = null;
@@ -296,15 +302,22 @@ class SpineSkeletonDataFile extends Phaser.Loader.MultiFile {
 	}
 }
 
+interface SpineAtlasFileConfig {
+	key: string;
+	url: string;
+	premultipliedAlpha?: boolean;
+	xhrSettings?: Phaser.Types.Loader.XHRSettingsObject;
+}
+
 class SpineAtlasFile extends Phaser.Loader.MultiFile {
-	constructor (loader: Phaser.Loader.LoaderPlugin, key: string, url: string, public premultipliedAlpha: boolean = true, xhrSettings: Phaser.Types.Loader.XHRSettingsObject) {
+	constructor (loader: Phaser.Loader.LoaderPlugin, key: string | SpineAtlasFileConfig, url?: string, public premultipliedAlpha: boolean = true, xhrSettings?: Phaser.Types.Loader.XHRSettingsObject) {
 		
-		if (Phaser.Utils.Objects.IsPlainObject(key as any)) {
-            		const config = key as any;
-            		key = Phaser.Utils.Objects.GetFastValue(config, "key");
-            		url = Phaser.Utils.Objects.GetFastValue(config, "url");
-			premultipliedAlpha = Phaser.Utils.Objects.GetFastValue(config, "premultipliedAlpha", true);
-            		xhrSettings = Phaser.Utils.Objects.GetFastValue(config, "xhrSettings");
+		if (typeof key !== "string") {
+            		const config = key;
+            		key = config.key;
+            		url = config.url;
+			premultipliedAlpha = config.premultipliedAlpha ?? true;
+            		xhrSettings = config.xhrSettings;
         	}
 
 		super(loader, SPINE_ATLAS_FILE_TYPE, key, [

--- a/spine-ts/spine-phaser/src/SpinePlugin.ts
+++ b/spine-ts/spine-phaser/src/SpinePlugin.ts
@@ -257,6 +257,16 @@ enum SpineSkeletonDataFileType {
 
 class SpineSkeletonDataFile extends Phaser.Loader.MultiFile {
 	constructor (loader: Phaser.Loader.LoaderPlugin, key: string, url: string, public fileType: SpineSkeletonDataFileType, xhrSettings: Phaser.Types.Loader.XHRSettingsObject) {
+		
+		if (Phaser.Utils.Objects.IsPlainObject(key as any)) {
+            const config = key as any;
+            key = Phaser.Utils.Objects.GetFastValue(config, "key");
+            url = Phaser.Utils.Objects.GetFastValue(config, "url");
+			const type = Phaser.Utils.Objects.GetFastValue(config, "type");
+			fileType = type === "spineJson" ? SpineSkeletonDataFileType.json : SpineSkeletonDataFileType.binary;
+            xhrSettings = Phaser.Utils.Objects.GetFastValue(config, "xhrSettings");
+        }
+		
 		let file = null;
 		let isJson = fileType == SpineSkeletonDataFileType.json;
 		if (isJson) {
@@ -288,6 +298,15 @@ class SpineSkeletonDataFile extends Phaser.Loader.MultiFile {
 
 class SpineAtlasFile extends Phaser.Loader.MultiFile {
 	constructor (loader: Phaser.Loader.LoaderPlugin, key: string, url: string, public premultipliedAlpha: boolean = true, xhrSettings: Phaser.Types.Loader.XHRSettingsObject) {
+		
+		if (Phaser.Utils.Objects.IsPlainObject(key as any)) {
+            const config = key as any;
+            key = Phaser.Utils.Objects.GetFastValue(config, "key");
+            url = Phaser.Utils.Objects.GetFastValue(config, "url");
+			premultipliedAlpha = Phaser.Utils.Objects.GetFastValue(config, "premultipliedAlpha", true);
+            xhrSettings = Phaser.Utils.Objects.GetFastValue(config, "xhrSettings");
+        }
+
 		super(loader, SPINE_ATLAS_FILE_TYPE, key, [
 			new Phaser.Loader.FileTypes.TextFile(loader, {
 				key: key,
@@ -296,6 +315,8 @@ class SpineAtlasFile extends Phaser.Loader.MultiFile {
 				extension: "atlas"
 			})
 		]);
+
+		this.premultipliedAlpha = premultipliedAlpha;
 	}
 
 	onFileComplete (file: Phaser.Loader.File) {


### PR DESCRIPTION
Phaser provides the Asset Pack format for defining the assets in a manifest (JSON) file.

This pull request modifies the `SpineSkeletonDataFile` and `SpineAtlasFile` classes for implementing the Asset Pack feature. The modifications are about extracting the file info from the `key` argument of the constructor. The Phaser loader uses the file implementations for processing the asset pack entries. It passes the JSON info as the `key` parameter of the file constructor. The modifications in this PR follow the same pattern in the implementation of other Phaser files.

Here I attach a working demo. The `spine-phaser.js` runtime contains the modifications of this PR.

[demo-spine.zip](https://github.com/EsotericSoftware/spine-runtimes/files/12287323/demo-spine.zip)


