### PR TITLE
[ts] use skeletonData as a global viewport alternative

### DIFF
--- a/spine-ts/spine-player/src/Player.ts
+++ b/spine-ts/spine-player/src/Player.ts
@@ -120,6 +120,9 @@ export interface SpinePlayerConfig {
 
 		/* Optional: Viewports for specific animations. Default: none */
 		animations?: StringMap<Viewport>
+
+		/* Optional: Whether to use the x, y, height and width in skeletonData as global viewport. Default: false */
+		useSkeletonData?: boolean
 	}
 
 	/* Optional: Whether the canvas is transparent, allowing the web page behind the canvas to show through when
@@ -748,7 +751,18 @@ export class SpinePlayer implements Disposable {
 			padTop: globalViewport.padTop !== void 0 ? globalViewport.padTop : "10%",
 			padBottom: globalViewport.padBottom !== void 0 ? globalViewport.padBottom : "10%"
 		} as Viewport;
-		if (globalViewport.x !== void 0 && globalViewport.y !== void 0 && globalViewport.width && globalViewport.height) {
+		if (
+			globalViewport.useSkeletonData &&
+			this.skeleton!.data.x !== void 0 &&
+			this.skeleton!.data.y !== void 0 &&
+			this.skeleton!.data.width &&
+			this.skeleton!.data.height
+		) {
+			viewport.x = this.skeleton!.data.x;
+			viewport.y = this.skeleton!.data.y;
+			viewport.width = this.skeleton!.data.width;
+			viewport.height = this.skeleton!.data.height;
+		} else if (globalViewport.x !== void 0 && globalViewport.y !== void 0 && globalViewport.width && globalViewport.height) {
 			viewport.x = globalViewport.x;
 			viewport.y = globalViewport.y;
 			viewport.width = globalViewport.width;


### PR DESCRIPTION
[This doc](https://esotericsoftware.com/spine-player) explains that there's an automatic viewport feature by default. For instance, in [example.html](https://github.com/EsotericSoftware/spine-runtimes/blob/4.2/spine-ts/spine-player/example/example.html), without setting a global viewport, the spineboy and raptor characters will shrink when switching animations from 'walk' to 'jump'.

[original.webm](https://github.com/user-attachments/assets/079c9962-6f42-485e-9f54-09a5c4e9aab1)

While setting a global viewport resolves this, it's a manual step. Ideally, we could leverage the loaded skeletonData to avoid viewport updates whenever the Skeleton file is modified. So I'm wondering if the following could be an alternative to manual setting x, y, height and width:
```js
var jsControlledPlayer = new spine.SpinePlayer("container-raptor", {
	skeleton: "assets/raptor-pro.json",
	atlas: "assets/raptor-pma.atlas",
	animation: "walk",
	viewport: {
		useSkeletonData: true,
	},
});
```

[useSkeletonData.webm](https://github.com/user-attachments/assets/e8b36f56-29d1-42b7-a69c-734d3cafa9e2)

The characters don't shrink even if we don't explicitly set x, y, height and width ourselves.