### PR TITLE
[cpp] Fix mixShearY assignment in SkeletonJson::readAnimation

### DIFF
--- a/spine-cpp/spine-cpp/include/spine/Atlas.h
+++ b/spine-cpp/spine-cpp/include/spine/Atlas.h
@@ -39,6 +39,7 @@
 
 namespace spine {
 	enum Format {
+		SP_ATLAS_UNKNOWN_FORMAT,
 		Format_Alpha,
 		Format_Intensity,
 		Format_LuminanceAlpha,

--- a/spine-cpp/spine-cpp/include/spine/PathConstraintMixTimeline.h
+++ b/spine-cpp/spine-cpp/include/spine/PathConstraintMixTimeline.h
@@ -61,7 +61,7 @@ namespace spine {
 		static const int ENTRIES = 4;
 		static const int ROTATE = 1;
 		static const int X = 2;
-		static const int Y = 2;
+		static const int Y = 3;
 	};
 }
 

--- a/spine-cpp/spine-cpp/src/spine/SkeletonJson.cpp
+++ b/spine-cpp/spine-cpp/src/spine/SkeletonJson.cpp
@@ -1274,11 +1274,12 @@ Animation *SkeletonJson::readAnimation(Json *root, SkeletonData *skeletonData) {
 
 			time = time2;
 			mixRotate = mixRotate2;
+			mixShearY = mixShearY2;
 			mixX = mixX2;
 			mixY = mixY2;
 			mixScaleX = mixScaleX2;
 			mixScaleY = mixScaleY2;
-			mixScaleX = mixScaleX2;
+
 			keyMap = nextMap;
 		}
 


### PR DESCRIPTION
mixShearY2 was not assigned to mixShearY. Is this a bug?