### PR TITLE
[ts][pixi] Spine pixi fixes

### DIFF
--- a/spine-ts/spine-pixi/src/Spine.ts
+++ b/spine-ts/spine-pixi/src/Spine.ts
@@ -227,8 +227,15 @@ export class Spine extends Container {
 	/**
 	 * If you want to manually handle which meshes go on which slot and how you cache, overwrite this method.
 	 */
-	protected getMeshForSlot (slot: Slot): ISlotMesh {
-		if (!this.meshesCache.has(slot)) {
+	protected hasMeshForSlot(slot: Slot) {
+		return this.meshesCache.has(slot);
+	}
+
+	/**
+	 * If you want to manually handle which meshes go on which slot and how you cache, overwrite this method.
+	 */
+	protected getMeshForSlot(slot: Slot): ISlotMesh {
+		if (!this.hasMeshForSlot(slot)) {
 			let mesh = this.slotMeshFactory();
 			this.addChild(mesh);
 			this.meshesCache.set(slot, mesh);
@@ -410,6 +417,9 @@ export class Spine extends Container {
 				pixiMaskSource = { slot, computed: false };
 				continue;
 			} else {
+				if (this.hasMeshForSlot(slot)) {
+					this.getMeshForSlot(slot).renderable = false;
+				}
 				Spine.clipper.clipEndWithSlot(slot);
 				this.pixiMaskCleanup(slot);
 				continue;
@@ -481,6 +491,7 @@ export class Spine extends Container {
 				}
 
 				const mesh = this.getMeshForSlot(slot);
+                mesh.renderable = true;
 				mesh.zIndex = zIndex;
 				mesh.updateFromSpineData(texture, slot.data.blendMode, slot.data.name, finalVertices, finalVerticesLength, finalIndices, finalIndicesLength, useDarkColor);
 			}

--- a/spine-ts/spine-pixi/src/Spine.ts
+++ b/spine-ts/spine-pixi/src/Spine.ts
@@ -341,7 +341,7 @@ export class Spine extends Container {
 			if (!pixiMaskSource.computed) {
 				pixiMaskSource.computed = true;
 				const clippingAttachment = pixiMaskSource.slot.attachment as ClippingAttachment;
-                const world = new Array(clippingAttachment.worldVerticesLength);
+				const world = new Array(clippingAttachment.worldVerticesLength);
 				clippingAttachment.computeWorldVertices(pixiMaskSource.slot, 0, clippingAttachment.worldVerticesLength, world, 0, 2);
 				mask.clear().lineStyle(0).beginFill(0x000000).drawPolygon(world);
 			}
@@ -491,7 +491,7 @@ export class Spine extends Container {
 				}
 
 				const mesh = this.getMeshForSlot(slot);
-                mesh.renderable = true;
+				mesh.renderable = true;
 				mesh.zIndex = zIndex;
 				mesh.updateFromSpineData(texture, slot.data.blendMode, slot.data.name, finalVertices, finalVerticesLength, finalIndices, finalIndicesLength, useDarkColor);
 			}

--- a/spine-ts/spine-pixi/src/Spine.ts
+++ b/spine-ts/spine-pixi/src/Spine.ts
@@ -229,7 +229,7 @@ export class Spine extends Container {
 	 * Check the existence of a mesh for the given slot.
 	 * If you want to manually handle which meshes go on which slot and how you cache, overwrite this method.
 	 */
-	protected hasMeshForSlot(slot: Slot) {
+	protected hasMeshForSlot (slot: Slot) {
 		return this.meshesCache.has(slot);
 	}
 
@@ -237,7 +237,7 @@ export class Spine extends Container {
 	 * Search the mesh corresponding to the given slot or create it, if it does not exists.
 	 * If you want to manually handle which meshes go on which slot and how you cache, overwrite this method.
 	 */
-	protected getMeshForSlot(slot: Slot): ISlotMesh {
+	protected getMeshForSlot (slot: Slot): ISlotMesh {
 		if (!this.hasMeshForSlot(slot)) {
 			let mesh = this.slotMeshFactory();
 			this.addChild(mesh);
@@ -349,8 +349,8 @@ export class Spine extends Container {
 				clippingAttachment.computeWorldVertices(pixiMaskSource.slot, 0, worldVerticesLength, this.clippingVertAux, 0, 2);
 				mask.clear().lineStyle(0).beginFill(0x000000);
 				mask.moveTo(this.clippingVertAux[0], this.clippingVertAux[1]);
-				for (let i = 2; i < worldVerticesLength; i+=2) {
-					mask.lineTo(this.clippingVertAux[i], this.clippingVertAux[i+1]);
+				for (let i = 2; i < worldVerticesLength; i += 2) {
+					mask.lineTo(this.clippingVertAux[i], this.clippingVertAux[i + 1]);
 				}
 				mask.finishPoly();
 			}

--- a/spine-ts/spine-pixi/src/Spine.ts
+++ b/spine-ts/spine-pixi/src/Spine.ts
@@ -341,7 +341,7 @@ export class Spine extends Container {
 			if (!pixiMaskSource.computed) {
 				pixiMaskSource.computed = true;
 				const clippingAttachment = pixiMaskSource.slot.attachment as ClippingAttachment;
-				const world = Array.from(clippingAttachment.vertices);
+                const world = new Array(clippingAttachment.worldVerticesLength);
 				clippingAttachment.computeWorldVertices(pixiMaskSource.slot, 0, clippingAttachment.worldVerticesLength, world, 0, 2);
 				mask.clear().lineStyle(0).beginFill(0x000000).drawPolygon(world);
 			}


### PR DESCRIPTION
# Changes to spine-pixi
## Spine.ts
### Empty Attachment keyframes
slots with keyframes on the attachment property will continue rendering their previous attachment if they were keyed to remove the attachment.
#### Solution
we now check for the existence of the mesh when there is no attachment and set its renderable property to false if thats the case.

### Weighted clipping polygons
In the case of clipping attachments, the vertices properties can be very different to a simple x,y pairing if it uses a weighted clipping polygon. When calculating the worldVertices for the pixi graphics object, the resulting vertices array was being used as a basis for the end result rather than the vertexCount length, producing garbage data at the tail end of the world vertices array.
#### example clipping attachment data:
```
"vertexCount": 4,
"vertices": [ 1, 15, -47.71, 34.91, 1, 1, 18, -47.86, -35.06, 1, 1, 17, 47.8, -34.9, 1, 1, 16, 47.81, 34.87, 1 ]
```
this would produce a world vertices array of length 12
when the intended size was 8
#### Solution
we now create the world vertices array using the worldVerticesLength property to determine its length

