### PR TITLE
[ts][pixi-v7] Fix incorrect pixiObject scale in updatePixiObject

### DIFF
--- a/spine-ts/spine-pixi-v7/src/Spine.ts
+++ b/spine-ts/spine-pixi-v7/src/Spine.ts
@@ -398,7 +398,7 @@ export class Spine extends Container {
 	}
 	private updatePixiObject (pixiObject: Container, slot: Slot, zIndex: number) {
 		pixiObject.position.set(slot.bone.worldX, slot.bone.worldY);
-		pixiObject.scale.set(slot.bone.getWorldScaleX(), slot.bone.getWorldScaleX());
+		pixiObject.scale.set(slot.bone.getWorldScaleX(), slot.bone.getWorldScaleY());
 		pixiObject.rotation = slot.bone.getWorldRotationX() * MathUtils.degRad;
 		pixiObject.zIndex = zIndex + 1;
 		pixiObject.alpha = this.skeleton.color.a * slot.color.a;


### PR DESCRIPTION
This commit resolves a bug where both the X and Y components of the pixiObject's scale were incorrectly set to the bone's worldScaleX, instead of applying the correct scaling for each axis.

Additionally, I have a question (apologies if this isn't the appropriate place): Is it intentional that a pixi object added using addSlotObject does not apply the slot's transformations and only the parent bone's transform? The method name suggests it would, so I'm wondering if I'm misunderstanding something. Thanks for the quick updates :)