### PR TITLE
Fix possible NAN in IkConstraint.cpp

### DIFF
--- a/spine-cpp/spine-cpp/src/spine/IkConstraint.cpp
+++ b/spine-cpp/spine-cpp/src/spine/IkConstraint.cpp
@@ -208,8 +208,9 @@ void IkConstraint::apply(Bone &parent, Bone &child, float targetX, float targetY
 			r0 = q / c2;
 			r1 = c0 / q;
 			r = MathUtil::abs(r0) < MathUtil::abs(r1) ? r0 : r1;
-			if (r * r <= dd) {
-				y = MathUtil::sqrt(dd - r * r) * bendDir;
+			float ddrr = dd - r * r;
+			if (ddrr >= 0) {
+				y = MathUtil::sqrt(ddrr) * bendDir;
 				a1 = ta - MathUtil::atan2(y, r);
 				a2 = MathUtil::atan2(y / psy, (r - l1) / psx);
 				goto break_outer;


### PR DESCRIPTION
additional negative sqrt protection, float expressions may be not exact on android NDK 25.2.9519653 devices Oppo Find x3, Huawei lite M5

![image](https://github.com/user-attachments/assets/e08cc43e-76ef-4ba1-a382-78e0f6d2b5c7)
