### PR TITLE
Fix the inconsistent behavior between Spine vector's setSize and std::vector's resize, which causes the Spine vector to allocate additional space upfront.

### DIFF
--- a/spine-cpp/spine-cpp/include/spine/Vector.h
+++ b/spine-cpp/spine-cpp/include/spine/Vector.h
@@ -77,7 +77,11 @@ namespace spine {
 			size_t oldSize = _size;
 			_size = newSize;
 			if (_capacity < newSize) {
-				_capacity = (int) (_size * 1.75f);
+				if (_capacity == 0) {
+					_capacity = _size;
+				} else {
+					_capacity = (int) (_size * 1.75f);
+				}
 				if (_capacity < 8) _capacity = 8;
 				_buffer = spine::SpineExtension::realloc<T>(_buffer, _capacity, __FILE__, __LINE__);
 			}


### PR DESCRIPTION
![企业微信截图_17458243154941](https://github.com/user-attachments/assets/6155b916-5a8c-440b-b621-7ec7cdaadcc9)

As shown in the screenshot, when the vector is empty, the first call to resize results in capacity and size being equal, meaning no additional capacity is allocated.