### PR TITLE
[csharp] Exposed list optimizations

### DIFF
--- a/spine-csharp/src/ExposedList.cs
+++ b/spine-csharp/src/ExposedList.cs
@@ -76,7 +76,7 @@ namespace Spine {
 		public void Add (T item) {
 			// If we check to see if we need to grow before trying to grow
 			// we can speed things up by 25%
-			if (Count == Items.Length)
+			if (Count == Capacity)
 				GrowIfNeeded(1);
 			Items[Count++] = item;
 			version++;
@@ -84,27 +84,22 @@ namespace Spine {
 
 		public void GrowIfNeeded (int addedCount) {
 			int minimumSize = Count + addedCount;
-			if (minimumSize > Items.Length)
+			if (minimumSize > Capacity)
 				Capacity = Math.Max(Math.Max(Capacity * 2, DefaultCapacity), minimumSize);
 		}
 
-		public ExposedList<T> Resize (int newSize) {
-			int itemsLength = Items.Length;
-			var oldItems = Items;
-			if (newSize > itemsLength) {
-				Array.Resize(ref Items, newSize);
-			} else if (newSize < itemsLength) {
-				// Allow nulling of T reference type to allow GC.
-				for (int i = newSize; i < itemsLength; i++)
-					oldItems[i] = default(T);
-			}
+		public ExposedList<T> Resize(int newSize)
+		{
+			if (newSize > Capacity)
+				GrowIfNeeded(newSize - Count);
+
 			Count = newSize;
 			return this;
 		}
 
 		public void EnsureCapacity (int min) {
-			if (Items.Length < min) {
-				int newCapacity = Items.Length == 0 ? DefaultCapacity : Items.Length * 2;
+			if (Capacity < min) {
+				int newCapacity = Capacity == 0 ? DefaultCapacity : Capacity * 2;
 				//if ((uint)newCapacity > Array.MaxArrayLength) newCapacity = Array.MaxArrayLength;
 				if (newCapacity < min) newCapacity = min;
 				Capacity = newCapacity;
@@ -181,7 +176,7 @@ namespace Spine {
 
 		public void Clear (bool clearArray = true) {
 			if (clearArray)
-				Array.Clear(Items, 0, Items.Length);
+				Array.Clear(Items, 0, Capacity);
 
 			Count = 0;
 			version++;
@@ -364,7 +359,7 @@ namespace Spine {
 
 		public void Insert (int index, T item) {
 			CheckIndex(index);
-			if (Count == Items.Length)
+			if (Count == Capacity)
 				GrowIfNeeded(1);
 			Shift(index, 1);
 			Items[index] = item;


### PR DESCRIPTION
This commit handles unnecessary work with array.

Making unused items of array to default makes us iterate other all array every time, this slows work of our application dramatically. I believe, that you should do this somehow the other way. 
At least, if you want to ensure handling refs, check if your item is valueType, so you would not iterate other all array trying to set defaults which slower CPU. Anyway I believe that only when array is destroyed, working with its items stops in your app.

Also, you should compare sizes not with items.Length, but with Capacity.

I believe that you could handle working with your exposed list more accurately in individual cases.

By the way we work with il2cpp in our app and this leads to some slowing CPU cases while working with your arrays.
if you build app with il2cpp, there would be various code generations for null-checks, array boundary checks and etc during working with arrays. You could see [Il2CppSetOptionAttribute in unity docs](https://docs.unity3d.com/Manual/IL2CPP.html). This leads us to huge slowing of CPU work during iterations other array and etc. If you are sure you are working with arrays correctly, in what I believe (check your algorithms), you could turn off this code generation in il2cpp. This made work with our app faster up to 4-6 times. Especially during working with clipping zones and animations.

```
[Il2CppSetOption(Option.NullChecks, false), Il2CppSetOption(Option.ArrayBoundsChecks, false)]
CurveTimeline.GetCurveValue
```

```
[Il2CppSetOption(Option.NullChecks, false), Il2CppSetOption(Option.ArrayBoundsChecks, false)]
SkeletonCLipping.Clip (float x1, float y1, float x2, float y2, float x3, float y3, ExposedList<float> clippingArea, ExposedList<float> output)
```
I am sure that you could find much more cases there you could make your Spine Runtime much faster.
Just check work with arrays and il2cpp build cases.