### PR TITLE
[haxe] When SkeletonSprite is disposed, clean up listeners

### DIFF
--- a/spine-haxe/spine-haxe/spine/starling/SkeletonSprite.hx
+++ b/spine-haxe/spine-haxe/spine/starling/SkeletonSprite.hx
@@ -416,4 +416,12 @@ class SkeletonSprite extends DisplayObject implements IAnimatable {
 			bone.worldToLocal(point);
 		}
 	}
+
+	override public function dispose():Void {
+		if (null != _state) {
+			_state.clearListeners();
+			_state = null;
+		}
+		super.dispose();
+	}
 }


### PR DESCRIPTION
If you don't cleanup listeners, then callbacks get call for an object that is already thrown away.