### PR TITLE
[spine-ios] ADD: Spine support Cocoapods Static Framework

### DIFF
--- a/Spine.podspec
+++ b/Spine.podspec
@@ -14,11 +14,15 @@ Spine runtimes for iOS.
   s.license          = { :file => 'LICENSE' }
 
   s.source           = { :git => 'https://github.com/esotericsoftware/spine-runtimes.git', :branch => '4.2' }
-  s.source_files     = 'spine-ios/Sources/Spine/**/*.{swift,metal}'
+  s.source_files     = 'spine-ios/Sources/Spine/**/*.{swift}'
   s.platform         = :ios, '13.0'
 
   s.xcconfig = {
     'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/SpineCppLite/spine-cpp/spine-cpp/include" "$(PODS_ROOT)/SpineCppLite/spine-cpp/spine-cpp-lite"'
+  }
+
+  s.resource_bundles = {
+    'SpineBundle' => ['spine-ios/Sources/Spine/**/*.{metal}']
   }
 
   s.swift_version = '5.0'

--- a/spine-ios/Sources/Spine/Metal/SpineRenderer.swift
+++ b/spine-ios/Sources/Spine/Metal/SpineRenderer.swift
@@ -61,7 +61,8 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
         #if SWIFT_PACKAGE // SPM
         bundle = .module
         #else // CocoaPods
-        bundle = Bundle(for: SpineRenderer.self)
+        let bundleURL = Bundle(for: SpineRenderer.self).url(forResource: "SpineBundle", withExtension: "bundle")
+        bundle = Bundle(url: bundleURL!)!
         #endif
         
         let defaultLibrary = try device.makeDefaultLibrary(bundle: bundle)


### PR DESCRIPTION
# Support for both Static and Dynamic Framework
* Extract a SpineBundle to house the SpineShader.metal file, ensuring support for both static and dynamic libraries.