### PR TITLE
[unity] Explicitly specify 'SpineAtlasAsset' as a variable named 'atlasAsset'

### DIFF
--- a/spine-unity/Assets/Spine Examples/Scripts/Sample Components/Legacy/AtlasRegionAttacher.cs
+++ b/spine-unity/Assets/Spine Examples/Scripts/Sample Components/Legacy/AtlasRegionAttacher.cs
@@ -40,7 +40,7 @@ namespace Spine.Unity.Examples {
 		[System.Serializable]
 		public class SlotRegionPair {
 			[SpineSlot] public string slot;
-			[SpineAtlasRegion] public string region;
+			[SpineAtlasRegion("atlasAsset")] public string region;//Explicitly specify 'SpineAtlasAsset' as a variable named 'atlasAsset'.
 		}
 
 		[SerializeField] protected SpineAtlasAsset atlasAsset;


### PR DESCRIPTION
…asAsset'.

Explicitly specify 'SpineAtlasAsset' as a variable named 'atlasAsset'. Reduce the error 'Must have AtlasAsset variable!' when creating a variable with a name other than 'AtlasAsset' 'but somebody don't know why.