### PR TITLE
[Phaser] Fix GameObject input not working

### DIFF
--- a/spine-ts/spine-phaser/src/SpinePlugin.ts
+++ b/spine-ts/spine-phaser/src/SpinePlugin.ts
@@ -124,7 +124,7 @@ export class SpinePlugin extends Phaser.Plugins.ScenePlugin {
 
 		let self = this;
 		let addSpineGameObject = function (this: Phaser.GameObjects.GameObjectFactory, x: number, y: number, dataKey: string, atlasKey: string, boundsProvider: SpineGameObjectBoundsProvider) {
-			let gameObject = new SpineGameObject(scene, self, x, y, dataKey, atlasKey, boundsProvider);
+			let gameObject = new SpineGameObject(this.scene, self, x, y, dataKey, atlasKey, boundsProvider);
 			this.displayList.add(gameObject);
 			this.updateList.add(gameObject);
 			return gameObject;


### PR DESCRIPTION
Enabling the input on a spine GameObject with setInteractive() added it to the wrong scene input list, so was never hit.

The new SpineGameObject should use the gameObject's own scene ref, not the system scene.