### PR TITLE
[spine-unity] Fix for the issue [2346] causing canvasRenderers and submeshGraphics to get unsynced

### DIFF
--- a/spine-unity/Assets/Spine/Runtime/spine-unity/Components/SkeletonGraphic.cs
+++ b/spine-unity/Assets/Spine/Runtime/spine-unity/Components/SkeletonGraphic.cs
@@ -991,6 +991,20 @@ namespace Spine.Unity {
 #if UNITY_EDITOR
 			RemoveNullCanvasRenderers();
 #endif
+			foreach (var currentCanvasRenderer in canvasRenderers) {
+				if (!currentCanvasRenderer.TryGetComponent<SkeletonSubmeshGraphic>(out var submeshGraphic)) {
+					AddNewSubmeshGraphic(currentCanvasRenderer.gameObject);
+					continue;
+				}
+
+				if (!submeshGraphics.Contains(submeshGraphic)) {
+					submeshGraphics.Add(submeshGraphic);
+					continue;
+				}
+
+				AddNewSubmeshGraphic(currentCanvasRenderer.gameObject);
+			}
+
 			int currentCount = canvasRenderers.Count;
 			for (int i = currentCount; i < targetCount; ++i) {
 				GameObject go = new GameObject(string.Format("Renderer{0}", i), typeof(RectTransform));
@@ -998,15 +1012,19 @@ namespace Spine.Unity {
 				go.transform.localPosition = Vector3.zero;
 				CanvasRenderer canvasRenderer = go.AddComponent<CanvasRenderer>();
 				canvasRenderers.Add(canvasRenderer);
-				SkeletonSubmeshGraphic submeshGraphic = go.AddComponent<SkeletonSubmeshGraphic>();
-				submeshGraphic.maskable = this.maskable;
-				submeshGraphic.raycastTarget = false;
-				submeshGraphic.rectTransform.pivot = rectTransform.pivot;
-				submeshGraphic.rectTransform.anchorMin = Vector2.zero;
-				submeshGraphic.rectTransform.anchorMax = Vector2.one;
-				submeshGraphic.rectTransform.sizeDelta = Vector2.zero;
-				submeshGraphics.Add(submeshGraphic);
+				AddNewSubmeshGraphic(canvasRenderer.gameObject);
 			}
+		}
+
+		private void AddNewSubmeshGraphic(GameObject targetGameObject) {
+			SkeletonSubmeshGraphic submeshGraphic = targetGameObject.AddComponent<SkeletonSubmeshGraphic>();
+			submeshGraphic.maskable = this.maskable;
+			submeshGraphic.raycastTarget = false;
+			submeshGraphic.rectTransform.pivot = rectTransform.pivot;
+			submeshGraphic.rectTransform.anchorMin = Vector2.zero;
+			submeshGraphic.rectTransform.anchorMax = Vector2.one;
+			submeshGraphic.rectTransform.sizeDelta = Vector2.zero;
+			submeshGraphics.Add(submeshGraphic);
 		}
 
 		protected void PrepareRendererGameObjects (SkeletonRendererInstruction currentInstructions,

--- a/spine-unity/Assets/Spine/Runtime/spine-unity/Components/SkeletonGraphic.cs
+++ b/spine-unity/Assets/Spine/Runtime/spine-unity/Components/SkeletonGraphic.cs
@@ -991,19 +991,7 @@ namespace Spine.Unity {
 #if UNITY_EDITOR
 			RemoveNullCanvasRenderers();
 #endif
-			foreach (var currentCanvasRenderer in canvasRenderers) {
-				if (!currentCanvasRenderer.TryGetComponent<SkeletonSubmeshGraphic>(out var submeshGraphic)) {
-					AddNewSubmeshGraphic(currentCanvasRenderer.gameObject);
-					continue;
-				}
-
-				if (!submeshGraphics.Contains(submeshGraphic)) {
-					submeshGraphics.Add(submeshGraphic);
-					continue;
-				}
-
-				AddNewSubmeshGraphic(currentCanvasRenderer.gameObject);
-			}
+			SyncSubmeshGraphicsWithCanvasRenderers();
 
 			int currentCount = canvasRenderers.Count;
 			for (int i = currentCount; i < targetCount; ++i) {
@@ -1012,19 +1000,15 @@ namespace Spine.Unity {
 				go.transform.localPosition = Vector3.zero;
 				CanvasRenderer canvasRenderer = go.AddComponent<CanvasRenderer>();
 				canvasRenderers.Add(canvasRenderer);
-				AddNewSubmeshGraphic(canvasRenderer.gameObject);
+				SkeletonSubmeshGraphic submeshGraphic = go.AddComponent<SkeletonSubmeshGraphic>();
+				submeshGraphic.maskable = this.maskable;
+				submeshGraphic.raycastTarget = false;
+				submeshGraphic.rectTransform.pivot = rectTransform.pivot;
+				submeshGraphic.rectTransform.anchorMin = Vector2.zero;
+				submeshGraphic.rectTransform.anchorMax = Vector2.one;
+				submeshGraphic.rectTransform.sizeDelta = Vector2.zero;
+				submeshGraphics.Add(submeshGraphic);
 			}
-		}
-
-		private void AddNewSubmeshGraphic(GameObject targetGameObject) {
-			SkeletonSubmeshGraphic submeshGraphic = targetGameObject.AddComponent<SkeletonSubmeshGraphic>();
-			submeshGraphic.maskable = this.maskable;
-			submeshGraphic.raycastTarget = false;
-			submeshGraphic.rectTransform.pivot = rectTransform.pivot;
-			submeshGraphic.rectTransform.anchorMin = Vector2.zero;
-			submeshGraphic.rectTransform.anchorMax = Vector2.one;
-			submeshGraphic.rectTransform.sizeDelta = Vector2.zero;
-			submeshGraphics.Add(submeshGraphic);
 		}
 
 		protected void PrepareRendererGameObjects (SkeletonRendererInstruction currentInstructions,


### PR DESCRIPTION
Fix for the [issue 2346](https://github.com/EsotericSoftware/spine-runtimes/issues/2346) causing canvasRenderers and submeshGraphics to get unsynced and throwing null exception reference at:

https://github.com/EsotericSoftware/spine-runtimes/blob/3b8069f4b91cc05329147c372446cd5b54e0f5dd/spine-unity/Assets/Spine/Runtime/spine-unity/Components/SkeletonGraphic.cs#L1055