### PR TITLE
Make String::startsWith and String::lastIndexOf const.

### DIFF
--- a/spine-cpp/spine-cpp/include/spine/SpineString.h
+++ b/spine-cpp/spine-cpp/include/spine/SpineString.h
@@ -179,7 +179,7 @@ namespace spine {
 			return *this;
 		}
 
-		bool startsWith(const String &needle) {
+		bool startsWith(const String &needle) const {
 			if (needle.length() > length()) return false;
 			for (int i = 0; i < (int)needle.length(); i++) {
 				if (buffer()[i] != needle.buffer()[i]) return false;
@@ -187,7 +187,7 @@ namespace spine {
 			return true;
 		}
 
-        int lastIndexOf(const char c) {
+        int lastIndexOf(const char c) const {
             for (int i = (int)length() - 1; i >= 0; i--) {
                 if (buffer()[i] == c) return i;
             }


### PR DESCRIPTION
The `String::startsWith` and `String::lastIndexOf` methods were not marked `const` which makes it impossible to use them when we only have constant String object.