### PR TITLE
[cmake] Add SPINE_SET_COMPILER_FLAGS

### DIFF
--- a/flags.cmake
+++ b/flags.cmake
@@ -1,4 +1,9 @@
 option(SPINE_SANITIZE "Build with sanitization" OFF)
+option(SPINE_SET_COMPILER_FLAGS "Set compiler flags" ON)
+
+if (NOT SPINE_SET_COMPILER_FLAGS)
+    return();
+endif()
 
 if(MSVC)
     message("MSCV detected")


### PR DESCRIPTION
The spine library setting compiler flags may not be wanted by the user using this library.
Adding an option to make it adjustable. 
