### PR TITLE
[cpp-lite] wrong type casting inside drawable dispose

### DIFF
--- a/spine-cpp/spine-cpp-lite/spine-cpp-lite.cpp
+++ b/spine-cpp/spine-cpp-lite/spine-cpp-lite.cpp
@@ -624,7 +624,7 @@ void spine_skeleton_drawable_dispose(spine_skeleton_drawable drawable) {
 	if (_drawable->skeleton) delete (Skeleton *) _drawable->skeleton;
 	if (_drawable->animationState) delete (AnimationState *) _drawable->animationState;
 	if (_drawable->animationStateData) delete (AnimationStateData *) _drawable->animationStateData;
-	if (_drawable->animationStateEvents) delete (Vector<AnimationStateEvent> *) (_drawable->animationStateEvents);
+	if (_drawable->animationStateEvents) delete (EventListener *) (_drawable->animationStateEvents);
 	if (_drawable->renderer) delete (SkeletonRenderer *) _drawable->renderer;
 	SpineExtension::free(drawable, __FILE__, __LINE__);
 }


### PR DESCRIPTION
* [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).


creating with `EventListener` (line 614~615)
but disposing it with casting to `Vector<AnimationStateEvent>` does not make sense to me.