### PR TITLE
[spine-unity] SkeletonRenderTexture set dynamic GameObject layer same as original Renderer

### DIFF
--- a/spine-unity/Assets/Spine Examples/Scripts/Sample Components/SkeletonRenderTexture/SkeletonRenderTexture.cs
+++ b/spine-unity/Assets/Spine Examples/Scripts/Sample Components/SkeletonRenderTexture/SkeletonRenderTexture.cs
@@ -86,6 +86,7 @@ namespace Spine.Unity.Examples {
 		void CreateQuadChild () {
 			quad = new GameObject(this.name + " RenderTexture", typeof(MeshRenderer), typeof(MeshFilter));
 			quad.transform.SetParent(this.transform.parent, false);
+			quad.layer = meshRenderer.gameObject.layer;
 			quadMeshRenderer = quad.GetComponent<MeshRenderer>();
 			quadMeshFilter = quad.GetComponent<MeshFilter>();
 


### PR DESCRIPTION
When using the example `SkeletonRenderTexture` Component, new GameObject is created in hierarchy to hold Quad with RenderTexture Renderer. Sorting layer and sorting order values are mimicking the original Renderer as expected, but the GameObject Layer is not and kept Default.

Please consider this tiny touch, so the dynamically created Renderer is as close to original Renderer and so is for example being visible to the same Cameras when using layer mask culling.