### PR TITLE
[ts][webgl] SpineCanvas constructor config.webglConfig condition correted

### DIFF
--- a/spine-ts/spine-webgl/src/SpineCanvas.ts
+++ b/spine-ts/spine-webgl/src/SpineCanvas.ts
@@ -89,7 +89,7 @@ export class SpineCanvas {
 			error: () => { },
 			dispose: () => { },
 		}
-		if (config.webglConfig) config.webglConfig = { alpha: true };
+		if (!config.webglConfig) config.webglConfig = { alpha: true };
 
 		this.htmlCanvas = canvas;
 		this.context = new ManagedWebGLRenderingContext(canvas, config.webglConfig);


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/40df88d1-6d61-4eb4-a650-f8cda1bf5ca7)


Condition of the config.webglConfig ignored the parameter. After condtion is fixed the paramter is set properly.