### PR TITLE
Remove SkeletonSprite from the Juggler on dispose

### DIFF
--- a/spine-haxe/spine-haxe/spine/starling/SkeletonSprite.hx
+++ b/spine-haxe/spine-haxe/spine/starling/SkeletonSprite.hx
@@ -423,6 +423,7 @@ class SkeletonSprite extends DisplayObject implements IAnimatable {
 			_state = null;
 		}
 		if (_skeleton != null) _skeleton = null;
+		if (null != Starling.current && null != Starling.current.juggler) Starling.current.juggler.remove(this);
 		super.dispose();
 	}
 }


### PR DESCRIPTION
When we dispose of the SkeletonSprite, we should remove it from the juggler - since this is the default thing that would be calling advanceTime().  If the SkeletonSprite is not in the juggler, nothing happens, but if we don't remove it - we now have a memory leak (and we are calling advanceTime on a item that it disposed).

You could make an argument then when we create a SkeletonSprite, it should be added to the Starling juggler automatically.  However, I can see arguments to NOT do this (i.e. you aren't using the default juggler, or you are using something else to call advanceTime).