### PR TITLE
Flutter runtime: fix varying Podfile.lock checksums by using standard pod target dir for HEADER_SEARCH_PATHS

### DIFF
--- a/spine-flutter/ios/spine_flutter.podspec
+++ b/spine-flutter/ios/spine_flutter.podspec
@@ -19,7 +19,7 @@ A new Flutter FFI plugin project.
   # `../src/*` so that the C sources can be shared among all target platforms.
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*.{cpp}'
-  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '"' + __dir__ + '/Classes/spine-cpp/include"' }
+  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)/Classes/spine-cpp/include"' }
   s.dependency 'Flutter'
   s.platform = :ios, '9.0'
 

--- a/spine-flutter/macos/spine_flutter.podspec
+++ b/spine-flutter/macos/spine_flutter.podspec
@@ -19,7 +19,7 @@ A new Flutter FFI plugin project.
   # `../src/*` so that the C sources can be shared among all target platforms.
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*.{cpp}'
-  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '"' + __dir__ + '/Classes/spine-cpp/include"' }
+  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)/Classes/spine-cpp/include"' }
   s.dependency 'FlutterMacOS'
 
   s.platform = :osx, '10.11'


### PR DESCRIPTION
**Issue:**
The current .podspec files (for both iOS and macOS) define the `HEADER_SEARCH_PATHS` using `__dir__`. There is nothing wrong with this in isolation.
On running `pod install` in a Spine-dependent Flutter project, this generates the `Local Podspecs/spine_flutter.podspec.json` file with the `HEADER_SEARCH_PATHS` value containing a path specific to that machine/environment. For example, if I ran this locally for a Flutter iOS project, it would result in:
```
"HEADER_SEARCH_PATHS": "\"Users/andeart/my_flutter_project/ios/.symlinks/plugins/spine_flutter/ios/Classes/spine-cpp/include\""
```
This is still harmless in isolation as this file is typically inside a gitignored directory for the Flutter project, and so (in theory) _should not_ matter that it contains values specific to the developer's environment.

However, because of this machine/environment-specific value, the Flutter project's `ios/Podfile.lock` file now contains a `spine_flutter` spec-checksum entry that varies per developer/environment. This is an issue on shared Flutter projects because the `Podfile.lock` files are usually added to source control.

In other words, due to the nature of the current `HEADER_SEARCH_PATHS` assignment, every cloner of the Spine-dependent Flutter repo will end up with a different `spine_flutter` spec-checksum entry in their `ios/Podfile.lock` file, leading to source-control hassles or repeated overwrites of the same file without any dependency changes to explain it.

---

**Solution:**
By using the officially defined `PODS_TARGET_SRCROOT` variable from the CocoaPods spec, the generated `spine_flutter.podspec.json` gets generated with a `HEADER_SEARCH_PATHS` value that is not specific to that machine/environment, and (importantly) still points to the same location of the expected `spine-cpp` directory within that Flutter project's iOS plugins.
Consequently, even after running `pod install`, the spec-checksum of the `spine_flutter` entry in `ios/Podfile.lock` remains constant across machines/environments, as we might expect if the Spine dependency isn't actually being modified.

---

**Additional context:**
I gave this update a test with fresh clones across multiple machines and the checksum value in the `Podfile.lock` files now remains consistent across multiple machines, for both iOS and macOS.

Let me know if I missed anything please. Thanks for creating this useful runtime!