### PR TITLE
[godot] Allow double precision Godot Builds

### DIFF
--- a/spine-godot/spine_godot/SpineBone.cpp
+++ b/spine-godot/spine_godot/SpineBone.cpp
@@ -140,27 +140,27 @@ Vector2 SpineBone::parent_to_world(Vector2 local_position) {
 	return Vector2(x, y);
 }
 
-float SpineBone::world_to_local_rotation(float world_rotation) {
+real_t SpineBone::world_to_local_rotation(real_t world_rotation) {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->worldToLocalRotation(world_rotation);
 }
 
-float SpineBone::local_to_world_rotation(float local_rotation) {
+real_t SpineBone::local_to_world_rotation(real_t local_rotation) {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->localToWorldRotation(local_rotation);
 }
 
-void SpineBone::rotate_world(float degrees) {
+void SpineBone::rotate_world(real_t degrees) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->rotateWorld(degrees);
 }
 
-float SpineBone::get_world_to_local_rotation_x() {
+real_t SpineBone::get_world_to_local_rotation_x() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getWorldToLocalRotationX();
 }
 
-float SpineBone::get_world_to_local_rotation_y() {
+real_t SpineBone::get_world_to_local_rotation_y() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getWorldToLocalRotationY();
 }
@@ -196,223 +196,223 @@ Array SpineBone::get_children() {
 	return result;
 }
 
-float SpineBone::get_x() {
+real_t SpineBone::get_x() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getX();
 }
 
-void SpineBone::set_x(float v) {
+void SpineBone::set_x(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setX(v);
 }
 
-float SpineBone::get_y() {
+real_t SpineBone::get_y() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getY();
 }
 
-void SpineBone::set_y(float v) {
+void SpineBone::set_y(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setY(v);
 }
 
-float SpineBone::get_rotation() {
+real_t SpineBone::get_rotation() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getRotation();
 }
 
-void SpineBone::set_rotation(float v) {
+void SpineBone::set_rotation(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setRotation(v);
 }
 
-float SpineBone::get_scale_x() {
+real_t SpineBone::get_scale_x() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getScaleX();
 }
 
-void SpineBone::set_scale_x(float v) {
+void SpineBone::set_scale_x(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setScaleX(v);
 }
 
-float SpineBone::get_scale_y() {
+real_t SpineBone::get_scale_y() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getScaleY();
 }
 
-void SpineBone::set_scale_y(float v) {
+void SpineBone::set_scale_y(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setScaleY(v);
 }
 
-float SpineBone::get_shear_x() {
+real_t SpineBone::get_shear_x() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getShearX();
 }
 
-void SpineBone::set_shear_x(float v) {
+void SpineBone::set_shear_x(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setShearX(v);
 }
 
-float SpineBone::get_shear_y() {
+real_t SpineBone::get_shear_y() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getShearY();
 }
 
-void SpineBone::set_shear_y(float v) {
+void SpineBone::set_shear_y(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setShearY(v);
 }
 
-float SpineBone::get_applied_rotation() {
+real_t SpineBone::get_applied_rotation() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getAppliedRotation();
 }
 
-void SpineBone::set_applied_rotation(float v) {
+void SpineBone::set_applied_rotation(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setAppliedRotation(v);
 }
 
-float SpineBone::get_a_x() {
+real_t SpineBone::get_a_x() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getAX();
 }
 
-void SpineBone::set_a_x(float v) {
+void SpineBone::set_a_x(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setAX(v);
 }
 
-float SpineBone::get_a_y() {
+real_t SpineBone::get_a_y() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getAY();
 }
 
-void SpineBone::set_a_y(float v) {
+void SpineBone::set_a_y(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setAY(v);
 }
 
-float SpineBone::get_a_scale_x() {
+real_t SpineBone::get_a_scale_x() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getAScaleX();
 }
 
-void SpineBone::set_a_scale_x(float v) {
+void SpineBone::set_a_scale_x(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setAScaleX(v);
 }
 
-float SpineBone::get_a_scale_y() {
+real_t SpineBone::get_a_scale_y() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getAScaleY();
 }
 
-void SpineBone::set_a_scale_y(float v) {
+void SpineBone::set_a_scale_y(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setAScaleY(v);
 }
 
-float SpineBone::get_a_shear_x() {
+real_t SpineBone::get_a_shear_x() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getAShearX();
 }
 
-void SpineBone::set_a_shear_x(float v) {
+void SpineBone::set_a_shear_x(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setAShearX(v);
 }
 
-float SpineBone::get_a_shear_y() {
+real_t SpineBone::get_a_shear_y() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getAShearY();
 }
 
-void SpineBone::set_a_shear_y(float v) {
+void SpineBone::set_a_shear_y(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setAShearY(v);
 }
 
-float SpineBone::get_a() {
+real_t SpineBone::get_a() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getA();
 }
 
-void SpineBone::set_a(float v) {
+void SpineBone::set_a(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setA(v);
 }
 
-float SpineBone::get_b() {
+real_t SpineBone::get_b() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getB();
 }
 
-void SpineBone::set_b(float v) {
+void SpineBone::set_b(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setB(v);
 }
 
-float SpineBone::get_c() {
+real_t SpineBone::get_c() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getC();
 }
 
-void SpineBone::set_c(float v) {
+void SpineBone::set_c(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setC(v);
 }
 
-float SpineBone::get_d() {
+real_t SpineBone::get_d() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getD();
 }
 
-void SpineBone::set_d(float v) {
+void SpineBone::set_d(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setD(v);
 }
 
-float SpineBone::get_world_x() {
+real_t SpineBone::get_world_x() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getWorldX();
 }
 
-void SpineBone::set_world_x(float v) {
+void SpineBone::set_world_x(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setWorldX(v);
 }
 
-float SpineBone::get_world_y() {
+real_t SpineBone::get_world_y() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getWorldY();
 }
 
-void SpineBone::set_world_y(float v) {
+void SpineBone::set_world_y(real_t v) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setWorldY(v);
 }
 
-float SpineBone::get_world_rotation_x() {
+real_t SpineBone::get_world_rotation_x() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getWorldRotationX();
 }
 
-float SpineBone::get_world_rotation_y() {
+real_t SpineBone::get_world_rotation_y() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getWorldRotationY();
 }
 
 
-float SpineBone::get_world_scale_x() {
+real_t SpineBone::get_world_scale_x() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getWorldScaleX();
 }
 
-float SpineBone::get_world_scale_y() {
+real_t SpineBone::get_world_scale_y() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getWorldScaleY();
 }
@@ -448,7 +448,7 @@ Transform2D SpineBone::get_transform() {
 void SpineBone::set_transform(Transform2D transform) {
 	SPINE_CHECK(get_spine_object(), )
 	Vector2 position = transform.get_origin();
-	float rotation = spine::MathUtil::Rad_Deg * transform.get_rotation();
+	real_t rotation = spine::MathUtil::Rad_Deg * transform.get_rotation();
 	Vector2 scale = transform.get_scale();
 
 	set_x(position.x);
@@ -481,14 +481,18 @@ void SpineBone::set_global_transform(Transform2D transform) {
 	Transform2D inverse_sprite_transform = get_spine_owner()->get_global_transform().affine_inverse();
 	transform = inverse_sprite_transform * transform;
 	Vector2 position = transform.get_origin();
-	float rotation = spine::MathUtil::Rad_Deg * transform.get_rotation();
+	real_t rotation = spine::MathUtil::Rad_Deg * transform.get_rotation();
 	Vector2 scale = transform.get_scale();
 	Vector2 local_position = position;
-	float local_rotation = bone->worldToLocalRotation(rotation) - 180;
+	real_t local_rotation = bone->worldToLocalRotation(rotation) - 180;
 	Vector2 local_scale = scale;
 	spine::Bone *parent = bone->getParent();
 	if (parent) {
-		parent->worldToLocal(local_position.x, local_position.y, local_position.x, local_position.y);
+        float in_x = local_position.x;
+        float in_y = local_position.y;
+		parent->worldToLocal(local_position.x, local_position.y, in_x, in_y);
+        local_position.x = in_x;
+        local_position.y = in_y;
 	}
 	bone->setX(local_position.x);
 	bone->setY(local_position.y);

--- a/spine-godot/spine_godot/SpineBone.h
+++ b/spine-godot/spine_godot/SpineBone.h
@@ -61,15 +61,15 @@ public:
 
 	Vector2 parent_to_world(Vector2 local_position);
 
-	float world_to_local_rotation(float world_rotation);
+	real_t world_to_local_rotation(real_t world_rotation);
 
-	float local_to_world_rotation(float local_rotation);
+	real_t local_to_world_rotation(real_t local_rotation);
 
-	void rotate_world(float degrees);
+	void rotate_world(real_t degrees);
 
-	float get_world_to_local_rotation_x();
+	real_t get_world_to_local_rotation_x();
 
-	float get_world_to_local_rotation_y();
+	real_t get_world_to_local_rotation_y();
 
 	Ref<SpineBoneData> get_data();
 
@@ -77,93 +77,93 @@ public:
 
 	Array get_children();
 
-	float get_x();
+	real_t get_x();
 
-	void set_x(float v);
+	void set_x(real_t v);
 
-	float get_y();
+	real_t get_y();
 
-	void set_y(float v);
+	void set_y(real_t v);
 
-	float get_rotation();
+	real_t get_rotation();
 
-	void set_rotation(float v);
+	void set_rotation(real_t v);
 
-	float get_scale_x();
+	real_t get_scale_x();
 
-	void set_scale_x(float v);
+	void set_scale_x(real_t v);
 
-	float get_scale_y();
+	real_t get_scale_y();
 
-	void set_scale_y(float v);
+	void set_scale_y(real_t v);
 
-	float get_shear_x();
+	real_t get_shear_x();
 
-	void set_shear_x(float v);
+	void set_shear_x(real_t v);
 
-	float get_shear_y();
+	real_t get_shear_y();
 
-	void set_shear_y(float v);
+	void set_shear_y(real_t v);
 
-	float get_applied_rotation();
+	real_t get_applied_rotation();
 
-	void set_applied_rotation(float v);
+	void set_applied_rotation(real_t v);
 
-	float get_a_x();
+	real_t get_a_x();
 
-	void set_a_x(float v);
+	void set_a_x(real_t v);
 
-	float get_a_y();
+	real_t get_a_y();
 
-	void set_a_y(float v);
+	void set_a_y(real_t v);
 
-	float get_a_scale_x();
+	real_t get_a_scale_x();
 
-	void set_a_scale_x(float v);
+	void set_a_scale_x(real_t v);
 
-	float get_a_scale_y();
+	real_t get_a_scale_y();
 
-	void set_a_scale_y(float v);
+	void set_a_scale_y(real_t v);
 
-	float get_a_shear_x();
+	real_t get_a_shear_x();
 
-	void set_a_shear_x(float v);
+	void set_a_shear_x(real_t v);
 
-	float get_a_shear_y();
+	real_t get_a_shear_y();
 
-	void set_a_shear_y(float v);
+	void set_a_shear_y(real_t v);
 
-	float get_a();
+	real_t get_a();
 
-	void set_a(float v);
+	void set_a(real_t v);
 
-	float get_b();
+	real_t get_b();
 
-	void set_b(float v);
+	void set_b(real_t v);
 
-	float get_c();
+	real_t get_c();
 
-	void set_c(float v);
+	void set_c(real_t v);
 
-	float get_d();
+	real_t get_d();
 
-	void set_d(float v);
+	void set_d(real_t v);
 
-	float get_world_x();
+	real_t get_world_x();
 
-	void set_world_x(float v);
+	void set_world_x(real_t v);
 
-	float get_world_y();
+	real_t get_world_y();
 
-	void set_world_y(float v);
+	void set_world_y(real_t v);
 
-	float get_world_rotation_x();
+	real_t get_world_rotation_x();
 
-	float get_world_rotation_y();
+	real_t get_world_rotation_y();
 
-	float get_world_scale_x();
+	real_t get_world_scale_x();
 
-	float get_world_scale_y();
+	real_t get_world_scale_y();
 
 	bool is_active();
 

--- a/spine-godot/spine_godot/SpineCommon.h
+++ b/spine-godot/spine_godot/SpineCommon.h
@@ -72,6 +72,7 @@ using namespace godot;
 #define REF Ref<RefCounted>
 #define GEOMETRY2D Geometry2D
 #else
+#include "core/math/math_defs.h"
 #include "core/object.h"
 #include "core/reference.h"
 #include "core/error_macros.h"

--- a/spine-godot/spine_godot/SpineEditorPlugin.cpp
+++ b/spine-godot/spine_godot/SpineEditorPlugin.cpp
@@ -40,12 +40,12 @@
 #include "editor/editor_undo_redo_manager.h"
 #endif
 #ifdef SPINE_GODOT_EXTENSION
-Error SpineAtlasResourceImportPlugin::_import(const String &source_file, const String &save_path, const Dictionary &options, const TypedArray<String> &platform_variants, const TypedArray<String> &gen_files) const {
+Error SpineAtlasResourceImportPlugin::_import(ResourceUID::ID source_id, const String &source_file, const String &save_path, const Dictionary &options, const TypedArray<String> &platform_variants, const TypedArray<String> &gen_files) const {
 #else
-Error SpineAtlasResourceImportPlugin::import(const String &source_file, const String &save_path, const HashMap<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) {
+Error SpineAtlasResourceImportPlugin::import(ResourceUID::ID source_id, const String &source_file, const String &save_path, const HashMap<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) {
 #endif
 #else
-Error SpineAtlasResourceImportPlugin::import(const String &source_file, const String &save_path, const Map<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) {
+Error SpineAtlasResourceImportPlugin::import(ResourceUID::ID source_id, const String &source_file, const String &save_path, const Map<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) {
 #endif
 	Ref<SpineAtlasResource> atlas(memnew(SpineAtlasResource));
 	atlas->set_normal_texture_prefix(options["normal_map_prefix"]);
@@ -96,12 +96,12 @@ void SpineAtlasResourceImportPlugin::get_import_options(List<ImportOption> *opti
 
 #if VERSION_MAJOR > 3
 #ifdef SPINE_GODOT_EXTENSION
-Error SpineJsonResourceImportPlugin::_import(const String &source_file, const String &save_path, const Dictionary &options, const TypedArray<String> &platform_variants, const TypedArray<String> &gen_files) const {
+ Error SpineJsonResourceImportPlugin::_import(ResourceUID::ID source_id, const String &source_file, const String &save_path, const Dictionary &options, const TypedArray<String> &platform_variants, const TypedArray<String> &gen_files) const {
 #else
-Error SpineJsonResourceImportPlugin::import(const String &source_file, const String &save_path, const HashMap<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) {
+Error SpineJsonResourceImportPlugin::import(ResourceUID::ID source_id, const String &source_file, const String &save_path, const HashMap<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) {
 #endif
 #else
-Error SpineJsonResourceImportPlugin::import(const String &source_file, const String &save_path, const Map<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) {
+Error SpineJsonResourceImportPlugin::import(ResourceUID::ID source_id, const String &source_file, const String &save_path, const Map<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) {
 #endif
 	Ref<SpineSkeletonFileResource> skeleton_file_res(memnew(SpineSkeletonFileResource));
 	Error error = skeleton_file_res->load_from_file(source_file);
@@ -124,12 +124,12 @@ Error SpineJsonResourceImportPlugin::import(const String &source_file, const Str
 
 #if VERSION_MAJOR > 3
 #ifdef SPINE_GODOT_EXTENSION
-Error SpineBinaryResourceImportPlugin::_import(const String &source_file, const String &save_path, const Dictionary &options, const TypedArray<String> &platform_variants, const TypedArray<String> &gen_files) const {
+Error SpineBinaryResourceImportPlugin::_import(ResourceUID::ID source_id, const String &source_file, const String &save_path, const Dictionary &options, const TypedArray<String> &platform_variants, const TypedArray<String> &gen_files) const {
 #else
-Error SpineBinaryResourceImportPlugin::import(const String &source_file, const String &save_path, const HashMap<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) {
+Error SpineBinaryResourceImportPlugin::import(ResourceUID::ID source_id, const String &source_file, const String &save_path, const HashMap<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) {
 #endif
 #else
-Error SpineBinaryResourceImportPlugin::import(const String &source_file, const String &save_path, const Map<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) {
+Error SpineBinaryResourceImportPlugin::import(ResourceUID::ID source_id, const String &source_file, const String &save_path, const Map<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) {
 #endif
 	Ref<SpineSkeletonFileResource> skeleton_file_res(memnew(SpineSkeletonFileResource));
 	Error error = skeleton_file_res->load_from_file(source_file);

--- a/spine-godot/spine_godot/SpineEditorPlugin.h
+++ b/spine-godot/spine_godot/SpineEditorPlugin.h
@@ -108,14 +108,14 @@ public:
 
 	virtual bool get_option_visibility(const String &path, const String &option, const HashMap<StringName, Variant> &options) const override { return true; }
 
-	Error import(const String &source_file, const String &save_path, const HashMap<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) override;
+	Error import(ResourceUID::ID source_id, const String &source_file, const String &save_path, const HashMap<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) override;
 #endif
 #else
 	void get_import_options(List<ImportOption> *options, int preset) const override;
 
 	bool get_option_visibility(const String &option, const Map<StringName, Variant> &options) const override { return true; }
 
-	Error import(const String &source_file, const String &save_path, const Map<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) override;
+	Error import(ResourceUID::ID source_id, const String &source_file, const String &save_path, const Map<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) override;
 #endif
 };
 
@@ -172,7 +172,7 @@ public:
 
 	virtual bool _get_option_visibility(const String &p_path, const StringName &p_option_name, const Dictionary &p_options) const override { return true; };
 
-	virtual Error _import(const String &p_source_file, const String &p_save_path, const Dictionary &p_options, const TypedArray<String> &p_platform_variants, const TypedArray<String> &p_gen_files) const override;
+	virtual Error _import(ResourceUID::ID source_id, const String &p_source_file, const String &p_save_path, const Dictionary &p_options, const TypedArray<String> &p_platform_variants, const TypedArray<String> &p_gen_files) const override;
 #else
 	int get_import_order() const override { return IMPORT_ORDER_DEFAULT; }
 
@@ -182,14 +182,14 @@ public:
 
 	bool get_option_visibility(const String &path, const String &option, const HashMap<StringName, Variant> &options) const override { return true; }
 
-	Error import(const String &source_file, const String &save_path, const HashMap<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) override;
+	Error import(ResourceUID::ID source_id, const String &source_file, const String &save_path, const HashMap<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) override;
 #endif
 #else
 	void get_import_options(List<ImportOption> *options, int preset) const override {}
 
 	bool get_option_visibility(const String &option, const Map<StringName, Variant> &options) const override { return true; }
 
-	Error import(const String &source_file, const String &save_path, const Map<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) override;
+	Error import(ResourceUID::ID source_id, const String &source_file, const String &save_path, const Map<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) override;
 #endif
 };
 
@@ -256,14 +256,14 @@ public:
 
 	bool get_option_visibility(const String &path, const String &option, const HashMap<StringName, Variant> &options) const override { return true; }
 
-	Error import(const String &source_file, const String &save_path, const HashMap<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) override;
+	Error import(ResourceUID::ID source_id, const String &source_file, const String &save_path, const HashMap<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) override;
 #endif
 #else
 	void get_import_options(List<ImportOption> *options, int preset) const override {}
 
 	bool get_option_visibility(const String &option, const Map<StringName, Variant> &options) const override { return true; }
 
-	Error import(const String &source_file, const String &save_path, const Map<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) override;
+	Error import(ResourceUID::ID source_id, const String &source_file, const String &save_path, const Map<StringName, Variant> &options, List<String> *platform_variants, List<String> *gen_files, Variant *metadata) override;
 #endif
 };
 
@@ -280,7 +280,7 @@ public:
 #else
 	explicit SpineEditorPlugin(EditorNode *node);
 
-	String get_name() const override { return "SpineEditorPlugin"; }
+	StringName get_name() const { return "SpineEditorPlugin"; }
 #endif
 };
 

--- a/spine-godot/spine_godot/SpineSkeleton.cpp
+++ b/spine-godot/spine_godot/SpineSkeleton.cpp
@@ -362,67 +362,67 @@ void SpineSkeleton::set_position(Vector2 position) {
 	skeleton->setPosition(position.x, position.y);
 }
 
-float SpineSkeleton::get_x() {
+real_t SpineSkeleton::get_x() {
 	SPINE_CHECK(skeleton, 0)
 	return skeleton->getX();
 }
 
-void SpineSkeleton::set_x(float v) {
+void SpineSkeleton::set_x(real_t v) {
 	SPINE_CHECK(skeleton, )
 	skeleton->setX(v);
 }
 
-float SpineSkeleton::get_y() {
+real_t SpineSkeleton::get_y() {
 	SPINE_CHECK(skeleton, 0)
 	return skeleton->getY();
 }
 
-void SpineSkeleton::set_y(float v) {
+void SpineSkeleton::set_y(real_t v) {
 	SPINE_CHECK(skeleton, )
 	skeleton->setY(v);
 }
 
-float SpineSkeleton::get_scale_x() {
+real_t SpineSkeleton::get_scale_x() {
 	SPINE_CHECK(skeleton, 1)
 	return skeleton->getScaleX();
 }
 
-void SpineSkeleton::set_scale_x(float v) {
+void SpineSkeleton::set_scale_x(real_t v) {
 	SPINE_CHECK(skeleton, )
 	skeleton->setScaleX(v);
 }
 
-float SpineSkeleton::get_scale_y() {
+real_t SpineSkeleton::get_scale_y() {
 	SPINE_CHECK(skeleton, 1)
 	return -skeleton->getScaleY();
 }
 
-void SpineSkeleton::set_scale_y(float v) {
+void SpineSkeleton::set_scale_y(real_t v) {
 	SPINE_CHECK(skeleton, )
 	skeleton->setScaleY(v);
 }
 
-float SpineSkeleton::get_time() {
+real_t SpineSkeleton::get_time() {
 	SPINE_CHECK(get_spine_object(), 0)
 	return get_spine_object()->getTime();
 }
 
-void SpineSkeleton::set_time(float time) {
+void SpineSkeleton::set_time(real_t time) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->setTime(time);
 }
 
-void SpineSkeleton::update(float delta) {
+void SpineSkeleton::update(real_t delta) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->update(delta);
 }
 
-void SpineSkeleton::physics_translate(float x, float y) {
+void SpineSkeleton::physics_translate(real_t x, real_t y) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->physicsTranslate(x, y);
 }
 
-void SpineSkeleton::physics_rotate(float x, float y, float degrees) {
+void SpineSkeleton::physics_rotate(real_t x, real_t y, real_t degrees) {
 	SPINE_CHECK(get_spine_object(), )
 	get_spine_object()->physicsRotate(x, y, degrees);
 }

--- a/spine-godot/spine_godot/SpineSkeleton.h
+++ b/spine-godot/spine_godot/SpineSkeleton.h
@@ -132,29 +132,29 @@ public:
 
 	void set_position(Vector2 position);
 
-	float get_x();
+	real_t get_x();
 
-	void set_x(float v);
+	void set_x(real_t v);
 
-	float get_y();
+	real_t get_y();
 
-	void set_y(float v);
+	void set_y(real_t v);
 
-	float get_scale_x();
+	real_t get_scale_x();
 
-	void set_scale_x(float v);
+	void set_scale_x(real_t v);
 
-	float get_scale_y();
+	real_t get_scale_y();
 
-	void set_scale_y(float v);
+	void set_scale_y(real_t v);
 
-	float get_time();
+	real_t get_time();
 
-	void set_time(float time);
+	void set_time(real_t time);
 
-	void update(float delta);
+	void update(real_t delta);
 
-	void physics_translate(float x, float y);
+	void physics_translate(real_t x, real_t y);
 
-	void physics_rotate(float x, float y, float degrees);
+	void physics_rotate(real_t x, real_t y, real_t degrees);
 };

--- a/spine-godot/spine_godot/SpineSkeletonFileResource.cpp
+++ b/spine-godot/spine_godot/SpineSkeletonFileResource.cpp
@@ -100,7 +100,7 @@ void SpineSkeletonFileResource::_bind_methods() {
 static bool checkVersion(const char *version) {
 	if (!version) return false;
 	char *result = (char *) (strstr(version, SPINE_VERSION_STRING) - version);
-	return result == 0;
+    return result == nullptr;
 }
 
 static bool checkJson(const char *jsonData) {

--- a/spine-godot/spine_godot/SpineSkeletonFileResource.h
+++ b/spine-godot/spine_godot/SpineSkeletonFileResource.h
@@ -94,7 +94,7 @@ public:
 	Variant _load(const String &path, const String &original_path, bool use_sub_threads, int32_t cache_mode);
 #else
 #if VERSION_MAJOR > 3
-	RES load(const String &path, const String &original_path, Error *error, bool use_sub_threads, float *progress, CacheMode cache_mode);
+	virtual RES load(const String &path, const String &original_path, Error *error, bool use_sub_threads, float *progress, CacheMode cache_mode) override;
 #else
 #if VERSION_MINOR > 5
 	RES load(const String &path, const String &original_path, Error *error, bool no_subresource_cache = false);

--- a/spine-godot/spine_godot/SpineSprite.cpp
+++ b/spine-godot/spine_godot/SpineSprite.cpp
@@ -184,7 +184,7 @@ static void add_triangles(SpineMesh2D *mesh_instance,
 																  colors,
 																  uvs,
 																  Vector<int>(),
-																  Vector<float>(),
+																  Vector<real_t>(),
 																  texture.is_null() ? RID() : texture->get_rid(),
 																  -1,
 																  normal_map.is_null() ? RID() : normal_map->get_rid());
@@ -267,8 +267,8 @@ void SpineMesh2D::update_mesh(const PackedVector2Array &vertices,
 				aabb_new.expand_to(Vector3(vertex.x, vertex.y, 0));
 			}
 
-			float uv[2] = {(float) uvs[i].x, (float) uvs[i].y};
-			memcpy(&vertex_write_buffer[i * vertex_stride + surface_offsets[RS::ARRAY_VERTEX]], &vertex, sizeof(float) * 2);
+			float uv[2] = {uvs[i].x, uvs[i].y};
+			memcpy(&vertex_write_buffer[i * vertex_stride + surface_offsets[RS::ARRAY_VERTEX]], &vertices[i], sizeof(float) * 2);
 			memcpy(&attribute_write_buffer[i * attribute_stride + surface_offsets[RS::ARRAY_COLOR]], color, 4);
 			memcpy(&attribute_write_buffer[i * attribute_stride + surface_offsets[RS::ARRAY_TEX_UV]], uv, 8);
 		}
@@ -334,16 +334,17 @@ void SpineMesh2D::update_mesh(const Vector<Point2> &vertices,
 				aabb_new.expand_to(Vector3(vertex.x, vertex.y, 0));
 			}
 
-			float uv[2] = {(float) uvs[i].x, (float) uvs[i].y};
-			memcpy(&vertex_write_buffer[i * vertex_stride + surface_offsets[RS::ARRAY_VERTEX]], &vertex, sizeof(float) * 2);
+			float uv[2] = {(float)uvs[i].x, (float)uvs[i].y};
+            float xy[2] = {(float)vertex.x, (float)vertex.y};
+			memcpy(&vertex_write_buffer[i * vertex_stride + surface_offsets[RS::ARRAY_VERTEX]], xy, sizeof(float) * 2);
 			memcpy(&attribute_write_buffer[i * attribute_stride + surface_offsets[RS::ARRAY_COLOR]], color, 4);
-			memcpy(&attribute_write_buffer[i * attribute_stride + surface_offsets[RS::ARRAY_TEX_UV]], uv, 8);
+			memcpy(&attribute_write_buffer[i * attribute_stride + surface_offsets[RS::ARRAY_TEX_UV]], uv, sizeof(float) * 2);
 		}
 		RS::get_singleton()->mesh_surface_update_vertex_region(mesh, 0, 0, vertex_buffer);
 		RS::get_singleton()->mesh_surface_update_attribute_region(mesh, 0, 0, attribute_buffer);
 		RS::get_singleton()->mesh_set_custom_aabb(mesh, aabb_new);
 	}
-
+    
 	RenderingServer::get_singleton()->canvas_item_add_mesh(this->get_canvas_item(), mesh, Transform2D(), Color(1, 1, 1, 1), renderer_object->canvas_texture->get_rid());
 #else
 	if (!mesh.is_valid() || vertices.size() != num_vertices || indices.size() != num_indices || indices_changed) {
@@ -386,10 +387,11 @@ void SpineMesh2D::update_mesh(const Vector<Point2> &vertices,
 				aabb_new.expand_to(Vector3(vertex.x, vertex.y, 0));
 			}
 
-			float uv[2] = {(float) uvs[i].x, (float) uvs[i].y};
-			memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_VERTEX] + mesh_surface_offsets[VS::ARRAY_VERTEX]], &vertex, sizeof(float) * 2);
+			float uv[2] = { (float) uvs[i].x, (float) uvs[i].y};
+            float xy[2] = {(float)vertex.x, (float)vertex.y};
+			memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_VERTEX] + mesh_surface_offsets[VS::ARRAY_VERTEX]], xy, sizeof(float) * 2);
 			memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_TEX_UV] + mesh_surface_offsets[VS::ARRAY_TEX_UV]], uv, 8);
-			memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_COLOR] + mesh_surface_offsets[VS::ARRAY_COLOR]], color, 4);
+			memcpy(&write_buffer[i * mesh_stride[VS::ARRAY_COLOR] + mesh_surface_offsets[VS::ARRAY_COLOR]], color, sizeof(float) * 2);
 		}
 		write_buffer.release();
 		VS::get_singleton()->mesh_surface_update_region(mesh, 0, 0, mesh_buffer);
@@ -716,7 +718,7 @@ void SpineSprite::_get_property_list(List<PropertyInfo> *list) const {
 	preview_time_property.name = "preview_time";
 	preview_time_property.type = VARIANT_FLOAT;
 	preview_time_property.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE;
-	float animation_duration = 0;
+	real_t animation_duration = 0;
 	if (!EMPTY(preview_animation) && preview_animation != "-- Empty --") {
 		auto animation = skeleton_data_res->find_animation(preview_animation);
 		if (animation.is_valid()) animation_duration = animation->get_duration();
@@ -753,7 +755,7 @@ bool SpineSprite::_get(const StringName &property, Variant &value) const {
 	return false;
 }
 
-static void update_preview_animation(SpineSprite *sprite, const String &skin, const String &animation, bool frame, float time) {
+static void update_preview_animation(SpineSprite *sprite, const String &skin, const String &animation, bool frame, real_t time) {
 	if (!Engine::get_singleton()->is_editor_hint()) return;
 	if (!sprite->get_skeleton().is_valid()) return;
 
@@ -806,7 +808,7 @@ bool SpineSprite::_set(const StringName &property, const Variant &value) {
 	return false;
 }
 
-void SpineSprite::update_skeleton(float delta) {
+void SpineSprite::update_skeleton(real_t delta) {
 	if (!skeleton_data_res.is_valid() ||
 		!skeleton_data_res->is_skeleton_data_loaded() ||
 		!skeleton.is_valid() ||
@@ -914,12 +916,16 @@ void SpineSprite::update_meshes(Ref<SpineSkeleton> skeleton_ref) {
 			mesh_instance->set_light_mask(get_light_mask());
 			size_t num_vertices = vertices->size() / 2;
 			mesh_instance->vertices.resize((int) num_vertices);
-			memcpy(mesh_instance->vertices.ptrw(), vertices->buffer(), num_vertices * 2 * sizeof(float));
 			mesh_instance->uvs.resize((int) num_vertices);
-			memcpy(mesh_instance->uvs.ptrw(), uvs->buffer(), num_vertices * 2 * sizeof(float));
 			mesh_instance->colors.resize((int) num_vertices);
-			for (int j = 0; j < (int) num_vertices; j++) {
-				mesh_instance->colors.set(j, Color(tint.r, tint.g, tint.b, tint.a));
+			for (int i = 0, j = 0; i < (int) num_vertices; i++, j += 2) {
+				real_t x = vertices->buffer()[j];
+				real_t y = vertices->buffer()[j + 1];
+				real_t u = uvs->buffer()[j];
+				real_t v = uvs->buffer()[j + 1];
+				mesh_instance->vertices.set(i, Vector2(x, y));
+				mesh_instance->uvs.set(i, Vector2(u, v));
+				mesh_instance->colors.set(i, Color(tint.r, tint.g, tint.b, tint.a));
 			}
 
 			auto indices_changed = false;
@@ -1057,8 +1063,8 @@ void SpineSprite::draw() {
 			// Render hull.
 			statics.scratch_points.resize(0);
 			for (int i = 0, j = 0; i < 4; i++, j += 2) {
-				float x = vertices->buffer()[j];
-				float y = vertices->buffer()[j + 1];
+				real_t x = vertices->buffer()[j];
+				real_t y = vertices->buffer()[j + 1];
 				statics.scratch_points.push_back(Vector2(x, y));
 			}
 			statics.scratch_points.push_back(Vector2(vertices->buffer()[0], vertices->buffer()[1]));
@@ -1098,8 +1104,8 @@ void SpineSprite::draw() {
 			// Render hull
 			statics.scratch_points.resize(0);
 			for (int i = 0, j = 0; i < mesh->getHullLength(); i++, j += 2) {
-				float x = vertices->buffer()[j];
-				float y = vertices->buffer()[j + 1];
+				real_t x = vertices->buffer()[j];
+				real_t y = vertices->buffer()[j + 1];
 				statics.scratch_points.push_back(Vector2(x, y));
 			}
 
@@ -1131,9 +1137,16 @@ void SpineSprite::draw() {
 			vertices->setSize(bounding_box->getWorldVerticesLength(), 0);
 			bounding_box->computeWorldVertices(*slot, *vertices);
 			size_t num_vertices = vertices->size() / 2;
-			statics.scratch_points.resize((int) num_vertices);
-			memcpy(statics.scratch_points.ptrw(), vertices->buffer(), num_vertices * 2 * sizeof(float));
+			// Render hull.
+			statics.scratch_points.resize(0);
+			for (int i = 0, j = 0; i < num_vertices; i++, j += 2) {
+				real_t x = vertices->buffer()[j];
+				real_t y = vertices->buffer()[j + 1];
+				statics.scratch_points.push_back(Vector2(x, y));
+			}
 			statics.scratch_points.push_back(Vector2(vertices->buffer()[0], vertices->buffer()[1]));
+			//memcpy(statics.scratch_points.ptrw(), vertices->buffer(), num_vertices * sizeof(float) * 2);
+			//statics.scratch_points.push_back(Vector2(vertices->buffer()[0], vertices->buffer()[1]));
 			draw_polyline(statics.scratch_points, debug_bounding_boxes_color, 2);
 		}
 	}
@@ -1152,9 +1165,17 @@ void SpineSprite::draw() {
 			vertices->setSize(clipping->getWorldVerticesLength(), 0);
 			clipping->computeWorldVertices(*slot, *vertices);
 			size_t num_vertices = vertices->size() / 2;
-			statics.scratch_points.resize((int) num_vertices);
-			memcpy(statics.scratch_points.ptrw(), vertices->buffer(), num_vertices * 2 * sizeof(float));
+			// Render hull.
+			statics.scratch_points.resize(0);
+			for (int i = 0, j = 0; i < num_vertices; i++, j += 2) {
+				real_t x = vertices->buffer()[j];
+				real_t y = vertices->buffer()[j + 1];
+				statics.scratch_points.push_back(Vector2(x, y));
+			}
 			statics.scratch_points.push_back(Vector2(vertices->buffer()[0], vertices->buffer()[1]));
+			// statics.scratch_points.resize((int) num_vertices);
+			// memcpy(statics.scratch_points.ptrw(), vertices->buffer(), num_vertices * sizeof(real_t));
+			// statics.scratch_points.push_back(Vector2(vertices->buffer()[0], vertices->buffer()[1]));
 			draw_polyline(statics.scratch_points, debug_clipping_color, 2);
 		}
 	}
@@ -1165,7 +1186,7 @@ void SpineSprite::draw() {
 		auto bone = skeleton->get_spine_object()->getRootBone();
 		draw_bone(bone, debug_root_color);
 
-		float bone_length = bone->getData().getLength();
+		real_t bone_length = bone->getData().getLength();
 		if (bone_length == 0) bone_length = debug_bones_thickness * 2;
 
 		statics.scratch_points.resize(5);
@@ -1193,7 +1214,7 @@ void SpineSprite::draw() {
 			if (!bone->isActive()) continue;
 			draw_bone(bone, debug_bones_color);
 
-			float bone_length = bone->getData().getLength();
+			real_t bone_length = bone->getData().getLength();
 			if (bone_length == 0) bone_length = debug_bones_thickness * 2;
 
 			statics.scratch_points.resize(5);
@@ -1216,17 +1237,17 @@ void SpineSprite::draw() {
 	}
 
 #if TOOLS_ENABLED
-	float editor_scale = 1.0;
+	real_t editor_scale = 1.0;
 	if (Engine::get_singleton()->is_editor_hint()) editor_scale = EditorInterface::get_singleton()->get_editor_scale();
 
-	float inverse_zoom = 1 / get_viewport()->get_global_canvas_transform().get_scale().x * editor_scale;
+	real_t inverse_zoom = 1 / get_viewport()->get_global_canvas_transform().get_scale().x * editor_scale;
 	Vector<String> hover_text_lines;
 	if (hovered_slot) {
 		hover_text_lines.push_back(String("Slot: ") + hovered_slot->getData().getName().buffer());
 	}
 
 	if (hovered_bone) {
-		float thickness = debug_bones_thickness;
+		real_t thickness = debug_bones_thickness;
 		debug_bones_thickness *= 1.1;
 		draw_bone(hovered_bone, Color(debug_bones_color.r, debug_bones_color.g, debug_bones_color.b, 1));
 		debug_bones_thickness = thickness;
@@ -1248,14 +1269,14 @@ void SpineSprite::draw() {
 #if VERSION_MAJOR > 3
 #ifdef SPINE_GODOT_EXTENSION
 	// FIXME possibly wrong
-	float line_height = default_font->get_height() + default_font->get_descent();
+	real_t line_height = default_font->get_height() + default_font->get_descent();
 #else
-	float line_height = default_font->get_height(Font::DEFAULT_FONT_SIZE) + default_font->get_descent(Font::DEFAULT_FONT_SIZE);
+	real_t line_height = default_font->get_height(Font::DEFAULT_FONT_SIZE) + default_font->get_descent(Font::DEFAULT_FONT_SIZE);
 #endif
 #else
-	float line_height = default_font->get_height() + default_font->get_descent();
+	real_t line_height = default_font->get_height() + default_font->get_descent();
 #endif
-	float rect_width = 0;
+	real_t rect_width = 0;
 	for (int i = 0; i < hover_text_lines.size(); i++) {
 		rect_width = MAX(rect_width, default_font->get_string_size(hover_text_lines[i]).x);
 	}
@@ -1286,7 +1307,7 @@ void SpineSprite::draw() {
 
 void SpineSprite::draw_bone(spine::Bone *bone, const Color &color) {
 	draw_set_transform(Vector2(bone->getWorldX(), bone->getWorldY()), spine::MathUtil::Deg_Rad * bone->getWorldRotationX(), Vector2(bone->getWorldScaleX(), bone->getWorldScaleY()));
-	float bone_length = bone->getData().getLength();
+	real_t bone_length = bone->getData().getLength();
 	if (bone_length == 0) bone_length = debug_bones_thickness * 2;
 #ifdef SPINE_GODOT_EXTENSION
 	PackedVector2Array points;

--- a/spine-godot/spine_godot/SpineSprite.h
+++ b/spine-godot/spine_godot/SpineSprite.h
@@ -39,6 +39,7 @@
 #include <godot_cpp/classes/canvas_item_material.hpp>
 #else
 #include "scene/2d/node_2d.h"
+#include "scene/resources/canvas_item_material.h"
 #endif
 
 class SpineSlotNode;
@@ -145,13 +146,13 @@ protected:
 	String preview_skin;
 	String preview_animation;
 	bool preview_frame;
-	float preview_time;
+	real_t preview_time;
 
 	bool debug_root;
 	Color debug_root_color;
 	bool debug_bones;
 	Color debug_bones_color;
-	float debug_bones_thickness;
+	real_t debug_bones_thickness;
 	bool debug_regions;
 	Color debug_regions_color;
 	bool debug_meshes;
@@ -202,7 +203,7 @@ public:
 
 	void on_skeleton_data_changed();
 
-	void update_skeleton(float delta);
+	void update_skeleton(real_t delta);
 
 	Transform2D get_global_bone_transform(const String &bone_name);
 
@@ -246,9 +247,9 @@ public:
 
 	void set_debug_bones_color(const Color &color) { debug_bones_color = color; }
 
-	float get_debug_bones_thickness() { return debug_bones_thickness; }
+	real_t get_debug_bones_thickness() { return debug_bones_thickness; }
 
-	void set_debug_bones_thickness(float thickness) { debug_bones_thickness = thickness; }
+	void set_debug_bones_thickness(real_t thickness) { debug_bones_thickness = thickness; }
 
 	bool get_debug_regions() { return debug_regions; }
 


### PR DESCRIPTION
This swaps out the `<float>` stuff for `<real_t>`. It also updates the ResourceLoaders to work with godot 4.4.

I haven not tested this with a single precision build, which is definitely on my radar. There's probably some cleanup necessary in here, too.