### PR TITLE
Fix infinite loop when reading json inherit timeline.

### DIFF
--- a/spine-c/spine-c/src/spine/SkeletonJson.c
+++ b/spine-c/spine-c/src/spine/SkeletonJson.c
@@ -549,6 +549,7 @@ static spAnimation *_spSkeletonJson_readAnimation(spSkeletonJson *self, Json *ro
 					spInheritTimeline_setFrame(timeline, frame, time, inherit);
 					nextMap = keyMap->next;
 					if (!nextMap) break;
+					keyMap = nextMap;
 				}
 				spTimelineArray_add(timelines, SUPER(timeline));
 			} else {


### PR DESCRIPTION
* [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).
I found that there is an infinite loop when reading an inherit timeline with multiple keyframes in spine-c runtime;