### PR TITLE
[iOS] fix compile failure using SPM with recent xcode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,14 +21,14 @@ let package = Package(
             dependencies: [
                 "SpineCppLite", "SpineShadersStructs"
             ],
-            path: "spine-ios/Sources/Spine",
-            swiftSettings: [
-                .interoperabilityMode(.Cxx)
-            ]
+            path: "spine-ios/Sources/Spine"
         ),
         .target(
             name: "SpineCppLite",
-            path: "spine-ios/Sources/SpineCppLite"
+            path: "spine-ios/Sources/SpineCppLite",
+            linkerSettings: [
+                .linkedLibrary("c++"),
+            ]
         ),
         .systemLibrary(
             name: "SpineShadersStructs",


### PR DESCRIPTION
since SpineCppLite expose c-interface only and does not expose cpp interface

c++ interperability is no-op and just causing compiler crash.
So we could add linker flag to ensure SpineCppLite is build with C++ while removing c++ interperability mode

I have tested it using Spine example project, and it will solve #2777 , #2712