### PR TITLE
[godot] Fix Skeleton/Texture loader for runtime loading

### DIFF
--- a/spine-godot/spine_godot/SpineAnimationTrack.cpp
+++ b/spine-godot/spine_godot/SpineAnimationTrack.cpp
@@ -37,7 +37,7 @@
 #include "scene/resources/animation.h"
 
 #ifdef TOOLS_ENABLED
-#include "godot/editor/editor_node.h"
+#include "editor/editor_node.h"
 #include "editor/plugins/animation_player_editor_plugin.h"
 #include "editor/plugins/animation_tree_editor_plugin.h"
 #endif

--- a/spine-godot/spine_godot/SpineSkeletonFileResource.cpp
+++ b/spine-godot/spine_godot/SpineSkeletonFileResource.cpp
@@ -89,6 +89,7 @@ static char *readString(BinaryInput *input) {
 }
 
 void SpineSkeletonFileResource::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("load_from_file", "path"), &SpineSkeletonFileResource::load_from_file);
 	ADD_SIGNAL(MethodInfo("skeleton_file_changed"));
 }
 

--- a/spine-godot/spine_godot/docs/SpineSkeletonFileResource.xml
+++ b/spine-godot/spine_godot/docs/SpineSkeletonFileResource.xml
@@ -9,6 +9,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="load_from_file">
+			<return type="int" enum="Error" />
+			<argument index="0" name="path" type="String" />
+			<description>
+			</description>
+		</method>
 	</methods>
 	<constants>
 	</constants>


### PR DESCRIPTION
The API `load_from_xxx()` must be valid for files outside `res://` in the Godot.

- Expose `load_from_file()` in `SpineSkeletonFileResource`
- Fix `GodotSpineTextureLoader` for runtime loading to avoid using `ResourceLoader` if it is not in the `res://`
  -  `load_from_atlas_file()` has been fixed to allow loading files outside of `res://`
 
**Known issues:**

1. If there is an image in `res://`, a load error occurs while the `.import` is not created, because `ResourceLoader` is used. If you generate images from Godot and Spine loads them, it is recommended to output them in the `user://` folder.
2. There is a problem that `Resource.duplicate()` does not work for `SpineSkeletonFileResource` and `SpineAtlasResource` because Spine's data resources have incomplete serialization integration with Godot's Resource. This PR allows us to serialize the internal data of those SpineResources to our own Resource, and when we want to load Spine, we can temporarily output those serialized data as a file in the `user://` folder, and load Spine from there to make it work, although it's bit hacky.