### PR TITLE
[c] fix wrong setTimeline call in RGB2

### DIFF
--- a/spine-c/spine-c/src/spine/SkeletonJson.c
+++ b/spine-c/spine-c/src/spine/SkeletonJson.c
@@ -434,7 +434,7 @@ static spAnimation *_spSkeletonJson_readAnimation(spSkeletonJson *self, Json *ro
 
 				for (frame = 0, bezier = 0;; ++frame) {
 					float time2;
-					spRGBA2Timeline_setFrame(timeline, frame, time, color.r, color.g, color.b, color.a, color2.r,
+					spRGB2Timeline_setFrame(timeline, frame, time, color.r, color.g, color.b, color2.r,
 											 color2.g, color2.b);
 					nextMap = keyMap->next;
 					if (!nextMap) {


### PR DESCRIPTION
* [X] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).



spRGB2Timeline should call `spRGB2Timeline_setFrame` not `spRGBA2Timeline_setFrame`