### PR TITLE
[ios] Using `UnsafeBufferPointer` to skip data copying and boost performance.

### DIFF
--- a/spine-cpp/spine-cpp-lite/spine-cpp-lite-codegen.py
+++ b/spine-cpp/spine-cpp-lite/spine-cpp-lite-codegen.py
@@ -305,19 +305,19 @@ class SwiftFunctionBodyWriter:
       return function_call
   
   def write_array_spine_class(self, num_function_name, function_call):
-    array_call = f"let num = Int({num_function_name}({self.spine_object.var_name}))"
-    array_call += "\n"
-    array_call += inset + inset
-    array_call += f"let ptr = {function_call}"
+    array_call = f"let ptr = {function_call}"
     array_call += "\n"
     array_call += inset + inset
     array_call += "guard let validPtr = ptr else { return [] }"
     array_call += "\n"
     array_call += inset + inset
+    array_call += f"let num = Int({num_function_name}({self.spine_object.var_name}))"
+    array_call += "\n"
+    array_call += inset + inset
     array_call += "let buffer = UnsafeBufferPointer(start: validPtr, count: num)"
     array_call += "\n"
     array_call += inset + inset
-    array_call += "return Array(buffer).compactMap {"
+    array_call += "return buffer.compactMap {"
     array_call += "\n"
     array_call += inset + inset + inset
     array_call += "$0.flatMap { .init($0) }"
@@ -329,15 +329,16 @@ class SwiftFunctionBodyWriter:
   def write_array_call(self, num_function_name, function_call):
     if self.spine_function.isReturningSpineClass():
        return self.write_array_spine_class(num_function_name, function_call)
-    array_call = f"let num = Int({num_function_name}({self.spine_object.var_name}))"
-    array_call += "\n"
-    array_call += inset + inset
-    array_call += f"let ptr = {function_call}"
+    array_call = f"let ptr = {function_call}"
     array_call += "\n"
     array_call += inset + inset
     array_call += "guard let validPtr = ptr else { return [] }"
     array_call += "\n"
     array_call += inset + inset
+    array_call += f"let num = Int({num_function_name}({self.spine_object.var_name}))"
+    array_call += "\n"
+    array_call += inset + inset
+
     array_call += "let buffer = UnsafeBufferPointer(start: validPtr, count: num)"
     array_call += "\n"
     array_call += inset + inset

--- a/spine-cpp/spine-cpp-lite/spine-cpp-lite-codegen.py
+++ b/spine-cpp/spine-cpp-lite/spine-cpp-lite-codegen.py
@@ -239,8 +239,6 @@ class SwiftFunctionBodyWriter:
 
     if swift_return_type_is_array:
       body += self.write_array_call(num_function_name, function_call)
-      body += inset + inset
-      body += "}"
     else:
       if not self.spine_function.return_type == "void":
         body += "return "
@@ -305,24 +303,45 @@ class SwiftFunctionBodyWriter:
          function_call += " != 0"
 
       return function_call
-    
-  def write_array_call(self, num_function_name, function_call):
+  
+  def write_array_spine_class(self, num_function_name, function_call):
     array_call = f"let num = Int({num_function_name}({self.spine_object.var_name}))"
     array_call += "\n"
     array_call += inset + inset
     array_call += f"let ptr = {function_call}"
     array_call += "\n"
     array_call += inset + inset
-    array_call += "return (0..<num).compactMap {"
+    array_call += "guard let validPtr = ptr else { return [] }"
+    array_call += "\n"
+    array_call += inset + inset
+    array_call += "let buffer = UnsafeBufferPointer(start: validPtr, count: num)"
+    array_call += "\n"
+    array_call += inset + inset
+    array_call += "return Array(buffer).compactMap {"
     array_call += "\n"
     array_call += inset + inset + inset
-
-    if self.spine_function.isReturningSpineClass():
-        array_call += "ptr?[$0].flatMap { .init($0) }" 
-    else:
-      array_call += "ptr?[$0]"
-
+    array_call += "$0.flatMap { .init($0) }"
     array_call += "\n"
