### PR TITLE
Fix bug when fetching atlas texture with loader path set.

### DIFF
--- a/spine-ts/spine-phaser-v3/src/SpinePlugin.ts
+++ b/spine-ts/spine-phaser-v3/src/SpinePlugin.ts
@@ -371,6 +371,10 @@ class SpineAtlasFile extends Phaser.Loader.MultiFile {
 				}
 
 				let basePath = file.src.match(/^.*\//) ?? "";
+				if(this.loader.path && this.loader.path.length > 0 && basePath.toString().startsWith(this.loader.path)) {
+					basePath = basePath.toString().slice(this.loader.path.length);
+				}
+
 				for (var i = 0; i < textures.length; i++) {
 					var url = basePath + textures[i];
 					var key = file.key + "!" + textures[i];


### PR DESCRIPTION
When setting a path via scene.load.setPath and loading a spine atlas, the texture(s) urls should not have path be in it's url otherwise the loader will doubly prepend the path.

EG:
this.load.setPath("assets/");
this.load.spineBinary("spineboy-data", "spineboy-pro.skel");
this.load.spineAtlas("spineboy-atlas", "spineboy-pma.atlas");

When atlas is fetched, the loader fetch to texture spineboy-pma.png will incorrect have src assets/assets/spineboy-pma.png.