### PR TITLE
Fix: pixi v8 bug in validate renderables

### DIFF
--- a/spine-ts/spine-pixi-v8/src/Spine.ts
+++ b/spine-ts/spine-pixi-v8/src/Spine.ts
@@ -377,6 +377,7 @@ export class Spine extends ViewContainer {
 	}
 
 	private validateAttachments () {
+
 		const currentDrawOrder = this.skeleton.drawOrder;
 
 		const lastAttachments = this._lastAttachments;
@@ -404,7 +405,7 @@ export class Spine extends ViewContainer {
 			lastAttachments.length = index;
 		}
 
-		this.spineAttachmentsDirty = spineAttachmentsDirty;
+		this.spineAttachmentsDirty ||= spineAttachmentsDirty;
 	}
 
 	private updateAndSetPixiMask (slot: Slot, last: boolean) {

--- a/spine-ts/spine-pixi-v8/src/SpinePipe.ts
+++ b/spine-ts/spine-pixi-v8/src/SpinePipe.ts
@@ -73,8 +73,10 @@ export class SpinePipe implements RenderPipe<Spine> {
 	validateRenderable (spine: Spine): boolean {
 		spine._validateAndTransformAttachments();
 
+		const gpuSpine = this.gpuSpineData[spine.uid];
+
 		// if spine attachments have changed or destroyed, we need to rebuild the batch!
-		if (spine.spineAttachmentsDirty) {
+		if (spine.spineAttachmentsDirty || !gpuSpine) {
 			return true;
 		}
 
@@ -82,8 +84,7 @@ export class SpinePipe implements RenderPipe<Spine> {
 		else if (spine.spineTexturesDirty) {
 			// loop through and see if the textures have changed..
 			const drawOrder = spine.skeleton.drawOrder;
-			const gpuSpine = this.gpuSpineData[spine.uid];
-
+			
 			for (let i = 0, n = drawOrder.length; i < n; i++) {
 				const slot = drawOrder[i];
 				const attachment = slot.getAttachment();

--- a/spine-ts/spine-pixi-v8/src/SpinePipe.ts
+++ b/spine-ts/spine-pixi-v8/src/SpinePipe.ts
@@ -73,10 +73,8 @@ export class SpinePipe implements RenderPipe<Spine> {
 	validateRenderable (spine: Spine): boolean {
 		spine._validateAndTransformAttachments();
 
-		const gpuSpine = this.gpuSpineData[spine.uid];
-
 		// if spine attachments have changed or destroyed, we need to rebuild the batch!
-		if (spine.spineAttachmentsDirty || !gpuSpine) {
+		if (spine.spineAttachmentsDirty) {
 			return true;
 		}
 
@@ -84,7 +82,8 @@ export class SpinePipe implements RenderPipe<Spine> {
 		else if (spine.spineTexturesDirty) {
 			// loop through and see if the textures have changed..
 			const drawOrder = spine.skeleton.drawOrder;
-			
+			const gpuSpine = this.gpuSpineData[spine.uid];
+
 			for (let i = 0, n = drawOrder.length; i < n; i++) {
 				const slot = drawOrder[i];
 				const attachment = slot.getAttachment();
@@ -117,6 +116,9 @@ export class SpinePipe implements RenderPipe<Spine> {
 		const roundPixels = (this.renderer._roundPixels | spine._roundPixels) as 0 | 1;
 
 		spine._validateAndTransformAttachments();
+
+		spine.spineAttachmentsDirty = false;
+		spine.spineTexturesDirty = false;
 
 		for (let i = 0, n = drawOrder.length; i < n; i++) {
 			const slot = drawOrder[i];
@@ -155,6 +157,9 @@ export class SpinePipe implements RenderPipe<Spine> {
 		const gpuSpine = this.gpuSpineData[spine.uid];
 
 		spine._validateAndTransformAttachments();
+		
+		spine.spineAttachmentsDirty = false;
+		spine.spineTexturesDirty = false;
 
 		const drawOrder = spine.skeleton.drawOrder;
 


### PR DESCRIPTION
I notived that my inital implementation was should have been reseting `spineAttachmentsDirty` and
`spineTexturesDirty` each render.

This caused two issues:
- once `spineTexturesDirty` is forever true so it will always cause a rebuild of the scene.
- it can be the case that `spineAttachmentsDirty` is set to true and then set to false in the `_validateAndTransformAttachments` function. This will cause an issue if slots have changed, but not been rendered yet.

Easy enough fixes.. once I figured out where to look!