+    array_call += inset + inset
+    array_call += "}"
+    return array_call
+    
+  def write_array_call(self, num_function_name, function_call):
+    if self.spine_function.isReturningSpineClass():
+       return self.write_array_spine_class(num_function_name, function_call)
+    array_call = f"let num = Int({num_function_name}({self.spine_object.var_name}))"
+    array_call += "\n"
+    array_call += inset + inset
+    array_call += f"let ptr = {function_call}"
+    array_call += "\n"
+    array_call += inset + inset
+    array_call += "guard let validPtr = ptr else { return [] }"
+    array_call += "\n"
+    array_call += inset + inset
+    array_call += "let buffer = UnsafeBufferPointer(start: validPtr, count: num)"
+    array_call += "\n"
+    array_call += inset + inset
+    array_call += "return Array(buffer)"
     return array_call
   
   def write_dispose_call(self):

--- a/spine-ios/Sources/Spine/Extensions/RenderCommand+Vertices.swift
+++ b/spine-ios/Sources/Spine/Extensions/RenderCommand+Vertices.swift
@@ -10,7 +10,7 @@ extension RenderCommand {
         let positions = positions(numVertices: numVertices)
         let uvs = uvs(numVertices: numVertices)
         let colors = colors(numVertices: numVertices)
-        
+        vertices.reserveCapacity(indices.count)
         for i in 0..<indices.count {
             let index = Int(indices[i])
             

--- a/spine-ios/Sources/Spine/Spine.Generated+Extensions.swift
+++ b/spine-ios/Sources/Spine/Spine.Generated+Extensions.swift
@@ -215,19 +215,25 @@ internal extension RenderCommand {
     func positions(numVertices: Int) -> [Float] {
         let num = numVertices * 2
         let ptr = spine_render_command_get_positions(wrappee)
-        return (0..<num).compactMap { ptr?[$0] }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer)
     }
     
     func uvs(numVertices: Int) -> [Float] {
         let num = numVertices * 2
         let ptr = spine_render_command_get_uvs(wrappee)
-        return (0..<num).compactMap { ptr?[$0] }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer)
     }
     
     func colors(numVertices: Int) ->[Int32] {
         let num = numVertices
         let ptr = spine_render_command_get_colors(wrappee)
-        return (0..<num).compactMap { ptr?[$0] }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer)
     }
 }
 

