### PR TITLE
Update iOS platform version to v17

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "spine-ios",
     platforms: [
-        .iOS(.v13)
+        .iOS(.v17)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.


### PR DESCRIPTION
Addresses the same issue as https://github.com/EsotericSoftware/spine-runtimes/pull/2780 does, but in a way that may not satisfy your project version policy.