### PR TITLE
fix: Fix ArgumentOutOfRangeException caused by propertyPath like "bod…

### DIFF
--- a/spine-unity/Assets/Spine/Editor/spine-unity/Editor/Utility/SpineInspectorUtility.cs
+++ b/spine-unity/Assets/Spine/Editor/spine-unity/Editor/Utility/SpineInspectorUtility.cs
@@ -155,12 +155,15 @@ namespace Spine.Unity.Editor {
 				// If this fails as well, try at any base property up the hierarchy
 				if (relativeProperty == null) {
 					int dotIndex = propertyPath.Length - property.name.Length - 1;
-					while (relativeProperty == null) {
-						dotIndex = propertyPath.LastIndexOf('.', dotIndex - 1);
-						if (dotIndex < 0)
-							break;
-						newPropertyPath = propertyPath.Remove(dotIndex + 1) + propertyName;
-						relativeProperty = property.serializedObject.FindProperty(newPropertyPath);
+					if (dotIndex > 0)
+					{
+						while (relativeProperty == null) {
+							dotIndex = propertyPath.LastIndexOf('.', dotIndex - 1);
+							if (dotIndex < 0)
+								break;
+							newPropertyPath = propertyPath.Remove(dotIndex + 1) + propertyName;
+							relativeProperty = property.serializedObject.FindProperty(newPropertyPath);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
My project encountered an exception, and I found that when the propertyPath is "bodySkin", it causes an ArgumentOutOfRangeException. At that time, dotIndex was -1. I have fixed the issue, and everything is now working correctly.

I believe this bug should be fixed as soon as possible. Otherwise, when other users encounter this issue, any code using the [SpineSkin(dataField: "skeletonDataAsset")] attribute will prevent them from using Unity's Inspector properly. I ran into this while using a publicly available third-party art asset, so I believe I’m not the only one affected. Other users may have experienced the same issue but were unable to report it to you due to various constraints.