### PR TITLE
[c] fix wrong rgb2 timeline management

### DIFF
--- a/spine-c/spine-c/src/spine/Animation.c
+++ b/spine-c/spine-c/src/spine/Animation.c
@@ -1393,7 +1393,7 @@ void spRGBA2Timeline_setFrame(spRGBA2Timeline *self, int frame, float time, floa
 
 /**/
 
-static const int RGB2_ENTRIES = 7, COLOR2_R2 = 5, COLOR2_G2 = 6, COLOR2_B2 = 7;
+static const int RGB2_ENTRIES = 7, COLOR2_R2 = 4, COLOR2_G2 = 5, COLOR2_B2 = 6;
 
 void _spRGB2Timeline_apply(spTimeline *timeline, spSkeleton *skeleton, float lastTime, float time, spEvent **firedEvents,
 						   int *eventsCount, float alpha, spMixBlend blend, spMixDirection direction) {

--- a/spine-c/spine-c/src/spine/SkeletonJson.c
+++ b/spine-c/spine-c/src/spine/SkeletonJson.c
@@ -426,7 +426,7 @@ static spAnimation *_spSkeletonJson_readAnimation(spSkeletonJson *self, Json *ro
 				spTimelineArray_add(timelines, SUPER(SUPER(timeline)));
 			} else if (strcmp(timelineMap->name, "rgb2") == 0) {
 				float time;
-				spRGBA2Timeline *timeline = spRGBA2Timeline_create(frames, frames * 6, slotIndex);
+                spRGB2Timeline *timeline = spRGB2Timeline_create(frames, frames * 6, slotIndex);
 				keyMap = timelineMap->child;
 				time = Json_getFloat(keyMap, "time", 0);
 				toColor2(&color, Json_getString(keyMap, "light", 0), 0);
@@ -434,7 +434,7 @@ static spAnimation *_spSkeletonJson_readAnimation(spSkeletonJson *self, Json *ro
 
 				for (frame = 0, bezier = 0;; ++frame) {
 					float time2;
-					spRGBA2Timeline_setFrame(timeline, frame, time, color.r, color.g, color.b, color.a, color2.r,
+					spRGB2Timeline_setFrame(timeline, frame, time, color.r, color.g, color.b, color2.r,
 											 color2.g, color2.b);
 					nextMap = keyMap->next;
 					if (!nextMap) {


### PR DESCRIPTION
* [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).


- this will fix illgeal memory access when spine is parsed from binary file
- this will fix wrong timeline animation when spine is parsed from json file
