### PR TITLE
[ios] Fix the issue where the SkeletonBounds instance couldn’t be initialized

### DIFF
--- a/spine-cpp/spine-cpp-lite/spine-cpp-lite.h
+++ b/spine-cpp/spine-cpp-lite/spine-cpp-lite.h
@@ -1049,6 +1049,7 @@ SPINE_CPP_LITE_EXPORT void spine_texture_region_set_original_width(spine_texture
 SPINE_CPP_LITE_EXPORT int32_t spine_texture_region_get_original_height(spine_texture_region textureRegion);
 SPINE_CPP_LITE_EXPORT void spine_texture_region_set_original_height(spine_texture_region textureRegion, int32_t originalHeight);
 
+// @ignore
 SPINE_CPP_LITE_EXPORT spine_skeleton_bounds spine_skeleton_bounds_create();
 SPINE_CPP_LITE_EXPORT void spine_skeleton_bounds_dispose(spine_skeleton_bounds bounds);
 SPINE_CPP_LITE_EXPORT void spine_skeleton_bounds_update(spine_skeleton_bounds bounds, spine_skeleton skeleton, spine_bool updateAabb);

--- a/spine-ios/Sources/Spine/Spine.Generated+Extensions.swift
+++ b/spine-ios/Sources/Spine/Spine.Generated+Extensions.swift
@@ -313,3 +313,9 @@ internal enum FileSource {
 extension String: Error {
     
 }
+
+public extension SkeletonBounds {
+    static func create() -> SkeletonBounds {
+        return SkeletonBounds(spine_skeleton_bounds_create())
+    }
+}

--- a/spine-ios/Sources/Spine/Spine.Generated.swift
+++ b/spine-ios/Sources/Spine/Spine.Generated.swift
@@ -1757,11 +1757,6 @@ public final class SkeletonBounds: NSObject {
         return spine_skeleton_bounds_get_height(wrappee)
     }
 
-    @discardableResult
-    public func create() -> SkeletonBounds {
-        return .init(spine_skeleton_bounds_create())
-    }
-
     public func dispose() {
         if disposed { return }
         disposed = true


### PR DESCRIPTION
`SkeletonBounds` has internal access, which is determined by the Python code. Because of that, we need to add a static method in `Spine.Generated+Extensions.swift` to create an instance.