### PR TITLE
[flutter] Fix missing definition of Blend mode set function

### DIFF
--- a/spine-flutter/lib/spine_flutter.dart
+++ b/spine-flutter/lib/spine_flutter.dart
@@ -3010,7 +3010,7 @@ class Skeleton {
   /// <p>
   /// Bones that do not inherit translation are still affected by this property.
   double getY() {
-    return _bindings.spine_skeleton_get_x(_skeleton);
+    return _bindings.spine_skeleton_get_y(_skeleton);
   }
 
   void setY(double y) {
@@ -3032,7 +3032,7 @@ class Skeleton {
   ///
   /// Bones that do not inherit scale are still affected by this property.
   double getScaleY() {
-    return _bindings.spine_skeleton_get_scale_x(_skeleton);
+    return _bindings.spine_skeleton_get_scale_y(_skeleton);
   }
 
   void setScaleY(double scaleY) {

--- a/spine-flutter/src/spine_flutter.cpp
+++ b/spine-flutter/src/spine_flutter.cpp
@@ -1863,6 +1863,12 @@ spine_blend_mode spine_slot_data_get_blend_mode(spine_slot_data slot) {
 	return (spine_blend_mode) _slot->getBlendMode();
 }
 
+void spine_slot_data_set_blend_mode(spine_slot_data slot, spine_blend_mode blendMode) {
+	if (slot == nullptr) return;
+	SlotData *_slot = (SlotData *) slot;
+	_slot->setBlendMode((BlendMode) blendMode);
+}
+
 // Slot
 void spine_slot_set_to_setup_pose(spine_slot slot) {
 	if (slot == nullptr) return;


### PR DESCRIPTION
Fixed a function on the C++ side that was not defined that is called by Flutter.