### PR TITLE
[unity] Set fps at generated SkeletonMecanim animation clip assets

### DIFF
--- a/spine-unity/Assets/Spine/Editor/spine-unity/Editor/Windows/SkeletonBaker.cs
+++ b/spine-unity/Assets/Spine/Editor/spine-unity/Editor/Windows/SkeletonBaker.cs
@@ -130,6 +130,8 @@ namespace Spine.Unity.Editor {
 				}
 			}
 
+			SkeletonData skeletonData = skeletonDataAsset.GetSkeletonData(true);
+
 			foreach (Animation animations in data.Animations) {
 				string animationName = animations.Name; // Review for unsafe names. Requires runtime implementation too.
 				spineAnimationTable.Add(animationName, animations);
@@ -144,6 +146,7 @@ namespace Spine.Unity.Editor {
 				}
 
 				AnimationClip clip = unityAnimationClipTable[animationName];
+				clip.frameRate = skeletonData.Fps;
 				clip.SetCurve("", typeof(GameObject), "dummy", AnimationCurve.Linear(0, 0, animations.Duration, 0));
 				AnimationClipSettings settings = AnimationUtility.GetAnimationClipSettings(clip);
 				settings.stopTime = animations.Duration;


### PR DESCRIPTION
In some case, the FPS of that animation clip is very important to detect which frame the animation is running at. That's why the we need to sync the FPS of spine animation and generated animation clip