### PR TITLE
[spine-cpp] FIX: Crash! The verticesLength variable isn't being used

### DIFF
--- a/spine-cpp/spine-cpp/src/spine/SkeletonBinary.cpp
+++ b/spine-cpp/spine-cpp/src/spine/SkeletonBinary.cpp
@@ -608,8 +608,8 @@ Attachment *SkeletonBinary::readAttachment(DataInput *input, Skin *skin, int slo
 				setError("Error reading attachment: ", name.buffer());
 				return NULL;
 			}
-			readVertices(input, box->getVertices(), box->getBones(), (flags & 16) != 0);
-			box->setWorldVerticesLength(box->getVertices().size());
+			int verticesLength = readVertices(input, box->getVertices(), box->getBones(), (flags & 16) != 0);
+			box->setWorldVerticesLength(verticesLength);
 			if (nonessential) {
 				readColor(input, box->getColor());
 			}


### PR DESCRIPTION
`verticesLength` is not used，This could cause the bounding box feature to crash.