### PR TITLE
Fix some On-demand exceptions + add logic to keep original TextureImporter settings

### DIFF
--- a/spine-unity/Modules/com.esotericsoftware.spine.on-demand-loading/Editor/GenericOnDemandTextureLoaderInspector.cs
+++ b/spine-unity/Modules/com.esotericsoftware.spine.on-demand-loading/Editor/GenericOnDemandTextureLoaderInspector.cs
@@ -374,7 +374,12 @@ namespace Spine.Unity.Editor {
 
 		public void DeletePlaceholderTextures (GenericOnDemandTextureLoader<TargetReference, TextureRequest> loader) {
 			foreach (var materialMap in loader.placeholderMap) {
-				Texture texture = materialMap.textures[0].placeholderTexture;
+				var textures = materialMap.textures;
+				if (textures == null || textures.Length == 0) {
+					continue;
+				}
+
+				Texture texture = textures[0].placeholderTexture;
 				if (texture)
 					AssetDatabase.DeleteAsset(AssetDatabase.GetAssetPath(texture));
 			}

--- a/spine-unity/Modules/com.esotericsoftware.spine.on-demand-loading/Editor/GenericOnDemandTextureLoaderInspector.cs
+++ b/spine-unity/Modules/com.esotericsoftware.spine.on-demand-loading/Editor/GenericOnDemandTextureLoaderInspector.cs
@@ -203,6 +203,9 @@ namespace Spine.Unity.Editor {
 					importer.SaveAndReimport();
 
 					if (resizePhysically) {
+						bool hasOverridesToEnable =
+							TextureImporterUtils.TryDisableOverrides(importer, out List<string> disabledPlatforms);
+
 						Texture2D texture2D = AssetDatabase.LoadAssetAtPath<Texture2D>(texturePath);
 						if (texture2D) {
 							Color[] maxTextureSizePixels = texture2D.GetPixels();
@@ -222,6 +225,10 @@ namespace Spine.Unity.Editor {
 
 							EditorUtility.SetDirty(nonCompressedTexture);
 							AssetDatabase.SaveAssets();
+						}
+
+						if (hasOverridesToEnable) {
+							TextureImporterUtils.EnableOverrides(importer, disabledPlatforms);
 						}
 					}
 					placeholderTexture = AssetDatabase.LoadAssetAtPath<Texture>(texturePath);

--- a/spine-unity/Modules/com.esotericsoftware.spine.on-demand-loading/Editor/GenericOnDemandTextureLoaderInspector.cs
+++ b/spine-unity/Modules/com.esotericsoftware.spine.on-demand-loading/Editor/GenericOnDemandTextureLoaderInspector.cs
@@ -206,13 +206,21 @@ namespace Spine.Unity.Editor {
 						Texture2D texture2D = AssetDatabase.LoadAssetAtPath<Texture2D>(texturePath);
 						if (texture2D) {
 							Color[] maxTextureSizePixels = texture2D.GetPixels();
-							texture2D.SetPixels(maxTextureSizePixels);
 
-							var bytes = texture2D.EncodeToPNG();
+							// SetPixels works only for non-compressed textures using certain formats.
+							var nonCompressedTexture =
+								new Texture2D(texture2D.width, texture2D.height, TextureFormat.RGBA32, false);
+
+							nonCompressedTexture.SetPixels(maxTextureSizePixels);
+
+							var bytes = nonCompressedTexture.EncodeToPNG();
 							string targetPath = Application.dataPath + "/../" + texturePath;
 							System.IO.File.WriteAllBytes(targetPath, bytes);
-							texture2D.Apply(updateMipmaps: true, makeNoLongerReadable: true);
-							EditorUtility.SetDirty(texture2D);
+
+							importer.isReadable = false;
+							importer.SaveAndReimport();
+
+							EditorUtility.SetDirty(nonCompressedTexture);
 							AssetDatabase.SaveAssets();
 						}
 					}

--- a/spine-unity/Modules/com.esotericsoftware.spine.on-demand-loading/Editor/TextureImporterUtils.cs
+++ b/spine-unity/Modules/com.esotericsoftware.spine.on-demand-loading/Editor/TextureImporterUtils.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+
+namespace Spine.Unity.Editor {
+
+	/// <summary>
+	/// Utility class for working with TextureImporter.
+	/// </summary>
+	public static class TextureImporterUtils {
+
+		private static IEnumerable<string> GetAllPossiblePlatforms() {
+			BuildTarget[] buildTargets = (BuildTarget[])Enum.GetValues(typeof(BuildTarget));
+			var platformNames = buildTargets.Select(x => x.ToString()).ToList();
+			
+			// Add additional platforms that are not part of BuildTarget enum.
+			platformNames.Add("Server");
+			
+			return platformNames.ToArray();
+		}
+
+		public static bool TryDisableOverrides(TextureImporter importer, out List<string> disabledPlatforms) {
+			IEnumerable<string> platforms = GetAllPossiblePlatforms();
+			disabledPlatforms = new List<string>();
+
+			foreach (string platform in platforms) {
+				var platformSettings = importer.GetPlatformTextureSettings(platform);
+
+				if (!platformSettings.overridden) {
+					continue;
+				}
+
+				disabledPlatforms.Add(platform);
+				platformSettings.overridden = false;
+				importer.SetPlatformTextureSettings(platformSettings);
+			}
+
+			if (disabledPlatforms.Count <= 0) {
+				return false;
+			}
+
+			importer.SaveAndReimport();
+			return true;
+		}
+
+		public static void EnableOverrides(TextureImporter importer, List<string> platformsToEnable) {
+			if (platformsToEnable.Count == 0) {
+				return;
+			}
+
+			foreach (string platform in platformsToEnable) {
+				var platformSettings = importer.GetPlatformTextureSettings(platform);
+				platformSettings.overridden = true;
+				importer.SetPlatformTextureSettings(platformSettings);
+			}
+
+			importer.SaveAndReimport();
+		}
+	}
+}

--- a/spine-unity/Modules/com.esotericsoftware.spine.on-demand-loading/Editor/TextureImporterUtils.cs.meta
+++ b/spine-unity/Modules/com.esotericsoftware.spine.on-demand-loading/Editor/TextureImporterUtils.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d7e6bbfca422433c9e60e78930eae065
+timeCreated: 1708382726

--- a/spine-unity/Modules/com.esotericsoftware.spine.on-demand-loading/Runtime/GenericOnDemandTextureLoader.cs
+++ b/spine-unity/Modules/com.esotericsoftware.spine.on-demand-loading/Runtime/GenericOnDemandTextureLoader.cs
@@ -264,6 +264,10 @@ namespace Spine.Unity {
 			System.Action<Texture> onTextureLoaded) {
 
 			PlaceholderTextureMapping[] placeholderTextures = placeholderMap[materialIndex].textures;
+			if (placeholderTextures == null || textureIndex >= placeholderTextures.Length) {
+				return null;
+			}
+
 			TargetReference targetReference = placeholderTextures[textureIndex].targetTextureReference;
 			loadedDataAtMaterial[materialIndex].lastFrameRequested = Time.frameCount;
 

--- a/spine-unity/Modules/com.esotericsoftware.spine.on-demand-loading/Runtime/GenericOnDemandTextureLoader.cs
+++ b/spine-unity/Modules/com.esotericsoftware.spine.on-demand-loading/Runtime/GenericOnDemandTextureLoader.cs
@@ -194,7 +194,13 @@ namespace Spine.Unity {
 				loadedDataAtMaterial = new MaterialOnDemandData[placeholderMap.Length];
 				for (int i = 0, count = loadedDataAtMaterial.Length; i < count; ++i) {
 					loadedDataAtMaterial[i].lastFrameRequested = -1;
-					int texturesAtMaterial = placeholderMap[i].textures.Length;
+
+					var textures = placeholderMap[i].textures;
+					if (textures == null) {
+						continue;
+					}
+
+					int texturesAtMaterial = textures.Length;
 					loadedDataAtMaterial[i].textureRequests = new TextureRequest[texturesAtMaterial];
 				}
 			}


### PR DESCRIPTION
While updating our spine skeleton with 70+ skins, I found multiple issues that caused the team members to get confused about how to update the current On-demand setup due to the new skeleton data having more textures than previous version.

So I went ahead and fixed all the issues I could find while editing and re-generating the on-demand textures mapping. (You can see the issues I got below).

Also, I have added a logic to make sure the low quality textures will keep the same compression settings set on the original ones. This is done by unchecking the overrides before the logic to rescale the texture and enable the same overrides again after saving the rescaled texture. See: `TextureImporterUtils.cs`

> Those changes were created based on branch 4.1 since it looks like 4.2-beta does not contain new changes on those classes.

## Issues I was getting:
-  **ArgumentException: Texture2D.SetPixels: texture uses an unsupported format:**
```
ArgumentException: Texture2D.SetPixels: texture uses an unsupported format. (Texture 'Ello_low')
UnityEngine.Texture2D.SetPixels (System.Int32 x, System.Int32 y, System.Int32 blockWidth, System.Int32 blockHeight, UnityEngine.Color[] colors, System.Int32 miplevel) (at /Users/bokken/build/output/unity/unity/Runtime/Export/Graphics/Texture.cs:751)
UnityEngine.Texture2D.SetPixels (UnityEngine.Color[] colors) (at /Users/bokken/build/output/unity/unity/Runtime/Export/Graphics/Texture.cs:770)
Spine.Unity.Editor.GenericOnDemandTextureLoaderInspector`2+StaticMethodImplementations[TargetReference,TextureRequest].CreatePlaceholderTextureFor (UnityEngine.Texture originalTexture, System.Int32 maxPlaceholderSize, Spine.Unity.GenericOnDemandTextureLoader`2[TargetReference,TextureRequest] loader) (at ./Library/PackageCache/com.esotericsoftware.spine.on-demand-loading@b3aa3e0c48/Editor/GenericOnDemandTextureLoaderInspector.cs:209)
Spine.Unity.Editor.GenericOnDemandTextureLoaderInspector`2+StaticMethodImplementations[TargetReference,TextureRequest].SetupForAtlasAsset (Spine.Unity.GenericOnDemandTextureLoader`2[TargetReference,TextureRequest] loader, Spine.Unity.AtlasAssetBase atlasAsset) (at ./Library/PackageCache/com.esotericsoftware.spine.on-demand-loading@b3aa3e0c48/Editor/GenericOnDemandTextureLoaderInspector.cs:168)
Spine.Unity.Editor.GenericOnDemandTextureLoaderInspector`2+StaticMethodImplementations[TargetReference,TextureRequest].AddOnDemandLoader (UnityEditor.MenuCommand cmd) (at ./Library/PackageCache/com.esotericsoftware.spine.on-demand-loading@b3aa3e0c48/Editor/GenericOnDemandTextureLoaderInspector.cs:135)
Spine.Unity.Editor.AddressablesTextureLoaderInspector.AddAddressablesLoader (UnityEditor.MenuCommand cmd) (at ./Library/PackageCache/com.esotericsoftware.spine.addressables@b3aa3e0c48/Editor/AddressablesTextureLoaderInspector.cs:91)
```

- **NullReferenceException**:
```
NullReferenceException: Object reference not set to an instance of an object
Spine.Unity.GenericOnDemandTextureLoader`2[TargetReference,TextureRequest].BeginCustomTextureLoading () (at ./Packages/com.esotericsoftware.spine.on-demand-loading/Runtime/GenericOnDemandTextureLoader.cs:197)
Spine.Unity.GenericOnDemandTextureLoader`2[TargetReference,TextureRequest].AssignTargetTextures (System.Collections.Generic.IEnumerable`1[UnityEngine.Material]& modifiedMaterials) (at ./Packages/com.esotericsoftware.spine.on-demand-loading/Runtime/GenericOnDemandTextureLoader.cs:175)
Spine.Unity.Editor.GenericOnDemandTextureLoaderInspector`2[TargetReference,TextureRequest].AssignTargetTextures (Spine.Unity.GenericOnDemandTextureLoader`2[TargetReference,TextureRequest] loader) (at ./Packages/com.esotericsoftware.spine.on-demand-loading/Editor/GenericOnDemandTextureLoaderInspector.cs:407)
Spine.Unity.Editor.GenericOnDemandTextureLoaderInspector`2[TargetReference,TextureRequest].ReinitPlaceholderTextures (Spine.Unity.GenericOnDemandTextureLoader`2[TargetReference,TextureRequest] loader) (at ./Packages/com.esotericsoftware.spine.on-demand-loading/Editor/GenericOnDemandTextureLoaderInspector.cs:391)
Spine.Unity.Editor.GenericOnDemandTextureLoaderInspector`2[TargetReference,TextureRequest].OnInspectorGUI () (at ./Packages/com.esotericsoftware.spine.on-demand-loading/Editor/GenericOnDemandTextureLoaderInspector.cs:360)
UnityEditor.UIElements.InspectorElement+<>c__DisplayClass72_0.<CreateInspectorElementUsingIMGUI>b__0 () (at /Users/bokken/build/output/unity/unity/Editor/Mono/UIElements/Inspector/InspectorElement.cs:713)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr, Boolean&) (at /Users/bokken/build/output/unity/unity/Modules/IMGUI/GUIUtility.cs:190)
```

- **IndexOutOfRangeException**:
```
IndexOutOfRangeException: Index was outside the bounds of the array.
Spine.Unity.Editor.GenericOnDemandTextureLoaderInspector`2[TargetReference,TextureRequest].DeletePlaceholderTextures (Spine.Unity.GenericOnDemandTextureLoader`2[TargetReference,TextureRequest] loader) (at ./Packages/com.esotericsoftware.spine.on-demand-loading/Editor/GenericOnDemandTextureLoaderInspector.cs:377)
Spine.Unity.Editor.GenericOnDemandTextureLoaderInspector`2[TargetReference,TextureRequest].ReinitPlaceholderTextures (Spine.Unity.GenericOnDemandTextureLoader`2[TargetReference,TextureRequest] loader) (at ./Packages/com.esotericsoftware.spine.on-demand-loading/Editor/GenericOnDemandTextureLoaderInspector.cs:387)
Spine.Unity.Editor.GenericOnDemandTextureLoaderInspector`2[TargetReference,TextureRequest].OnInspectorGUI () (at ./Packages/com.esotericsoftware.spine.on-demand-loading/Editor/GenericOnDemandTextureLoaderInspector.cs:360)
UnityEditor.UIElements.InspectorElement+<>c__DisplayClass72_0.<CreateInspectorElementUsingIMGUI>b__0 () (at /Users/bokken/build/output/unity/unity/Editor/Mono/UIElements/Inspector/InspectorElement.cs:713)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr, Boolean&) (at /Users/bokken/build/output/unity/unity/Modules/IMGUI/GUIUtility.cs:190)
```

