### PR TITLE
 [ts][pixi-v8] Fix copy method, use structuredClone instead of manually creating array copies

### DIFF
--- a/spine-ts/spine-core/src/attachments/Attachment.ts
+++ b/spine-ts/spine-core/src/attachments/Attachment.ts
@@ -144,14 +144,12 @@ export abstract class VertexAttachment extends Attachment {
 	/** Does not copy id (generated) or name (set on construction). **/
 	copyTo (attachment: VertexAttachment) {
 		if (this.bones) {
-			attachment.bones = new Array<number>(this.bones.length);
-			Utils.arrayCopy(this.bones, 0, attachment.bones, 0, this.bones.length);
+			attachment.bones = structuredClone(this.bones)
 		} else
 			attachment.bones = null;
 
 		if (this.vertices) {
-			attachment.vertices = Utils.newFloatArray(this.vertices.length);
-			Utils.arrayCopy(this.vertices, 0, attachment.vertices, 0, this.vertices.length);
+			attachment.vertices = structuredClone(this.vertices)
 		}
 
 		attachment.worldVerticesLength = this.worldVerticesLength;

--- a/spine-ts/spine-core/src/attachments/MeshAttachment.ts
+++ b/spine-ts/spine-core/src/attachments/MeshAttachment.ts
@@ -174,20 +174,16 @@ export class MeshAttachment extends VertexAttachment implements HasTextureRegion
 		copy.color.setFromColor(this.color);
 
 		this.copyTo(copy);
-		copy.regionUVs = new Array<number>(this.regionUVs.length);
-		Utils.arrayCopy(this.regionUVs, 0, copy.regionUVs, 0, this.regionUVs.length);
-		copy.uvs = new Array<number>(this.uvs.length);
-		Utils.arrayCopy(this.uvs, 0, copy.uvs, 0, this.uvs.length);
-		copy.triangles = new Array<number>(this.triangles.length);
-		Utils.arrayCopy(this.triangles, 0, copy.triangles, 0, this.triangles.length);
+		copy.regionUVs = structuredClone(this.regionUVs)
+		copy.uvs = structuredClone(this.uvs)
+		copy.triangles = structuredClone(this.triangles)
 		copy.hullLength = this.hullLength;
 
 		copy.sequence = this.sequence != null ? this.sequence.copy() : null;
 
 		// Nonessential.
 		if (this.edges) {
-			copy.edges = new Array<number>(this.edges.length);
-			Utils.arrayCopy(this.edges, 0, copy.edges, 0, this.edges.length);
+			copy.edges = structuredClone(this.edges)
 		}
 		copy.width = this.width;
 		copy.height = this.height;


### PR DESCRIPTION
When I use spine-pixi-v8, there is an error.

![CleanShot 2025-06-24 at 12 48 22@2x](https://github.com/user-attachments/assets/0071399f-e168-47cd-8839-77f6e0d91ff1)


some code like this:
```
        const customMesh = slot.getAttachment().copy()
        customMesh.region = textureRegion;
        customMesh.updateRegion();
        slot.setAttachment(customMesh);
```

After some time, I got the reason.

https://github.com/EsotericSoftware/spine-runtimes/blob/5967b3c3f0e568d8278c71c61b9f29d2bd1af876/spine-ts/spine-core/src/attachments/MeshAttachment.ts#L177-L182



![CleanShot 2025-06-24 at 12 53 44@2x](https://github.com/user-attachments/assets/48bbfc9a-2369-4ad9-84c9-dd971489e0d5)

https://github.com/EsotericSoftware/spine-runtimes/blob/5967b3c3f0e568d8278c71c61b9f29d2bd1af876/spine-ts/spine-pixi-v8/src/Spine.ts#L656


The reason for this problem is that the original type of UVS was Float32Array, but after the copy method, it became Array and lost the buffer property.


---
So, it can be implemented using [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone) of the web standard.
If some browser do not support `structuredClone`, they can use some polyfill.
eg:
```
import { defineConfig } from 'vite'
import react from '@vitejs/plugin-react-swc'
import legacy from '@vitejs/plugin-legacy'


// https://vite.dev/config/
export default defineConfig({
  plugins: [react(),
  legacy({
    targets: ['chrome>=62', 'defaults', 'not IE 11'],
    modernTargets: ["chrome>=62"],
   modernPolyfills:['web.structured-clone']
  }),
  ]
})
```


