### PR TITLE
[ios] Provide the ability to convert an Attachment into a BoundingBoxAttachment

### DIFF
--- a/spine-cpp/spine-cpp-lite/spine-cpp-lite.cpp
+++ b/spine-cpp/spine-cpp-lite/spine-cpp-lite.cpp
@@ -2424,6 +2424,16 @@ spine_attachment spine_attachment_copy(spine_attachment attachment) {
 	return (spine_attachment) _attachment->copy();
 }
 
+spine_bounding_box_attachment spine_attachment_cast_to_bounding_box_attachment(spine_attachment attachment) {
+    if (attachment == nullptr) return nullptr;
+    Attachment *_attachment = (Attachment *)attachment;
+    if (_attachment->getRTTI().isExactly(BoundingBoxAttachment::rtti)) {
+        BoundingBoxAttachment *boundingBox = static_cast<BoundingBoxAttachment *>(_attachment);
+        return (spine_bounding_box_attachment)boundingBox;
+    }
+    return nullptr;
+}
+
 void spine_attachment_dispose(spine_attachment attachment) {
 	if (attachment == nullptr) return;
 	Attachment *_attachment = (Attachment *) attachment;

--- a/spine-cpp/spine-cpp-lite/spine-cpp-lite.h
+++ b/spine-cpp/spine-cpp-lite/spine-cpp-lite.h
@@ -630,6 +630,8 @@ SPINE_CPP_LITE_EXPORT const utf8 *spine_attachment_get_name(spine_attachment att
 SPINE_CPP_LITE_EXPORT spine_attachment_type spine_attachment_get_type(spine_attachment attachment);
 // @ignore
 SPINE_CPP_LITE_EXPORT spine_attachment spine_attachment_copy(spine_attachment attachment);
+// @optional
+SPINE_CPP_LITE_EXPORT spine_bounding_box_attachment spine_attachment_cast_to_bounding_box_attachment(spine_attachment attachment);
 SPINE_CPP_LITE_EXPORT void spine_attachment_dispose(spine_attachment attachment);
 
 SPINE_CPP_LITE_EXPORT spine_vector spine_point_attachment_compute_world_position(spine_point_attachment attachment, spine_bone bone);

--- a/spine-ios/Sources/Spine/Spine.Generated.swift
+++ b/spine-ios/Sources/Spine/Spine.Generated.swift
@@ -2553,6 +2553,11 @@ public final class Attachment: NSObject {
         return spine_attachment_get_type(wrappee)
     }
 
+    @discardableResult
+    public func castToBoundingBoxAttachment() -> BoundingBoxAttachment? {
+        return spine_attachment_cast_to_bounding_box_attachment(wrappee).flatMap { .init($0) }
+    }
+
     public func dispose() {
         if disposed { return }
         disposed = true


### PR DESCRIPTION
`BoundingBoxAttachment` is supposed to be a subclass of `Attachment` in SpineCppLite, but in Swift Spine, they’re not treated that way since both inherit from `NSObject`. When we’re trying to get the bounding box, we end up with an `Attachment` object, but `SkeletonBounds` needs a `BoundingBoxAttachment` to get the `Polygon`. So, we need to support type conversion for this.

Demo:

**InteractiveSpineView**
```
import Foundation
import SwiftUI
import Spine
import SpineCppLite

struct InteractiveSpineView: View {

    @StateObject var viewModel = InteractiveSpineViewModel()

    var body: some View {
        GeometryReader { geometry in
            VStack(alignment: .center, spacing: 20) {
                SpineView(
                    from: .bundle(atlasFileName: "role_jessica.atlas", skeletonFileName: "role_jessica.skel", bundle: .main),
                    controller: viewModel.controller ?? SpineController(),
                    mode: .fit,
                    alignment: .center,
                    boundsProvider: SkinAndAnimationBounds(animation: "action/happy1"),
                    backgroundColor: UIColor.white
                )
                .frame(width: geometry.size.width, height: 500)
                .gesture(
                    DragGesture(minimumDistance: 0, coordinateSpace: .local)
                        .onEnded { value in
                            let tapLocation = value.location
                            viewModel.tapPoint(tapLocation)
                        }
                )
                .padding(.top, 100)

                Text(viewModel.hitLabelText)
                    .padding()
                    .border(Color.gray, width: 1)
            }
            .navigationTitle("InteractiveSpine")
            .navigationBarTitleDisplayMode(.inline)
        }
    }
}

#Preview {
    InteractiveSpineView()
}
```

**InteractiveSpineViewModel**
```
import Foundation
import SwiftUI
import Spine
import SpineCppLite

class InteractiveSpineViewModel: NSObject, ObservableObject {

    @Published var controller: SpineController?

    @Published var hitLabelText: String = "Label indicator"

    private lazy var skeletonBounds: SkeletonBounds = {
        return SkeletonBounds.create()
    }()

    override init() {
        super.init()
        controller = SpineController(
            onInitialized: { controller in
                controller.animationState.setAnimationByName(trackIndex: 0, animationName: "action/highfive_waiting", loop: true)
        })
    }

    public func tapPoint(_ point: CGPoint) {
        guard let skeletonPoint = controller?.toSkeletonCoordinates(position: point),
              let skeleton = controller?.skeleton else {
            return
        }
        skeletonBounds.update(skeleton: skeleton, updateAabb: true)

        guard let attachment = controller?.skeleton.getAttachmentByName(slotName: "region", attachmentName: "regionAttachment"),
              let polygon = skeletonBounds.getPolygon(attachment: attachment.castToBoundingBoxAttachment()) else {
            return
        }
        let result = skeletonBounds.containsPoint(polygon: polygon, x: Float(skeletonPoint.x), y: Float(skeletonPoint.y))
        let text = result ? "hit bounding area" : "missed"
        hitLabelText = text
    }
}
```
