### PR TITLE
replaces setTransform on slotObject

### DIFF
--- a/spine-ts/spine-pixi/src/Spine.ts
+++ b/spine-ts/spine-pixi/src/Spine.ts
@@ -329,7 +329,9 @@ export class Spine extends Container {
 		}
 	}
 	private updatePixiObject (pixiObject: Container, slot: Slot, zIndex: number) {
-		pixiObject.setTransform(slot.bone.worldX, slot.bone.worldY, slot.bone.getWorldScaleX(), slot.bone.getWorldScaleX(), slot.bone.getWorldRotationX() * MathUtils.degRad);
+		pixiObject.position.set(slot.bone.worldX, slot.bone.worldY);
+		pixiObject.scale.set(slot.bone.getWorldScaleX(), slot.bone.getWorldScaleX());
+		pixiObject.rotation = slot.bone.getWorldRotationX() * MathUtils.degRad;
 		pixiObject.zIndex = zIndex + 1;
 		pixiObject.alpha = this.skeleton.color.a * slot.color.a;
 	}


### PR DESCRIPTION
Sorry only just noticed this also:

setTransform on pixi displayObjects performs:
```
this.scale.x = !scaleX ? 1 : scaleX;
this.scale.y = !scaleY ? 1 : scaleY;
```
meaning any transformations to scale 0 will become scale 1