### PR TITLE
[Spine-Android]FIX: clipEnd is not called  when attachment is null.

### DIFF
--- a/spine-android/spine-android/src/main/java/com/esotericsoftware/spine/android/SkeletonRenderer.java
+++ b/spine-android/spine-android/src/main/java/com/esotericsoftware/spine/android/SkeletonRenderer.java
@@ -112,6 +112,7 @@ public class SkeletonRenderer {
 			short[] indices = null;
 			Attachment attachment = slot.getAttachment();
 			if (attachment == null) {
+				clipper.clipEnd(slot);
 				continue;
 			}
 


### PR DESCRIPTION
If the attachment of the slot which has **End Slot** properties set is **null**, then _clipEnd_ will not called ever, which will cause rendering issue.