### PR TITLE
[csharp] Fix bug in SkeletonBinary.SkeletonInput.ReadInt

### DIFF
--- a/spine-csharp/src/SkeletonBinary.cs
+++ b/spine-csharp/src/SkeletonBinary.cs
@@ -1287,7 +1287,7 @@ namespace Spine {
 						}
 					}
 				}
-				return optimizePositive ? result : ((result >> 1) ^ -(result & 1));
+				return optimizePositive ? result : ((int)((uint)result >> 1) ^ -(result & 1));
 			}
 
 			public string ReadString () {


### PR DESCRIPTION
The `ReadInt` method in C# should align with the behavior of the C version. Here, an unsigned right shift should be used to ensure that the higher bits are consistently set to 0.

Expected:

https://github.com/EsotericSoftware/spine-runtimes/blob/18d30af5a9cd2429a16e003b85dc844a8f6f2ea9/spine-c/spine-c/src/spine/SkeletonBinary.c#L152