--- a/spine-ios/Sources/Spine/Spine.Generated.swift
+++ b/spine-ios/Sources/Spine/Spine.Generated.swift
@@ -24,11 +24,11 @@ public final class TransformConstraintData: NSObject {
     }
 
     public var bones: [BoneData] {
-        let num = Int(spine_transform_constraint_data_get_num_bones(wrappee))
         let ptr = spine_transform_constraint_data_get_bones(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_transform_constraint_data_get_num_bones(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
@@ -454,11 +454,11 @@ public final class TransformConstraint: NSObject {
     }
 
     public var bones: [Bone] {
-        let num = Int(spine_transform_constraint_get_num_bones(wrappee))
         let ptr = spine_transform_constraint_get_bones(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_transform_constraint_get_num_bones(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
@@ -553,11 +553,11 @@ public final class PathConstraintData: NSObject {
     }
 
     public var bones: [BoneData] {
-        let num = Int(spine_path_constraint_data_get_num_bones(wrappee))
         let ptr = spine_path_constraint_data_get_bones(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_path_constraint_data_get_num_bones(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
@@ -772,11 +772,11 @@ public final class IkConstraintData: NSObject {
     }
 
     public var bones: [BoneData] {
-        let num = Int(spine_ik_constraint_data_get_num_bones(wrappee))
         let ptr = spine_ik_constraint_data_get_bones(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_ik_constraint_data_get_num_bones(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
@@ -1137,17 +1137,17 @@ public final class RegionAttachment: NSObject {
     }
 
     public var offset: [Float?] {
-        let num = Int(spine_region_attachment_get_num_offset(wrappee))
         let ptr = spine_region_attachment_get_offset(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_region_attachment_get_num_offset(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
         return Array(buffer)
     }
 
     public var uvs: [Float?] {
-        let num = Int(spine_region_attachment_get_num_uvs(wrappee))
         let ptr = spine_region_attachment_get_uvs(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_region_attachment_get_num_uvs(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
         return Array(buffer)
     }
@@ -1241,17 +1241,17 @@ public final class VertexAttachment: NSObject {
     }
 
     public var bones: [Int32?] {
-        let num = Int(spine_vertex_attachment_get_num_bones(wrappee))
         let ptr = spine_vertex_attachment_get_bones(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_vertex_attachment_get_num_bones(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
         return Array(buffer)
     }
 
     public var vertices: [Float?] {
-        let num = Int(spine_vertex_attachment_get_num_vertices(wrappee))
         let ptr = spine_vertex_attachment_get_vertices(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_vertex_attachment_get_num_vertices(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
         return Array(buffer)
     }
@@ -1373,25 +1373,25 @@ public final class MeshAttachment: NSObject {
     }
 
     public var regionUvs: [Float?] {
-        let num = Int(spine_mesh_attachment_get_num_region_uvs(wrappee))
         let ptr = spine_mesh_attachment_get_region_uvs(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_mesh_attachment_get_num_region_uvs(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
         return Array(buffer)
     }
 
     public var uvs: [Float?] {
-        let num = Int(spine_mesh_attachment_get_num_uvs(wrappee))
         let ptr = spine_mesh_attachment_get_uvs(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_mesh_attachment_get_num_uvs(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
         return Array(buffer)
     }
 
     public var triangles: [UInt16] {
-        let num = Int(spine_mesh_attachment_get_num_triangles(wrappee))
         let ptr = spine_mesh_attachment_get_triangles(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_mesh_attachment_get_num_triangles(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
         return Array(buffer)
     }
@@ -1413,9 +1413,9 @@ public final class MeshAttachment: NSObject {
     }
 
     public var edges: [UInt16] {
-        let num = Int(spine_mesh_attachment_get_num_edges(wrappee))
         let ptr = spine_mesh_attachment_get_edges(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_mesh_attachment_get_num_edges(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
         return Array(buffer)
     }
@@ -1478,9 +1478,9 @@ public final class PathAttachment: NSObject {
     }
 
     public var lengths: [Float?] {
-        let num = Int(spine_path_attachment_get_num_lengths(wrappee))
         let ptr = spine_path_attachment_get_lengths(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_path_attachment_get_num_lengths(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
         return Array(buffer)
     }
@@ -1572,11 +1572,11 @@ public final class PathConstraint: NSObject {
     }
 
     public var bones: [Bone] {
-        let num = Int(spine_path_constraint_get_num_bones(wrappee))
         let ptr = spine_path_constraint_get_bones(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_path_constraint_get_num_bones(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
@@ -1744,21 +1744,21 @@ public final class SkeletonBounds: NSObject {
     }
 
     public var polygons: [Polygon] {
-        let num = Int(spine_skeleton_bounds_get_num_polygons(wrappee))
         let ptr = spine_skeleton_bounds_get_polygons(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_bounds_get_num_polygons(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var boundingBoxes: [BoundingBoxAttachment] {
-        let num = Int(spine_skeleton_bounds_get_num_bounding_boxes(wrappee))
         let ptr = spine_skeleton_bounds_get_bounding_boxes(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_bounds_get_num_bounding_boxes(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
@@ -1961,9 +1961,9 @@ public final class RenderCommand: NSObject {
     }
 
     public var indices: [UInt16] {
-        let num = Int(spine_render_command_get_num_indices(wrappee))
         let ptr = spine_render_command_get_indices(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_render_command_get_num_indices(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
         return Array(buffer)
     }
@@ -1999,91 +1999,91 @@ public final class SkeletonData: NSObject {
     }
 
     public var bones: [BoneData] {
-        let num = Int(spine_skeleton_data_get_num_bones(wrappee))
         let ptr = spine_skeleton_data_get_bones(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_data_get_num_bones(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var slots: [SlotData] {
-        let num = Int(spine_skeleton_data_get_num_slots(wrappee))
         let ptr = spine_skeleton_data_get_slots(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_data_get_num_slots(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var skins: [Skin] {
-        let num = Int(spine_skeleton_data_get_num_skins(wrappee))
         let ptr = spine_skeleton_data_get_skins(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_data_get_num_skins(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var events: [EventData] {
-        let num = Int(spine_skeleton_data_get_num_events(wrappee))
         let ptr = spine_skeleton_data_get_events(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_data_get_num_events(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var animations: [Animation] {
-        let num = Int(spine_skeleton_data_get_num_animations(wrappee))
         let ptr = spine_skeleton_data_get_animations(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_data_get_num_animations(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var ikConstraints: [IkConstraintData] {
-        let num = Int(spine_skeleton_data_get_num_ik_constraints(wrappee))
         let ptr = spine_skeleton_data_get_ik_constraints(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_data_get_num_ik_constraints(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var transformConstraints: [TransformConstraintData] {
-        let num = Int(spine_skeleton_data_get_num_transform_constraints(wrappee))
         let ptr = spine_skeleton_data_get_transform_constraints(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_data_get_num_transform_constraints(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var pathConstraints: [PathConstraintData] {
-        let num = Int(spine_skeleton_data_get_num_path_constraints(wrappee))
         let ptr = spine_skeleton_data_get_path_constraints(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_data_get_num_path_constraints(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var physicsConstraints: [PhysicsConstraintData] {
-        let num = Int(spine_skeleton_data_get_num_physics_constraints(wrappee))
         let ptr = spine_skeleton_data_get_physics_constraints(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_data_get_num_physics_constraints(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
@@ -2226,11 +2226,11 @@ public final class IkConstraint: NSObject {
     }
 
     public var bones: [Bone] {
-        let num = Int(spine_ik_constraint_get_num_bones(wrappee))
         let ptr = spine_ik_constraint_get_bones(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_ik_constraint_get_num_bones(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
@@ -2953,71 +2953,71 @@ public final class Skeleton: NSObject {
     }
 
     public var bones: [Bone] {
-        let num = Int(spine_skeleton_get_num_bones(wrappee))
         let ptr = spine_skeleton_get_bones(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_get_num_bones(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var slots: [Slot] {
-        let num = Int(spine_skeleton_get_num_slots(wrappee))
         let ptr = spine_skeleton_get_slots(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_get_num_slots(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var drawOrder: [Slot] {
-        let num = Int(spine_skeleton_get_num_draw_order(wrappee))
         let ptr = spine_skeleton_get_draw_order(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_get_num_draw_order(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var ikConstraints: [IkConstraint] {
-        let num = Int(spine_skeleton_get_num_ik_constraints(wrappee))
         let ptr = spine_skeleton_get_ik_constraints(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_get_num_ik_constraints(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var transformConstraints: [TransformConstraint] {
-        let num = Int(spine_skeleton_get_num_transform_constraints(wrappee))
         let ptr = spine_skeleton_get_transform_constraints(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_get_num_transform_constraints(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var pathConstraints: [PathConstraint] {
-        let num = Int(spine_skeleton_get_num_path_constraints(wrappee))
         let ptr = spine_skeleton_get_path_constraints(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_get_num_path_constraints(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var physicsConstraints: [PhysicsConstraint] {
-        let num = Int(spine_skeleton_get_num_physics_constraints(wrappee))
         let ptr = spine_skeleton_get_physics_constraints(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skeleton_get_num_physics_constraints(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
@@ -3182,11 +3182,11 @@ public final class Sequence: NSObject {
     }
 
     public var regions: [TextureRegion] {
-        let num = Int(spine_sequence_get_num_regions(wrappee))
         let ptr = spine_sequence_get_regions(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_sequence_get_num_regions(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
@@ -3250,9 +3250,9 @@ public final class Polygon: NSObject {
     }
 
     public var vertices: [Float?] {
-        let num = Int(spine_polygon_get_num_vertices(wrappee))
         let ptr = spine_polygon_get_vertices(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_polygon_get_num_vertices(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
         return Array(buffer)
     }
@@ -3478,11 +3478,11 @@ public final class Bone: NSObject {
     }
 
     public var children: [Bone] {
-        let num = Int(spine_bone_get_num_children(wrappee))
         let ptr = spine_bone_get_children(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_bone_get_num_children(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
@@ -3850,21 +3850,21 @@ public final class Skin: NSObject {
     }
 
     public var bones: [BoneData] {
-        let num = Int(spine_skin_get_num_bones(wrappee))
         let ptr = spine_skin_get_bones(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skin_get_num_bones(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }
 
     public var constraints: [ConstraintData] {
-        let num = Int(spine_skin_get_num_constraints(wrappee))
         let ptr = spine_skin_get_constraints(wrappee)
         guard let validPtr = ptr else { return [] }
+        let num = Int(spine_skin_get_num_constraints(wrappee))
         let buffer = UnsafeBufferPointer(start: validPtr, count: num)
-        return Array(buffer).compactMap {
+        return buffer.compactMap {
             $0.flatMap { .init($0) }
         }
     }

--- a/spine-ios/Sources/Spine/Spine.Generated.swift
+++ b/spine-ios/Sources/Spine/Spine.Generated.swift
@@ -26,8 +26,10 @@ public final class TransformConstraintData: NSObject {
     public var bones: [BoneData] {
         let num = Int(spine_transform_constraint_data_get_num_bones(wrappee))
         let ptr = spine_transform_constraint_data_get_bones(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
@@ -454,8 +456,10 @@ public final class TransformConstraint: NSObject {
     public var bones: [Bone] {
         let num = Int(spine_transform_constraint_get_num_bones(wrappee))
         let ptr = spine_transform_constraint_get_bones(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
@@ -551,8 +555,10 @@ public final class PathConstraintData: NSObject {
     public var bones: [BoneData] {
         let num = Int(spine_path_constraint_data_get_num_bones(wrappee))
         let ptr = spine_path_constraint_data_get_bones(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
@@ -768,8 +774,10 @@ public final class IkConstraintData: NSObject {
     public var bones: [BoneData] {
         let num = Int(spine_ik_constraint_data_get_num_bones(wrappee))
         let ptr = spine_ik_constraint_data_get_bones(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
@@ -1131,17 +1139,17 @@ public final class RegionAttachment: NSObject {
     public var offset: [Float?] {
         let num = Int(spine_region_attachment_get_num_offset(wrappee))
         let ptr = spine_region_attachment_get_offset(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0]
-        }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer)
     }
 
     public var uvs: [Float?] {
         let num = Int(spine_region_attachment_get_num_uvs(wrappee))
         let ptr = spine_region_attachment_get_uvs(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0]
-        }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer)
     }
 
     public var x: Float {
@@ -1235,17 +1243,17 @@ public final class VertexAttachment: NSObject {
     public var bones: [Int32?] {
         let num = Int(spine_vertex_attachment_get_num_bones(wrappee))
         let ptr = spine_vertex_attachment_get_bones(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0]
-        }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer)
     }
 
     public var vertices: [Float?] {
         let num = Int(spine_vertex_attachment_get_num_vertices(wrappee))
         let ptr = spine_vertex_attachment_get_vertices(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0]
-        }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer)
     }
 
     public var timelineAttachment: Attachment? {
@@ -1367,25 +1375,25 @@ public final class MeshAttachment: NSObject {
     public var regionUvs: [Float?] {
         let num = Int(spine_mesh_attachment_get_num_region_uvs(wrappee))
         let ptr = spine_mesh_attachment_get_region_uvs(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0]
-        }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer)
     }
 
     public var uvs: [Float?] {
         let num = Int(spine_mesh_attachment_get_num_uvs(wrappee))
         let ptr = spine_mesh_attachment_get_uvs(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0]
-        }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer)
     }
 
     public var triangles: [UInt16] {
         let num = Int(spine_mesh_attachment_get_num_triangles(wrappee))
         let ptr = spine_mesh_attachment_get_triangles(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0]
-        }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer)
     }
 
     public var color: Color {
@@ -1407,9 +1415,9 @@ public final class MeshAttachment: NSObject {
     public var edges: [UInt16] {
         let num = Int(spine_mesh_attachment_get_num_edges(wrappee))
         let ptr = spine_mesh_attachment_get_edges(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0]
-        }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer)
     }
 
     public var hullLength: Int32 {
@@ -1472,9 +1480,9 @@ public final class PathAttachment: NSObject {
     public var lengths: [Float?] {
         let num = Int(spine_path_attachment_get_num_lengths(wrappee))
         let ptr = spine_path_attachment_get_lengths(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0]
-        }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer)
     }
 
     public var color: Color {
@@ -1566,8 +1574,10 @@ public final class PathConstraint: NSObject {
     public var bones: [Bone] {
         let num = Int(spine_path_constraint_get_num_bones(wrappee))
         let ptr = spine_path_constraint_get_bones(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
@@ -1736,16 +1746,20 @@ public final class SkeletonBounds: NSObject {
     public var polygons: [Polygon] {
         let num = Int(spine_skeleton_bounds_get_num_polygons(wrappee))
         let ptr = spine_skeleton_bounds_get_polygons(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var boundingBoxes: [BoundingBoxAttachment] {
         let num = Int(spine_skeleton_bounds_get_num_bounding_boxes(wrappee))
         let ptr = spine_skeleton_bounds_get_bounding_boxes(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
@@ -1949,9 +1963,9 @@ public final class RenderCommand: NSObject {
     public var indices: [UInt16] {
         let num = Int(spine_render_command_get_num_indices(wrappee))
         let ptr = spine_render_command_get_indices(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0]
-        }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer)
     }
 
     public var atlasPage: Int32 {
@@ -1987,72 +2001,90 @@ public final class SkeletonData: NSObject {
     public var bones: [BoneData] {
         let num = Int(spine_skeleton_data_get_num_bones(wrappee))
         let ptr = spine_skeleton_data_get_bones(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var slots: [SlotData] {
         let num = Int(spine_skeleton_data_get_num_slots(wrappee))
         let ptr = spine_skeleton_data_get_slots(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var skins: [Skin] {
         let num = Int(spine_skeleton_data_get_num_skins(wrappee))
         let ptr = spine_skeleton_data_get_skins(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var events: [EventData] {
         let num = Int(spine_skeleton_data_get_num_events(wrappee))
         let ptr = spine_skeleton_data_get_events(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var animations: [Animation] {
         let num = Int(spine_skeleton_data_get_num_animations(wrappee))
         let ptr = spine_skeleton_data_get_animations(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var ikConstraints: [IkConstraintData] {
         let num = Int(spine_skeleton_data_get_num_ik_constraints(wrappee))
         let ptr = spine_skeleton_data_get_ik_constraints(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var transformConstraints: [TransformConstraintData] {
         let num = Int(spine_skeleton_data_get_num_transform_constraints(wrappee))
         let ptr = spine_skeleton_data_get_transform_constraints(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var pathConstraints: [PathConstraintData] {
         let num = Int(spine_skeleton_data_get_num_path_constraints(wrappee))
         let ptr = spine_skeleton_data_get_path_constraints(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var physicsConstraints: [PhysicsConstraintData] {
         let num = Int(spine_skeleton_data_get_num_physics_constraints(wrappee))
         let ptr = spine_skeleton_data_get_physics_constraints(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
@@ -2196,8 +2228,10 @@ public final class IkConstraint: NSObject {
     public var bones: [Bone] {
         let num = Int(spine_ik_constraint_get_num_bones(wrappee))
         let ptr = spine_ik_constraint_get_bones(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
@@ -2921,56 +2955,70 @@ public final class Skeleton: NSObject {
     public var bones: [Bone] {
         let num = Int(spine_skeleton_get_num_bones(wrappee))
         let ptr = spine_skeleton_get_bones(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var slots: [Slot] {
         let num = Int(spine_skeleton_get_num_slots(wrappee))
         let ptr = spine_skeleton_get_slots(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var drawOrder: [Slot] {
         let num = Int(spine_skeleton_get_num_draw_order(wrappee))
         let ptr = spine_skeleton_get_draw_order(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var ikConstraints: [IkConstraint] {
         let num = Int(spine_skeleton_get_num_ik_constraints(wrappee))
         let ptr = spine_skeleton_get_ik_constraints(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var transformConstraints: [TransformConstraint] {
         let num = Int(spine_skeleton_get_num_transform_constraints(wrappee))
         let ptr = spine_skeleton_get_transform_constraints(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var pathConstraints: [PathConstraint] {
         let num = Int(spine_skeleton_get_num_path_constraints(wrappee))
         let ptr = spine_skeleton_get_path_constraints(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var physicsConstraints: [PhysicsConstraint] {
         let num = Int(spine_skeleton_get_num_physics_constraints(wrappee))
         let ptr = spine_skeleton_get_physics_constraints(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
@@ -3136,8 +3184,10 @@ public final class Sequence: NSObject {
     public var regions: [TextureRegion] {
         let num = Int(spine_sequence_get_num_regions(wrappee))
         let ptr = spine_sequence_get_regions(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
@@ -3202,9 +3252,9 @@ public final class Polygon: NSObject {
     public var vertices: [Float?] {
         let num = Int(spine_polygon_get_num_vertices(wrappee))
         let ptr = spine_polygon_get_vertices(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0]
-        }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer)
     }
 
 }
@@ -3430,8 +3480,10 @@ public final class Bone: NSObject {
     public var children: [Bone] {
         let num = Int(spine_bone_get_num_children(wrappee))
         let ptr = spine_bone_get_children(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
@@ -3800,16 +3852,20 @@ public final class Skin: NSObject {
     public var bones: [BoneData] {
         let num = Int(spine_skin_get_num_bones(wrappee))
         let ptr = spine_skin_get_bones(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 
     public var constraints: [ConstraintData] {
         let num = Int(spine_skin_get_num_constraints(wrappee))
         let ptr = spine_skin_get_constraints(wrappee)
-        return (0..<num).compactMap {
-            ptr?[$0].flatMap { .init($0) }
+        guard let validPtr = ptr else { return [] }
+        let buffer = UnsafeBufferPointer(start: validPtr, count: num)
+        return Array(buffer).compactMap {
+            $0.flatMap { .init($0) }
         }
     }
 


### PR DESCRIPTION
# Optimizing Spine Performance on iOS: Reducing CPU Costs with UnsafeBufferPointer
Recently, I tested the performance of Spine on an iPad and noticed that it has high CPU usage. To dig deeper into the performance costs, I used Xcode Instruments' Time Profiler. After analyzing the data, I discovered that the most CPU-intensive function was `RenderCommand.getVertices()`.

One of the main issues I identified was the use of compactMap, which adds extra overhead during array generation. In contrast, using UnsafeBufferPointer helps to avoid this performance penalty, significantly reducing CPU usage.

After testing various Spine files and animations, I found that switching to UnsafeBufferPointer resulted in a 12% to 20% reduction in CPU usage. This optimization worked well for both animations and skins, improving performance across the board.

Additionally, I found that pre-allocating array capacity with `vertices.reserveCapacity(indices.count)` is also beneficial. This prevents the need for array resizing when new elements are appended, which can also incur high CPU costs.

# Performance Comparison: spine-boy Walk Animation
Here’s a comparison of the performance when using the [spine-boy](https://github.com/EsotericSoftware/spine-runtimes/tree/4.2/spine-ios/Example%20-%20Cocoapods/Spine%20iOS%20Example/spineboy) `walk` animation:

**Use `compactMap` to generate an array(By default):**
<img width="816" alt="image" src="https://github.com/user-attachments/assets/594f2a6e-232d-48e1-adac-149dad002e6a">

**Use `UnsafeBufferPointer ` :**
![image](https://github.com/user-attachments/assets/c5722f4b-d1cf-4df3-a2a6-1c195448a3ac)
