### PR TITLE
Add Godot Spine Skin init method to binds

### DIFF
--- a/spine-godot/spine_godot/SpineSkin.cpp
+++ b/spine-godot/spine_godot/SpineSkin.cpp
@@ -45,6 +45,7 @@ void SpineSkin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_attachments"), &SpineSkin::get_attachments);
 	ClassDB::bind_method(D_METHOD("get_bones"), &SpineSkin::get_bones);
 	ClassDB::bind_method(D_METHOD("get_constraints"), &SpineSkin::get_constraints);
+	ClassDB::bind_method(D_METHOD("init", "name", "sprite"), &SpineSkin::init);
 }
 
 SpineSkin::SpineSkin() : owns_skin(false) {


### PR DESCRIPTION
* [+] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).

I think that this is a crucial fix for complex games.
During development of my game i couldn't create dynamic skins. Because just having SpineSkin.new() does not initialise the skin, and all other alternatives were just useless as they reference some skin in original spine object one way or another. I was able to compile the GODOT extension with this change, and it is working just fine as i would want it to be.
