### PR TITLE
[cpp] avoid null pointer deference in PhysicsConstraintTimeline

### DIFF
--- a/spine-cpp/spine-cpp/src/spine/PhysicsConstraintTimeline.cpp
+++ b/spine-cpp/spine-cpp/src/spine/PhysicsConstraintTimeline.cpp
@@ -95,6 +95,7 @@ void PhysicsConstraintResetTimeline::apply(Skeleton &skeleton, float lastTime, f
 		else {
 			Vector<PhysicsConstraint *> &physicsConstraints = skeleton.getPhysicsConstraints();
 			for (size_t i = 0; i < physicsConstraints.size(); i++) {
+                                constraint = physicsConstraints[i];
 				if (constraint->_active) constraint->reset();
 			}
 		}


### PR DESCRIPTION
Compiling spine-cpp with mingw and -Werror results in:

```
/home/ben/Dev/march/krit/spine-runtimes/spine-cpp/spine-cpp/src/spine/PhysicsConstraintTimeline.cpp:98:75: error: ‘this’ pointer is null [-Werror=nonnull]
   98 |                                 if (constraint->_active) constraint->reset();
      | 
```

This looks like a real issue as `constraint` is definitely null here. The intent seems pretty clear though so here's a quick fix - feel free to throw it away and fix it a different way.