### PR TITLE
[ts][pixi] Add `tint` property for Pixi's convention.

### DIFF
--- a/spine-ts/spine-core/src/Utils.ts
+++ b/spine-ts/spine-core/src/Utils.ts
@@ -172,9 +172,7 @@ export class Color {
 	}
 
 	toRgb888 () {
-		function hex(x: number) {
-			return ("0" + (x * 255).toString(16)).slice(-2);
-		}
+		const hex = (x: number) => ("0" + (x * 255).toString(16)).slice(-2);
 		return Number("0x" + hex(this.r) + hex(this.g) + hex(this.b));
 	}
 

--- a/spine-ts/spine-core/src/Utils.ts
+++ b/spine-ts/spine-core/src/Utils.ts
@@ -171,6 +171,13 @@ export class Color {
 		color.b = ((value & 0x000000ff)) / 255;
 	}
 
+	toRgb888 () {
+		function hex(x: number) {
+			return ("0" + (x * 255).toString(16)).slice(-2);
+		}
+		return Number("0x" + hex(this.r) + hex(this.g) + hex(this.b));
+	}
+
 	static fromString (hex: string): Color {
 		return new Color().setFromString(hex);
 	}

--- a/spine-ts/spine-pixi/src/Spine.ts
+++ b/spine-ts/spine-pixi/src/Spine.ts
@@ -432,6 +432,13 @@ export class Spine extends Container {
 		Spine.skeletonCache[cacheKey] = skeletonData;
 		return new this(skeletonData, options);
 	}
+
+	public get tint (): number {
+		return this.skeleton.color.toRgb888();
+	}
+	public set tint (value: number) {
+		Color.rgb888ToColor(this.skeleton.color, value);
+	}
 }
 
 Skeleton.yDown = true;


### PR DESCRIPTION
[Issue 2527](https://github.com/EsotericSoftware/spine-runtimes/issues/2527)

[Pixi uses](https://pixijs.download/v6.1.0-rc.2/docs/PIXI.Sprite.html#tint) `tint: number` for color, it would be nice to match the convention and expose the property for easy usage:

```
spineboy.tint = 0xff00ff;
console.log(spineboy.tint);
```