### PR TITLE
[iOS] Refactor error and data access

### DIFF
--- a/spine-ios/Sources/Spine/BoundsProvider.swift
+++ b/spine-ios/Sources/Spine/BoundsProvider.swift
@@ -59,7 +59,7 @@ public final class SkinAndAnimationBounds: NSObject, BoundsProvider {
     /// the bounding box of the skeleton. If no skins are given, the default skin is used.
     /// The `stepTime`, given in seconds, defines at what interval the bounds should be sampled
     /// across the entire animation.
-    public init(animation: String? = nil, skins: [String]? = nil, let stepTime: TimeInterval = 0.1) {
+    public init(animation: String? = nil, skins: [String]? = nil, stepTime: TimeInterval = 0.1) {
         self.animation = animation
         if let skins, !skins.isEmpty {
             self.skins = skins

--- a/spine-ios/Sources/Spine/Extensions/SkeletonDrawableWrapper+CGImage.swift
+++ b/spine-ios/Sources/Spine/Extensions/SkeletonDrawableWrapper+CGImage.swift
@@ -27,7 +27,7 @@ public extension SkeletonDrawableWrapper {
         spineView.delegate?.draw(in: spineView)
         
         guard let texture = spineView.currentDrawable?.texture else {
-            throw "Could not read texture."
+            throw "Could not read texture." as SpineError
         }
         let width = texture.width
         let height = texture.height
@@ -47,7 +47,7 @@ public extension SkeletonDrawableWrapper {
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         guard let context = CGContext(data: data, width: width, height: height, bitsPerComponent: 8, bytesPerRow: rowBytes, space: colorSpace, bitmapInfo: bitmapInfo.rawValue),
               let cgImage = context.makeImage() else {
-                throw "Could not create image."
+                throw "Could not create image." as SpineError
         }
         return cgImage
     }

--- a/spine-ios/Sources/Spine/Extensions/SkeletonDrawableWrapper+CGImage.swift
+++ b/spine-ios/Sources/Spine/Extensions/SkeletonDrawableWrapper+CGImage.swift
@@ -27,7 +27,7 @@ public extension SkeletonDrawableWrapper {
         spineView.delegate?.draw(in: spineView)
         
         guard let texture = spineView.currentDrawable?.texture else {
-            throw "Could not read texture." as SpineError
+            throw SpineError("Could not read texture.")
         }
         let width = texture.width
         let height = texture.height
@@ -47,7 +47,7 @@ public extension SkeletonDrawableWrapper {
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         guard let context = CGContext(data: data, width: width, height: height, bitsPerComponent: 8, bytesPerRow: rowBytes, space: colorSpace, bitmapInfo: bitmapInfo.rawValue),
               let cgImage = context.makeImage() else {
-                throw "Could not create image." as SpineError
+                throw SpineError("Could not create image.")
         }
         return cgImage
     }

--- a/spine-ios/Sources/Spine/SkeletonDrawableWrapper.swift
+++ b/spine-ios/Sources/Spine/SkeletonDrawableWrapper.swift
@@ -94,22 +94,22 @@ public final class SkeletonDrawableWrapper: NSObject {
         self.skeletonData = skeletonData
             
         guard let nativeSkeletonDrawable = spine_skeleton_drawable_create(skeletonData.wrappee) else {
-            throw "Could not load native skeleton drawable"
+            throw "Could not load native skeleton drawable" as SpineError
         }
         skeletonDrawable = SkeletonDrawable(nativeSkeletonDrawable)
         
         guard let nativeSkeleton = spine_skeleton_drawable_get_skeleton(skeletonDrawable.wrappee) else {
-            throw "Could not load native skeleton"
+            throw "Could not load native skeleton" as SpineError
         }
         skeleton = Skeleton(nativeSkeleton)
         
         guard let nativeAnimationStateData = spine_skeleton_drawable_get_animation_state_data(skeletonDrawable.wrappee) else {
-            throw "Could not load native animation state data"
+            throw "Could not load native animation state data" as SpineError
         }
         animationStateData = AnimationStateData(nativeAnimationStateData)
         
         guard let nativeAnimationState = spine_skeleton_drawable_get_animation_state(skeletonDrawable.wrappee) else {
-            throw "Could not load native animation state"
+            throw "Could not load native animation state" as SpineError
         }
         animationState = AnimationState(nativeAnimationState)
         animationStateWrapper = AnimationStateWrapper(

--- a/spine-ios/Sources/Spine/SkeletonDrawableWrapper.swift
+++ b/spine-ios/Sources/Spine/SkeletonDrawableWrapper.swift
@@ -94,22 +94,22 @@ public final class SkeletonDrawableWrapper: NSObject {
         self.skeletonData = skeletonData
             
         guard let nativeSkeletonDrawable = spine_skeleton_drawable_create(skeletonData.wrappee) else {
-            throw "Could not load native skeleton drawable" as SpineError
+            throw SpineError("Could not load native skeleton drawable")
         }
         skeletonDrawable = SkeletonDrawable(nativeSkeletonDrawable)
         
         guard let nativeSkeleton = spine_skeleton_drawable_get_skeleton(skeletonDrawable.wrappee) else {
-            throw "Could not load native skeleton" as SpineError
+            throw SpineError("Could not load native skeleton")
         }
         skeleton = Skeleton(nativeSkeleton)
         
         guard let nativeAnimationStateData = spine_skeleton_drawable_get_animation_state_data(skeletonDrawable.wrappee) else {
-            throw "Could not load native animation state data" as SpineError
+            throw SpineError("Could not load native animation state data")
         }
         animationStateData = AnimationStateData(nativeAnimationStateData)
         
         guard let nativeAnimationState = spine_skeleton_drawable_get_animation_state(skeletonDrawable.wrappee) else {
-            throw "Could not load native animation state" as SpineError
+            throw SpineError("Could not load native animation state")
         }
         animationState = AnimationState(nativeAnimationState)
         animationStateWrapper = AnimationStateWrapper(

--- a/spine-ios/Sources/Spine/Spine.Generated+Extensions.swift
+++ b/spine-ios/Sources/Spine/Spine.Generated+Extensions.swift
@@ -58,18 +58,18 @@ public extension Atlas {
     
     private static func fromData(data: Data, loadFile: (_ name: String) async throws -> Data) async throws -> (Atlas, [UIImage]) {
         guard let atlasData = String(data: data, encoding: .utf8) else {
-            throw "Couldn't read atlas bytes as utf8 string"
+            throw "Couldn't read atlas bytes as utf8 string" as SpineError
         }
         let atlas = try atlasData.utf8CString.withUnsafeBufferPointer {
             guard let atlas = spine_atlas_load($0.baseAddress) else {
-                throw "Couldn't load atlas data"
+                throw "Couldn't load atlas data" as SpineError
             }
             return atlas
         }
         if let error = spine_atlas_get_error(atlas) {
             let message = String(cString: error)
             spine_atlas_dispose(atlas)
-            throw "Couldn't load atlas: \(message)"
+            throw "Couldn't load atlas: \(message)" as SpineError
         }
         
         var atlasPages = [UIImage]()
@@ -134,7 +134,7 @@ public extension SkeletonData {
         let result = try data.withUnsafeBytes{
             try $0.withMemoryRebound(to: UInt8.self) { buffer in
                 guard let ptr = buffer.baseAddress else {
-                    throw "Couldn't read atlas binary"
+                    throw "Couldn't read atlas binary" as SpineError
                 }
                 return spine_skeleton_data_load_binary(
                     atlas.wrappee,
@@ -144,17 +144,17 @@ public extension SkeletonData {
             }
         }
         guard let result else {
-            throw "Couldn't load skeleton data"
+            throw "Couldn't load skeleton data" as SpineError
         }
         defer {
             spine_skeleton_data_result_dispose(result)
         }
         if let error = spine_skeleton_data_result_get_error(result) {
             let message = String(cString: error)
-            throw "Couldn't load skeleton data: \(message)"
+            throw "Couldn't load skeleton data: \(message)" as SpineError
         }
         guard let data = spine_skeleton_data_result_get_data(result) else {
-            throw "Couldn't load skeleton data from result"
+            throw "Couldn't load skeleton data from result" as SpineError
         }
         return SkeletonData(data)
     }
@@ -168,7 +168,7 @@ public extension SkeletonData {
             guard
                 let basePtr = buffer.baseAddress,
                 let result = spine_skeleton_data_load_json(atlas.wrappee, basePtr) else {
-                throw "Couldn't load skeleton data json"
+                throw "Couldn't load skeleton data json" as SpineError
             }
             return result
         }
@@ -177,10 +177,10 @@ public extension SkeletonData {
         }
         if let error = spine_skeleton_data_result_get_error(result) {
             let message = String(cString: error)
-            throw "Couldn't load skeleton data: \(message)"
+            throw "Couldn't load skeleton data: \(message)" as SpineError
         }
         guard let data = spine_skeleton_data_result_get_data(result) else {
-            throw "Couldn't load skeleton data from result"
+            throw "Couldn't load skeleton data from result" as SpineError
         }
         return SkeletonData(data)
     }
@@ -188,7 +188,7 @@ public extension SkeletonData {
     private static func fromData(atlas: Atlas, data: Data, isJson: Bool) throws -> SkeletonData {
         if isJson {
             guard let json = String(data: data, encoding: .utf8) else {
-                throw "Couldn't read skeleton data json string"
+                throw "Couldn't read skeleton data json string" as SpineError
             }
             return try fromJson(atlas: atlas, json: json)
         } else {
@@ -282,12 +282,12 @@ internal enum FileSource {
         case .bundle(let fileName, let bundle):
             let components = fileName.split(separator: ".")
             guard components.count > 1, let ext = components.last else {
-                throw "Provide both file name and file extension"
+                throw "Provide both file name and file extension" as SpineError
             }
             let name = components.dropLast(1).joined(separator: ".")
             
             guard let fileUrl = bundle.url(forResource: name, withExtension: String(ext)) else {
-                throw "Could not load file with name \(name) from bundle"
+                throw "Could not load file with name \(name) from bundle" as SpineError
             }
             return try Data(contentsOf: fileUrl, options: [])
         case .file(let fileUrl):
@@ -316,7 +316,7 @@ internal enum FileSource {
                                     return
                                 }
                                 guard let temp else {
-                                    continuation.resume(throwing: "Could not download file.")
+                                    continuation.resume(throwing: "Could not download file." as SpineError)
                                     return
                                 }
                                 do {
@@ -350,7 +350,13 @@ internal enum FileSource {
     }
 }
 
-extension String: Error {
+public struct SpineError: ExpressibleByStringInterpolation, Error, Hashable {
+    
+    public let message: String
+    
+    public init(stringLiteral value: String) {
+        self.message = value
+    }
     
 }
 

--- a/spine-ios/Sources/Spine/Spine.Generated+Extensions.swift
+++ b/spine-ios/Sources/Spine/Spine.Generated+Extensions.swift
@@ -57,14 +57,15 @@ public extension Atlas {
     }
     
     private static func fromData(data: Data, loadFile: (_ name: String) async throws -> Data) async throws -> (Atlas, [UIImage]) {
-        guard let atlasData = String(data: data, encoding: .utf8) as? NSString else {
+        guard let atlasData = String(data: data, encoding: .utf8) else {
             throw "Couldn't read atlas bytes as utf8 string"
         }
-        let atlasDataNative = UnsafeMutablePointer<CChar>(mutating: atlasData.utf8String)
-        guard let atlas = spine_atlas_load(atlasDataNative) else {
-            throw "Couldn't load atlas data"
+        let atlas = try atlasData.utf8CString.withUnsafeBufferPointer {
+            guard let atlas = spine_atlas_load($0.baseAddress) else {
+                throw "Couldn't load atlas data"
+            }
+            return atlas
         }
-        
         if let error = spine_atlas_get_error(atlas) {
             let message = String(cString: error)
             spine_atlas_dispose(atlas)
@@ -130,26 +131,31 @@ public extension SkeletonData {
     ///
     /// Throws an `Error` in case the skeleton data could not be loaded.
     static func fromData(atlas: Atlas, data: Data) throws -> SkeletonData {
-        let binaryNative = try data.withUnsafeBytes { unsafeBytes in
-            guard let bytes = unsafeBytes.bindMemory(to: UInt8.self).baseAddress else {
-                throw "Couldn't read atlas binary"
+        let result = try data.withUnsafeBytes{
+            try $0.withMemoryRebound(to: UInt8.self) { buffer in
+                guard let ptr = buffer.baseAddress else {
+                    throw "Couldn't read atlas binary"
+                }
+                return spine_skeleton_data_load_binary(
+                    atlas.wrappee,
+                    ptr,
+                    Int32(buffer.count)
+                )
             }
-            return (data: bytes, length: Int32(unsafeBytes.count))
         }
-        let result = spine_skeleton_data_load_binary(
-            atlas.wrappee,
-            binaryNative.data,
-            binaryNative.length
-        )
+        guard let result else {
+            throw "Couldn't load skeleton data"
+        }
+        defer {
+            spine_skeleton_data_result_dispose(result)
+        }
         if let error = spine_skeleton_data_result_get_error(result) {
             let message = String(cString: error)
-            spine_skeleton_data_result_dispose(result)
             throw "Couldn't load skeleton data: \(message)"
         }
         guard let data = spine_skeleton_data_result_get_data(result) else {
             throw "Couldn't load skeleton data from result"
         }
-        spine_skeleton_data_result_dispose(result)
         return SkeletonData(data)
     }
     
@@ -158,19 +164,24 @@ public extension SkeletonData {
     ///
     /// Throws an `Error` in case the atlas could not be loaded.
     static func fromJson(atlas: Atlas, json: String) throws -> SkeletonData {
-        let jsonNative = UnsafeMutablePointer<CChar>(mutating: (json as NSString).utf8String)
-        guard let result = spine_skeleton_data_load_json(atlas.wrappee, jsonNative) else {
-            throw "Couldn't load skeleton data json"
+        let result = try json.utf8CString.withUnsafeBufferPointer { buffer in
+            guard
+                let basePtr = buffer.baseAddress,
+                let result = spine_skeleton_data_load_json(atlas.wrappee, basePtr) else {
+                throw "Couldn't load skeleton data json"
+            }
+            return result
+        }
+        defer {
+            spine_skeleton_data_result_dispose(result)
         }
         if let error = spine_skeleton_data_result_get_error(result) {
             let message = String(cString: error)
-            spine_skeleton_data_result_dispose(result)
             throw "Couldn't load skeleton data: \(message)"
         }
         guard let data = spine_skeleton_data_result_get_data(result) else {
             throw "Couldn't load skeleton data from result"
         }
-        spine_skeleton_data_result_dispose(result)
         return SkeletonData(data)
     }
     
@@ -289,27 +300,50 @@ internal enum FileSource {
                 }
                 return try Data(contentsOf: temp, options: [])
             } else {
-                return try await withCheckedThrowingContinuation { continuation in
-                    let task = URLSession.shared.downloadTask(with: url) { temp, response, error in
-                        if let error {
-                            continuation.resume(throwing: error)
-                        } else {
-                            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-                                continuation.resume(throwing: URLError(.badServerResponse))
-                                return
-                            }
-                            guard let temp else {
-                                continuation.resume(throwing: "Could not download file.")
-                                return
-                            }
-                            do {
-                                continuation.resume(returning: try Data(contentsOf: temp, options: []))
-                            } catch {
+                let lock = NSRecursiveLock()
+                nonisolated(unsafe)
+                var isCancelled = false
+                nonisolated(unsafe)
+                var taskHolder:URLSessionDownloadTask? = nil
+                return try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { continuation in
+                        let task = URLSession.shared.downloadTask(with: url) { temp, response, error in
+                            if let error {
                                 continuation.resume(throwing: error)
+                            } else {
+                                guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                                    continuation.resume(throwing: URLError(.badServerResponse))
+                                    return
+                                }
+                                guard let temp else {
+                                    continuation.resume(throwing: "Could not download file.")
+                                    return
+                                }
+                                do {
+                                    continuation.resume(returning: try Data(contentsOf: temp, options: []))
+                                } catch {
+                                    continuation.resume(throwing: error)
+                                }
                             }
                         }
+                        task.resume()
+                        let shouldCancel = lock.withLock {
+                            if !isCancelled {
+                                taskHolder = task
+                            }
+                            return isCancelled
+                        }
+                        if shouldCancel {
+                            task.cancel()
+                        }
                     }
-                    task.resume()
+                } onCancel: {
+                    lock.withLock {
+                        isCancelled = true
+                        let value = taskHolder
+                        taskHolder = nil
+                        return value
+                    }?.cancel()
                 }
             }
         }

--- a/spine-ios/Sources/Spine/Spine.Generated+Extensions.swift
+++ b/spine-ios/Sources/Spine/Spine.Generated+Extensions.swift
@@ -58,18 +58,18 @@ public extension Atlas {
     
     private static func fromData(data: Data, loadFile: (_ name: String) async throws -> Data) async throws -> (Atlas, [UIImage]) {
         guard let atlasData = String(data: data, encoding: .utf8) else {
-            throw "Couldn't read atlas bytes as utf8 string" as SpineError
+            throw SpineError("Couldn't read atlas bytes as utf8 string")
         }
         let atlas = try atlasData.utf8CString.withUnsafeBufferPointer {
             guard let atlas = spine_atlas_load($0.baseAddress) else {
-                throw "Couldn't load atlas data" as SpineError
+                throw SpineError("Couldn't load atlas data")
             }
             return atlas
         }
         if let error = spine_atlas_get_error(atlas) {
             let message = String(cString: error)
             spine_atlas_dispose(atlas)
-            throw "Couldn't load atlas: \(message)" as SpineError
+            throw SpineError("Couldn't load atlas: \(message)")
         }
         
         var atlasPages = [UIImage]()
@@ -134,7 +134,7 @@ public extension SkeletonData {
         let result = try data.withUnsafeBytes{
             try $0.withMemoryRebound(to: UInt8.self) { buffer in
                 guard let ptr = buffer.baseAddress else {
-                    throw "Couldn't read atlas binary" as SpineError
+                    throw SpineError("Couldn't read atlas binary")
                 }
                 return spine_skeleton_data_load_binary(
                     atlas.wrappee,
@@ -144,17 +144,17 @@ public extension SkeletonData {
             }
         }
         guard let result else {
-            throw "Couldn't load skeleton data" as SpineError
+            throw SpineError("Couldn't load skeleton data")
         }
         defer {
             spine_skeleton_data_result_dispose(result)
         }
         if let error = spine_skeleton_data_result_get_error(result) {
             let message = String(cString: error)
-            throw "Couldn't load skeleton data: \(message)" as SpineError
+            throw SpineError("Couldn't load skeleton data: \(message)")
         }
         guard let data = spine_skeleton_data_result_get_data(result) else {
-            throw "Couldn't load skeleton data from result" as SpineError
+            throw SpineError("Couldn't load skeleton data from result")
         }
         return SkeletonData(data)
     }
@@ -168,7 +168,7 @@ public extension SkeletonData {
             guard
                 let basePtr = buffer.baseAddress,
                 let result = spine_skeleton_data_load_json(atlas.wrappee, basePtr) else {
-                throw "Couldn't load skeleton data json" as SpineError
+                throw SpineError("Couldn't load skeleton data json")
             }
             return result
         }
@@ -177,10 +177,10 @@ public extension SkeletonData {
         }
         if let error = spine_skeleton_data_result_get_error(result) {
             let message = String(cString: error)
-            throw "Couldn't load skeleton data: \(message)" as SpineError
+            throw SpineError("Couldn't load skeleton data: \(message)")
         }
         guard let data = spine_skeleton_data_result_get_data(result) else {
-            throw "Couldn't load skeleton data from result" as SpineError
+            throw SpineError("Couldn't load skeleton data from result")
         }
         return SkeletonData(data)
     }
@@ -188,7 +188,7 @@ public extension SkeletonData {
     private static func fromData(atlas: Atlas, data: Data, isJson: Bool) throws -> SkeletonData {
         if isJson {
             guard let json = String(data: data, encoding: .utf8) else {
-                throw "Couldn't read skeleton data json string" as SpineError
+                throw SpineError("Couldn't read skeleton data json string")
             }
             return try fromJson(atlas: atlas, json: json)
         } else {
@@ -282,12 +282,12 @@ internal enum FileSource {
         case .bundle(let fileName, let bundle):
             let components = fileName.split(separator: ".")
             guard components.count > 1, let ext = components.last else {
-                throw "Provide both file name and file extension" as SpineError
+                throw SpineError("Provide both file name and file extension")
             }
             let name = components.dropLast(1).joined(separator: ".")
             
             guard let fileUrl = bundle.url(forResource: name, withExtension: String(ext)) else {
-                throw "Could not load file with name \(name) from bundle" as SpineError
+                throw SpineError("Could not load file with name \(name) from bundle")
             }
             return try Data(contentsOf: fileUrl, options: [])
         case .file(let fileUrl):
@@ -316,7 +316,7 @@ internal enum FileSource {
                                     return
                                 }
                                 guard let temp else {
-                                    continuation.resume(throwing: "Could not download file." as SpineError)
+                                    continuation.resume(throwing: SpineError("Could not download file."))
                                     return
                                 }
                                 do {
@@ -350,12 +350,12 @@ internal enum FileSource {
     }
 }
 
-public struct SpineError: ExpressibleByStringInterpolation, Error, Hashable {
+public struct SpineError: Error, CustomStringConvertible {
     
-    public let message: String
+    public let description: String
     
-    public init(stringLiteral value: String) {
-        self.message = value
+    internal init(_ description: String) {
+        self.description = description
     }
     
 }


### PR DESCRIPTION
1. Declare `SpineError`

- Declaring conformance of standard protocol `Error` to standard library type `String` is highly discouraged. So I created `SpineError` which can be used with the same syntax as before while using Explicit type.


2. Support `URLSessionDownloadTask` cancellation

- `URLSession`  async download does supports Task cancellation, while current implementation does not, this commit will support Task cancellation below iOS 15.0


3. refactor accessing binary or c-String memory region

- current implementation may have dangling pointer and access pointer out of scope that the Swift guarantee.
- casting Swift.String to NSString can cause implicit deep copy which is not needed.
- According to the guideline, only access the pointer inside the scope is safe.
- this pr, move the access to the `Data`, `String` memory,  inside the block scope which is guaranteed to be safe.