### PR TITLE
[ts][pixi] Fix not working alpha channel in mesh animations

### DIFF
--- a/spine-ts/spine-pixi/src/SlotMesh.ts
+++ b/spine-ts/spine-pixi/src/SlotMesh.ts
@@ -99,6 +99,7 @@ export class SlotMesh extends Mesh implements ISlotMesh {
 		SlotMesh.auxColor[3] = finalVertices[5];
 
 		this.tint = SlotMesh.auxColor;
+		this.alpha = SlotMesh.auxColor[3];
 		this.blendMode = SpineTexture.toPixiBlending(slotBlendMode);
 
 		if (this.geometry.indexBuffer.data.length !== finalIndices.length) {


### PR DESCRIPTION
Alpha channel is not working in pixi animations right now. I prepared demo with rotating and fading object, so we can see that rotating animation is working, but fading animation is not:
![alpha-not-working mov](https://github.com/EsotericSoftware/spine-runtimes/assets/357696/41d5f01e-2ad4-4846-a878-18e0fe054ea5)
As you can see we have changing alpha in auxColor[3], but it has no effect on scene.

The problem is in SlotMesh's `tint`:
https://github.com/EsotericSoftware/spine-runtimes/blob/73318d6c79b34ca8201e91e120e85a3cc2f9dacd/spine-ts/spine-pixi/src/SlotMesh.ts#L96-L101

[Tint](https://pixijs.download/dev/docs/PIXI.Mesh.html#tint) in Pixi (as I understand) is not working with [alpha](https://pixijs.download/dev/docs/PIXI.Mesh.html#alpha). If we want to use alpha, we should directly set it:
```
SlotMesh.auxColor[0] = finalVertices[2];
SlotMesh.auxColor[1] = finalVertices[3];
SlotMesh.auxColor[2] = finalVertices[4];
SlotMesh.auxColor[3] = finalVertices[5];

this.tint = SlotMesh.auxColor;
this.alpha = SlotMesh.auxColor[3]; // <--- here
```

When we do this, everything starts to work :)
![alpha-working mov](https://github.com/EsotericSoftware/spine-runtimes/assets/357696/0738f340-6d65-433c-a025-9befc87e3a41)
