### PR TITLE
[cpp] fix bound computation ignores clipping

### DIFF
--- a/spine-cpp/spine-cpp/src/spine/Skeleton.cpp
+++ b/spine-cpp/spine-cpp/src/spine/Skeleton.cpp
@@ -507,6 +507,7 @@ void Skeleton::getBounds(float &outX, float &outY, float &outWidth,
 		} else if (attachment != NULL &&
 				   attachment->getRTTI().instanceOf(ClippingAttachment::rtti) && clipper != NULL) {
 			clipper->clipStart(*slot, static_cast<ClippingAttachment *>(attachment));
+			continue;
 		}
 
 		if (verticesLength > 0) {


### PR DESCRIPTION
cpp bound calculation ignores Clipping while other platform does not

https://github.com/EsotericSoftware/spine-runtimes/blob/4.2/spine-libgdx/spine-libgdx/src/com/esotericsoftware/spine/Skeleton.java#L728
```java
	} else if (attachment instanceof ClippingAttachment && clipper != null) {
		ClippingAttachment clip = (ClippingAttachment)attachment;
		clipper.clipStart(slot, clip);
		continue;
	}
```