### PR TITLE
Fix warning -Wimplicit-fallthrough

### DIFF
--- a/spine-c/spine-c/src/spine/Debug.c
+++ b/spine-c/spine-c/src/spine/Debug.c
@@ -208,11 +208,11 @@ void spDebug_printTimeline(spTimeline *timeline) {
 		case SP_TIMELINE_SEQUENCE: {
 			spSequenceTimeline *t = (spSequenceTimeline *) timeline;
 			_spDebug_printTimelineBase(&t->super);
-		}
+		} // fallthrough
 		case SP_TIMELINE_INHERIT: {
 			spInheritTimeline *t = (spInheritTimeline *) timeline;
 			_spDebug_printTimelineBase(&t->super);
-		}
+		} // fallthrough
 		default: {
 			_spDebug_printTimelineBase(timeline);
 		}

--- a/spine-c/spine-c/src/spine/IkConstraint.c
+++ b/spine-c/spine-c/src/spine/IkConstraint.c
@@ -98,7 +98,7 @@ void spIkConstraint_apply1(spBone *bone, float targetX, float targetY, int /*boo
 			pb = -sc * s * bone->skeleton->scaleX;
 			pd = sa * s * bone->skeleton->scaleY;
 			rotationIK += ATAN2(sc, sa) * RAD_DEG;
-		}
+		} // fallthrough
 		default: {
 			float x = targetX - p->worldX, y = targetY - p->worldY;
 			float d = pa * pd - pb * pc;


### PR DESCRIPTION
GCC 14 on Fedora

```
spine-c/src/spine/Debug.c: In function ‘spDebug_printTimeline’:
spine-c/src/spine/Debug.c:210:25: warning: this statement may fall through [-Wimplicit-fallthrough=]
  210 |                         _spDebug_printTimelineBase(&t->super);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
spine-c/src/spine/Debug.c:212:17: note: here
  212 |                 case SP_TIMELINE_INHERIT: {
      |                 ^~~~
spine-c/src/spine/Debug.c:214:25: warning: this statement may fall through [-Wimplicit-fallthrough=]
  214 |                         _spDebug_printTimelineBase(&t->super);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
spine-c/src/spine/Debug.c:216:17: note: here
  216 |                 default: {
      |                 ^~~~~~~
spine-c/src/spine/IkConstraint.c: In function ‘spIkConstraint_apply1’:
spine-c/src/spine/IkConstraint.c:100:36: warning: this statement may fall through [-Wimplicit-fallthrough=]
  100 |                         rotationIK += ATAN2(sc, sa) * RAD_DEG;
      |                                    ^~
spine-c/src/spine/IkConstraint.c:102:17: note: here
  102 |                 default: {
      |                 ^~~~~~~
```