### PR TITLE
Fix type for first parameter of spRGBA2Timeline_setFrame

### DIFF
--- a/spine-c/spine-c/src/spine/SkeletonJson.c
+++ b/spine-c/spine-c/src/spine/SkeletonJson.c
@@ -426,7 +426,7 @@ static spAnimation *_spSkeletonJson_readAnimation(spSkeletonJson *self, Json *ro
 				spTimelineArray_add(timelines, SUPER(SUPER(timeline)));
 			} else if (strcmp(timelineMap->name, "rgb2") == 0) {
 				float time;
-				spRGB2Timeline *timeline = spRGB2Timeline_create(frames, frames * 6, slotIndex);
+				spRGBA2Timeline *timeline = spRGBA2Timeline_create(frames, frames * 6, slotIndex);
 				keyMap = timelineMap->child;
 				time = Json_getFloat(keyMap, "time", 0);
 				toColor2(&color, Json_getString(keyMap, "light", 0), 0);


### PR DESCRIPTION
GCC 15:

```
spine-c/spine-c/src/spine/SkeletonJson.c:437:66: error: passing argument 1 of ‘spRGBA2Timeline_setFrame’ from incompatible pointer type [-Wincompatible-pointer-types]
  437 |                                         spRGBA2Timeline_setFrame(timeline, frame, time, color.r, color.g, color.b, color.a, color2.r,
      |                                                                  ^~~~~~~~
      |                                                                  |
      |                                                                  spRGB2Timeline *
In file included from spine-c/spine-c/include/spine/SkeletonData.h:38,
                 from spine-c/spine-c/include/spine/SkeletonJson.h:36,
                 from spine-c/spine-c/src/spine/SkeletonJson.c:34:
spine-c/spine-c/include/spine/Animation.h:383:43: note: expected ‘spRGBA2Timeline *’ but argument is of type ‘spRGB2Timeline *’
  383 | spRGBA2Timeline_setFrame(spRGBA2Timeline *self, int frameIndex, float time, float r, float g, float b, float a,
      |                          ~~~~~~~~~~~~~~~~~^~~~
```

* [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).
