### PR TITLE
Fix android-specific rotation issue. bone->arotation == NaN, in some cases

### DIFF
--- a/spine-c/spine-c/src/spine/IkConstraint.c
+++ b/spine-c/spine-c/src/spine/IkConstraint.c
@@ -246,8 +246,9 @@ void spIkConstraint_apply2(spBone *parent, spBone *child, float targetX, float t
 			r0 = q / c2;
 			r1 = c0 / q;
 			r = ABS(r0) < ABS(r1) ? r0 : r1;
-			if (r * r <= dd) {
-				y = SQRT(dd - r * r) * bendDir;
+			y = dd - r * r;
+			if (y > 0) {
+				y = SQRT(y) * bendDir;
 				a1 = ta - ATAN2(y, r);
 				a2 = ATAN2(y / psy, (r - l1) / psx);
 				goto break_outer;


### PR DESCRIPTION
This pull request addresses a specific issue with bone rotation during animations on the Android platform

We identified that bones->arotation could occasionally result in NaN values at android only. 
After some investigation, I found the problematic area. 
This issue is similar to the frequent problem of ABS < 0.0001f scattered throughout the code. 
Specifically, on android devices, the condition if (r * r <= dd) was met for very small but negative numbers, allowing such a number inside the if statement. 
Subsequently, passing a very small negative number to sqrt() would then result in NaN, and then bone->arotation became also NaN.

After this fix we check our android builds and its removes the problem entirely.

Additionally, here is an example of a .spine project where this case is reproducible on android. 
For the bone R_leg_02, there are instances where bone->arotation becomes NaN

[Problematic_spine_hilda.zip](https://github.com/EsotericSoftware/spine-runtimes/files/14332556/Problematic_spine_hilda.zip)
