### PR TITLE
Add IsNextReady to TrackEntry

### DIFF
--- a/spine-csharp/src/AnimationState.cs
+++ b/spine-csharp/src/AnimationState.cs
@@ -1217,7 +1217,7 @@ namespace Spine {
 		/// <summary>Returns true if the next track entry is about to be applied on the next update call.</summary>
 		/// <seealso cref="AnimationState.Apply(Skeleton)"/>
 		public bool WillNextBeAppliedOnUpdate {
-            get { return next != null && System.MathF.Abs(nextTrackLast - next.delay) >= float.Epsilon; }
+            get { return next != null && System.MathF.Abs(nextTrackLast - next.delay) < float.Epsilon; }
         }
 
 		/// <summary>

--- a/spine-csharp/src/AnimationState.cs
+++ b/spine-csharp/src/AnimationState.cs
@@ -1216,8 +1216,8 @@ namespace Spine {
 
 		/// <summary>Returns true if the next track entry is about to be applied on the next update call.</summary>
 		/// <seealso cref="AnimationState.Apply(Skeleton)"/>
-		public bool WillNextBeAppliedOnUpdate {
-            get { return next != null && System.MathF.Abs(nextTrackLast - next.delay) < float.Epsilon; }
+        public bool IsNextReady {
+			get { return next != null && nextTrackLast - next.delay >= 0; }
         }
 
 		/// <summary>

--- a/spine-csharp/src/AnimationState.cs
+++ b/spine-csharp/src/AnimationState.cs
@@ -1214,9 +1214,9 @@ namespace Spine {
 			get { return nextTrackLast != -1; }
 		}
 
-		/// <summary>Returns true if the next track entry has been applied at least once.</summary>
+		/// <summary>Returns true if the next track entry is about to be applied on the next update call.</summary>
 		/// <seealso cref="AnimationState.Apply(Skeleton)"/>
-		public bool WasNextApplied {
+		public bool WillNextBeAppliedOnUpdate {
             get { return next != null && System.MathF.Abs(nextTrackLast - next.delay) >= float.Epsilon; }
         }
 

--- a/spine-csharp/src/AnimationState.cs
+++ b/spine-csharp/src/AnimationState.cs
@@ -1214,6 +1214,12 @@ namespace Spine {
 			get { return nextTrackLast != -1; }
 		}
 
+		/// <summary>Returns true if the next track entry has been applied at least once.</summary>
+		/// <seealso cref="AnimationState.Apply(Skeleton)"/>
+		public bool WasNextApplied {
+            get { return next != null && System.MathF.Abs(nextTrackLast - next.delay) >= float.Epsilon; }
+        }
+
 		/// <summary>
 		/// Returns true if at least one loop has been completed.</summary>
 		/// <seealso cref="TrackEntry.Complete"/>


### PR DESCRIPTION
This allows users to check when/if the next TrackEntry in a sequence of TrackEntries is applied (i.e. TrackEntries added to the currently playing TrackEntry using AnimationState.AddAnimation.

This is intended to avoid exposing any additional internal members that could be confusing to some users.

This is to avoid the issue that when TrackEntry has a non-null next member, using TrackEntry.Next.WasApplied will always return true, regardless of whether it has ever actually been applied.

If any changes are needed, or this logic doesn't work as it seems to with my use-case, or if these kinds of pull-requests are unsuitable, then please let me know. Thank you for this awesome tool!