### PR TITLE
[ts][pixi-v7][pixi-v8] 4.3 make spine init more universal

### DIFF
--- a/spine-ts/spine-pixi-v7/example/bounds.html
+++ b/spine-ts/spine-pixi-v7/example/bounds.html
@@ -29,21 +29,21 @@
 
 
         // Create the spine display object
-        const spineboy1 = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2 });
+        const spineboy1 = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2 });
 
-        const spineboy2 = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
+        const spineboy2 = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
           boundsProvider: new spine.SetupPoseBoundsProvider(),
         });
 
-        const spineboy3 = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
+        const spineboy3 = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
           boundsProvider: new spine.SkinsAndAnimationBoundsProvider("portal", undefined, undefined, false),
         });
 
-        const spineboy4 = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
+        const spineboy4 = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
           boundsProvider: new spine.SkinsAndAnimationBoundsProvider("portal", undefined, undefined, true),
         });
 
-        const spineboy5 = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
+        const spineboy5 = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
           boundsProvider: new spine.AABBRectangleBoundsProvider(-100, -100, 100, 100),
         });
 

--- a/spine-ts/spine-pixi-v7/example/bunnymark.html
+++ b/spine-ts/spine-pixi-v7/example/bunnymark.html
@@ -88,7 +88,7 @@
         bounds;
 
         constructor(bounds) {
-            const spineboy = spine.Spine.from({
+            const spineboy = new spine.Spine({
                 atlas: "spineboyAtlas",
                 skeleton: "spineboyData",
                 scale: 0.125,

--- a/spine-ts/spine-pixi-v7/example/control-bones-example.html
+++ b/spine-ts/spine-pixi-v7/example/control-bones-example.html
@@ -45,7 +45,7 @@
         await PIXI.Assets.load(["stretchymanData", "stretchymanAtlas"]);
 
         // Create the spine display object
-        const stretchyman = spine.Spine.from({skeleton: "stretchymanData", atlas: "stretchymanAtlas",
+        const stretchyman = new spine.Spine({skeleton: "stretchymanData", atlas: "stretchymanAtlas",
           scale: 0.75,
         });
 

--- a/spine-ts/spine-pixi-v7/example/events-example.html
+++ b/spine-ts/spine-pixi-v7/example/events-example.html
@@ -39,7 +39,7 @@
         await PIXI.Assets.load(["spineboyData", "spineboyAtlas"]);
 
         // Create the Spine display object
-        const spineboy = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas",
+        const spineboy = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas",
           scale: 0.5,
         });
 

--- a/spine-ts/spine-pixi-v7/example/index.html
+++ b/spine-ts/spine-pixi-v7/example/index.html
@@ -28,7 +28,7 @@
         await PIXI.Assets.load(["spineboyData", "spineboyAtlas"]);
 
         // Create the spine display object
-        const spineboy = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas",
+        const spineboy = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas",
           scale: 0.5,
         });
 

--- a/spine-ts/spine-pixi-v7/example/inline-loading.html
+++ b/spine-ts/spine-pixi-v7/example/inline-loading.html
@@ -53,7 +53,7 @@
 		await PIXI.Assets.load(["skelBase64", "atlasBase64"]);
 
 		// creating spine game object with base64 data
-		const base64GameObject = spine.Spine.from({skeleton: "skelBase64", atlas: "atlasBase64" });
+		const base64GameObject = new spine.Spine({skeleton: "skelBase64", atlas: "atlasBase64" });
 		app.stage.addChild(base64GameObject);
 		base64GameObject.state.setAnimation(0, "animation", true);
 		base64GameObject.position.set(window.innerWidth / 3, window.innerHeight / 2);
@@ -91,7 +91,7 @@
 		await PIXI.Assets.load(["skelBlob", "atlasBlob"]);
 
 		// creating spine game object
-		const blobGameObject = spine.Spine.from({skeleton: "skelBase64", atlas: "atlasBase64" });
+		const blobGameObject = new spine.Spine({skeleton: "skelBase64", atlas: "atlasBase64" });
 		app.stage.addChild(blobGameObject);
 		blobGameObject.state.setAnimation(0, "animation", true);
 		blobGameObject.position.set(window.innerWidth / 3 * 2, window.innerHeight / 2);

--- a/spine-ts/spine-pixi-v7/example/mix-and-match-example.html
+++ b/spine-ts/spine-pixi-v7/example/mix-and-match-example.html
@@ -28,7 +28,7 @@
         await PIXI.Assets.load(["mixAndMatchData", "mixAndMatchAtlas"]);
 
         // Create the Spine display object
-        const mixAndMatch = spine.Spine.from({skeleton: "mixAndMatchData", atlas: "mixAndMatchAtlas",
+        const mixAndMatch = new spine.Spine({skeleton: "mixAndMatchData", atlas: "mixAndMatchAtlas",
           scale: 0.5,
         });
 

--- a/spine-ts/spine-pixi-v7/example/mouse-following.html
+++ b/spine-ts/spine-pixi-v7/example/mouse-following.html
@@ -28,7 +28,7 @@
                 await PIXI.Assets.load(["spineboyData", "spineboyAtlas"]);
 
                 // Create the spine display object
-                const spineboy = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas",
+                const spineboy = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas",
                     scale: 0.5,
                 });
 

--- a/spine-ts/spine-pixi-v7/example/physics.html
+++ b/spine-ts/spine-pixi-v7/example/physics.html
@@ -28,7 +28,7 @@
         await PIXI.Assets.load(["sackData", "sackAtlas"]);
 
         // Create the spine display object
-        const sack = spine.Spine.from({skeleton: "sackData", atlas: "sackAtlas",
+        const sack = new spine.Spine({skeleton: "sackData", atlas: "sackAtlas",
           scale: 0.2,
         });
 

--- a/spine-ts/spine-pixi-v7/example/physics2.html
+++ b/spine-ts/spine-pixi-v7/example/physics2.html
@@ -28,7 +28,7 @@
         await PIXI.Assets.load(["girlData", "girlAtlas"]);
 
         // Create the spine display object
-        const girl = spine.Spine.from({skeleton: "girlData", atlas: "girlAtlas",
+        const girl = new spine.Spine({skeleton: "girlData", atlas: "girlAtlas",
           scale: 0.2,
         });
 

--- a/spine-ts/spine-pixi-v7/example/physics3.html
+++ b/spine-ts/spine-pixi-v7/example/physics3.html
@@ -28,7 +28,7 @@
         await PIXI.Assets.load(["snowglobeData", "snowglobeAtlas"]);
 
         // Create the spine display object
-        const snowglobe = spine.Spine.from({skeleton: "snowglobeData", atlas: "snowglobeAtlas",
+        const snowglobe = new spine.Spine({skeleton: "snowglobeData", atlas: "snowglobeAtlas",
           scale: 0.25,
         });
 

--- a/spine-ts/spine-pixi-v7/example/physics4.html
+++ b/spine-ts/spine-pixi-v7/example/physics4.html
@@ -28,7 +28,7 @@
         await PIXI.Assets.load(["cloudPotData", "cloudPotAtlas"]);
 
         // Create the spine display object
-        const cloudPot = spine.Spine.from({skeleton: "cloudPotData", atlas: "cloudPotAtlas",
+        const cloudPot = new spine.Spine({skeleton: "cloudPotData", atlas: "cloudPotAtlas",
           scale: 0.25,
         });
 

--- a/spine-ts/spine-pixi-v7/example/simple-input.html
+++ b/spine-ts/spine-pixi-v7/example/simple-input.html
@@ -28,7 +28,7 @@
         await PIXI.Assets.load(["spineboyData", "spineboyAtlas"]);
 
         // Create the spine display object
-        const spineboy = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas",
+        const spineboy = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas",
           scale: 0.5,
         });
 

--- a/spine-ts/spine-pixi-v7/example/slot-objects-scale-rotation.html
+++ b/spine-ts/spine-pixi-v7/example/slot-objects-scale-rotation.html
@@ -36,7 +36,7 @@
         PIXI.Assets.cache.set("spineboyAtlas", textureAtlas);
 
         // creating spine game object
-        const spineGO = spine.Spine.from({skeleton: "jsonSkel", atlas: "spineboyAtlas" });
+        const spineGO = new spine.Spine({skeleton: "jsonSkel", atlas: "spineboyAtlas" });
         spineGO.position.set(300, 300);
         app.stage.addChild(spineGO);
 

--- a/spine-ts/spine-pixi-v7/example/slot-objects.html
+++ b/spine-ts/spine-pixi-v7/example/slot-objects.html
@@ -28,7 +28,7 @@
         await PIXI.Assets.load(["spineboyData", "spineboyAtlas"]);
 
         // Create the spine display object
-        const spineboy = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas",
+        const spineboy = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas",
           scale: 0.25,
         });
 

--- a/spine-ts/spine-pixi-v7/example/typescript/index.ts
+++ b/spine-ts/spine-pixi-v7/example/typescript/index.ts
@@ -1,5 +1,5 @@
-import { Application, Assets } from 'pixi.js';
 import { Spine } from '@esotericsoftware/spine-pixi-v7';
+import { Application, Assets } from 'pixi.js';
 
 /** The PixiJS app Application instance, shared across the project */
 export const app = new Application<HTMLCanvasElement>({
@@ -23,7 +23,8 @@ async function init () {
 	await Assets.load(["spineboyData", "spineboyAtlas"]);
 
 	// Create the spine display object
-	const spineboy = Spine.from("spineboyData", "spineboyAtlas", {
+	const spineboy = new Spine({
+		skeleton: "spineboyData", atlas: "spineboyAtlas",
 		scale: 0.5,
 	});
 

--- a/spine-ts/spine-pixi-v7/src/Spine.ts
+++ b/spine-ts/spine-pixi-v7/src/Spine.ts
@@ -247,7 +247,8 @@ export class SkinsAndAnimationBoundsProvider
 
 /**
  * The class to instantiate a {@link Spine} game object in Pixi.
- * The static method {@link Spine.from} should be used to instantiate a Spine game object.
+ * Create and customize the default configuration using the static method {@link Spine.createOptions},
+ * then pass it to the constructor.
  */
 export class Spine extends Container {
 	/** The skeleton for this Spine game object. */
@@ -328,14 +329,11 @@ export class Spine extends Container {
 	private _boundsSpineID = -1;
 	private _boundsSpineDirty = true;
 
-	constructor (options: SpineOptions | SkeletonData) {
-		if (options instanceof SkeletonData) {
-			options = {
-				skeletonData: options,
-			};
-		}
-
+	constructor (options: SpineOptions | SpineFromOptions) {
 		super();
+
+		if ("skeleton" in options)
+			options = new.target.createOptions(options);
 
 		const skeletonData = options instanceof SkeletonData ? options : options.skeletonData;
 
@@ -861,14 +859,20 @@ export class Spine extends Container {
 	public static readonly skeletonCache: Record<string, SkeletonData> = Object.create(null);
 
 	/**
-	 * Prepares the initialization data for creating a Spine game object.
-	 * Handles skeleton data parsing and caching. If the skeleton data is already cached, returns the cached version.
-	 * Otherwise, loads and parses the skeleton and atlas assets, then caches the result.
+	 * Get a convenient initialization configuration for your Spine game object.
+	 * Before instantiating a Spine game object, the skeleton (`.skel` or `.json`) and the atlas text files must be loaded into the Assets. For example:
+	 * ```
+	 * PIXI.Assets.add("sackData", "/assets/sack-pro.skel");
+	 * PIXI.Assets.add("sackAtlas", "/assets/sack-pma.atlas");
+	 * await PIXI.Assets.load(["sackData", "sackAtlas"]);
+	 * ```
+	 * Once a Spine game object is created, its skeleton data is cached into {@link Spine.skeletonCache} using the key:
+	 * `${skeletonAssetName}-${atlasAssetName}-${options?.scale ?? 1}`
 	 *
 	 * @param options - Options to configure the Spine game object. See {@link SpineFromOptions}
-	 * @returns {SpineOptions} The initialization options object ready to be passed to the Spine constructor
+	 * @returns {SpineOptions} The configuration ready to be passed to the Spine constructor
 	 */
-	public static getSpineInitData ({ skeleton, atlas, scale = 1, darkTint, autoUpdate = true, boundsProvider, allowMissingRegions }: SpineFromOptions): SpineOptions {
+	public static createOptions ({ skeleton, atlas, scale = 1, darkTint, autoUpdate = true, boundsProvider, allowMissingRegions }: SpineFromOptions): SpineOptions {
 		const cacheKey = `${skeleton}-${atlas}-${scale}`;
 
 		let skeletonData = Spine.skeletonCache[cacheKey];
@@ -886,7 +890,7 @@ export class Spine extends Container {
 	}
 
 	/**
-	 * Use this method to instantiate a Spine game object.
+	 * @deprecated Use directly the Spine constructor or {@link createOptions} to make options and customize it to pass to the constructor
 	 * Before instantiating a Spine game object, the skeleton (`.skel` or `.json`) and the atlas text files must be loaded into the Assets. For example:
 	 * ```
 	 * PIXI.Assets.add("sackData", "/assets/sack-pro.skel");
@@ -900,7 +904,7 @@ export class Spine extends Container {
 	 * @returns {Spine} The Spine game object instantiated
 	 */
 	public static from (options: SpineFromOptions) {
-		return new Spine(Spine.getSpineInitData(options));
+		return new Spine(Spine.createOptions(options));
 	}
 
 	public get tint (): number {

--- a/spine-ts/spine-pixi-v7/src/Spine.ts
+++ b/spine-ts/spine-pixi-v7/src/Spine.ts
@@ -40,7 +40,7 @@ import {
 	Skeleton,
 	SkeletonBinary,
 	SkeletonClipping,
-	SkeletonData,
+	type SkeletonData,
 	SkeletonJson,
 	Skin,
 	Utils,
@@ -335,20 +335,17 @@ export class Spine extends Container {
 		if ("skeleton" in options)
 			options = new.target.createOptions(options);
 
-		const skeletonData = options instanceof SkeletonData ? options : options.skeletonData;
-
+		const { autoUpdate = true, boundsProvider, darkTint, skeletonData } = options;
 		this.skeleton = new Skeleton(skeletonData);
-		const animData = new AnimationStateData(skeletonData);
-		this.state = new AnimationState(animData);
-		this.autoUpdate = options?.autoUpdate ?? true;
+		this.state = new AnimationState(new AnimationStateData(skeletonData));
+		this.autoUpdate = autoUpdate;
+		this.boundsProvider = boundsProvider;
 
 		// dark tint can be enabled by options, otherwise is enable if at least one slot has tint black
-		this.darkTint = options?.darkTint === undefined
+		this.darkTint = darkTint === undefined
 			? this.skeleton.slots.some(slot => !!slot.data.setup.darkColor)
-			: options?.darkTint;
+			: darkTint;
 		if (this.darkTint) this.slotMeshFactory = () => new DarkSlotMesh();
-
-		this.boundsProvider = options.boundsProvider;
 	}
 
 	/** If {@link Spine.autoUpdate} is `false`, this method allows to update the AnimationState and the Skeleton with the given delta. */

--- a/spine-ts/spine-pixi-v7/src/Spine.ts
+++ b/spine-ts/spine-pixi-v7/src/Spine.ts
@@ -861,20 +861,14 @@ export class Spine extends Container {
 	public static readonly skeletonCache: Record<string, SkeletonData> = Object.create(null);
 
 	/**
-	 * Use this method to instantiate a Spine game object.
-	 * Before instantiating a Spine game object, the skeleton (`.skel` or `.json`) and the atlas text files must be loaded into the Assets. For example:
-	 * ```
-	 * PIXI.Assets.add("sackData", "/assets/sack-pro.skel");
-	 * PIXI.Assets.add("sackAtlas", "/assets/sack-pma.atlas");
-	 * await PIXI.Assets.load(["sackData", "sackAtlas"]);
-	 * ```
-	 * Once a Spine game object is created, its skeleton data is cached into {@link Spine.skeletonCache} using the key:
-	 * `${skeletonAssetName}-${atlasAssetName}-${options?.scale ?? 1}`
+	 * Prepares the initialization data for creating a Spine game object.
+	 * Handles skeleton data parsing and caching. If the skeleton data is already cached, returns the cached version.
+	 * Otherwise, loads and parses the skeleton and atlas assets, then caches the result.
 	 *
 	 * @param options - Options to configure the Spine game object. See {@link SpineFromOptions}
-	 * @returns {Spine} The Spine game object instantiated
+	 * @returns {SpineOptions} The initialization options object ready to be passed to the Spine constructor
 	 */
-	public static from ({ skeleton, atlas, scale = 1, darkTint, autoUpdate = true, boundsProvider, allowMissingRegions }: SpineFromOptions) {
+	public static getSpineInitData ({ skeleton, atlas, scale = 1, darkTint, autoUpdate = true, boundsProvider, allowMissingRegions }: SpineFromOptions): SpineOptions {
 		const cacheKey = `${skeleton}-${atlas}-${scale}`;
 
 		let skeletonData = Spine.skeletonCache[cacheKey];
@@ -888,7 +882,25 @@ export class Spine extends Container {
 			skeletonData = parser.readSkeletonData(skeletonAsset);
 			Spine.skeletonCache[cacheKey] = skeletonData;
 		}
-		return new Spine({ skeletonData, darkTint, autoUpdate, boundsProvider });
+		return { skeletonData, darkTint, autoUpdate, boundsProvider };
+	}
+
+	/**
+	 * Use this method to instantiate a Spine game object.
+	 * Before instantiating a Spine game object, the skeleton (`.skel` or `.json`) and the atlas text files must be loaded into the Assets. For example:
+	 * ```
+	 * PIXI.Assets.add("sackData", "/assets/sack-pro.skel");
+	 * PIXI.Assets.add("sackAtlas", "/assets/sack-pma.atlas");
+	 * await PIXI.Assets.load(["sackData", "sackAtlas"]);
+	 * ```
+	 * Once a Spine game object is created, its skeleton data is cached into {@link Spine.skeletonCache} using the key:
+	 * `${skeletonAssetName}-${atlasAssetName}-${options?.scale ?? 1}`
+	 *
+	 * @param options - Options to configure the Spine game object. See {@link SpineFromOptions}
+	 * @returns {Spine} The Spine game object instantiated
+	 */
+	public static from (options: SpineFromOptions) {
+		return new Spine(Spine.getSpineInitData(options));
 	}
 
 	public get tint (): number {

--- a/spine-ts/spine-pixi-v8/example/bounds.html
+++ b/spine-ts/spine-pixi-v8/example/bounds.html
@@ -29,21 +29,21 @@
         await PIXI.Assets.load(["spineboyData", "spineboyAtlas"]);
 
         // Create the spine display object
-        const spineboy1 = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2 });
+        const spineboy1 = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2 });
 
-        const spineboy2 = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
+        const spineboy2 = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
           boundsProvider: new spine.SetupPoseBoundsProvider(),
         });
 
-        const spineboy3 = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
+        const spineboy3 = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
           boundsProvider: new spine.SkinsAndAnimationBoundsProvider("portal", undefined, undefined, false),
         });
 
-        const spineboy4 = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
+        const spineboy4 = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
           boundsProvider: new spine.SkinsAndAnimationBoundsProvider("portal", undefined, undefined, true),
         });
 
-        const spineboy5 = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
+        const spineboy5 = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: .2,
           boundsProvider: new spine.AABBRectangleBoundsProvider(-100, -100, 100, 100),
         });
 

--- a/spine-ts/spine-pixi-v8/example/bunnymark.html
+++ b/spine-ts/spine-pixi-v8/example/bunnymark.html
@@ -98,7 +98,7 @@
         bounds;
 
         constructor(bounds) {
-            const spineboy = spine.Spine.from({
+            const spineboy = new spine.Spine({
                 atlas: "spineboyAtlas",
                 skeleton: "spineboyData",
                 scale: 0.125,

--- a/spine-ts/spine-pixi-v8/example/coin.html
+++ b/spine-ts/spine-pixi-v8/example/coin.html
@@ -30,7 +30,7 @@
         await PIXI.Assets.load(["spineboyData", "spineboyAtlas"]);
 
         // Create the spine display object
-        const spineboy = spine.Spine.from({
+        const spineboy = new spine.Spine({
           skeleton: "spineboyData",
           atlas: "spineboyAtlas",
           scale: 1,

--- a/spine-ts/spine-pixi-v8/example/control-bones-example.html
+++ b/spine-ts/spine-pixi-v8/example/control-bones-example.html
@@ -45,7 +45,7 @@
         await PIXI.Assets.load(["stretchymanData", "stretchymanAtlas"]);
 
         // Create the spine display object
-        const stretchyman = spine.Spine.from({skeleton: "stretchymanData", atlas: "stretchymanAtlas",
+        const stretchyman = new spine.Spine({skeleton: "stretchymanData", atlas: "stretchymanAtlas",
           scale: 0.75,
         });
 

--- a/spine-ts/spine-pixi-v8/example/dragon.html
+++ b/spine-ts/spine-pixi-v8/example/dragon.html
@@ -32,8 +32,8 @@
         await PIXI.Assets.load(["spineboyData", "spineboyAtlas", "spineboyData", "spineboyAtlas2"]);
 
         // Create the spine display object
-        const spineboy = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: 0.5 });
-        const spineboy2 = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: 0.5 });
+        const spineboy = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: 0.5 });
+        const spineboy2 = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: 0.5 });
         spineboy.autoUpdate = false;
         spineboy2.autoUpdate = false;
 

--- a/spine-ts/spine-pixi-v8/example/events-example.html
+++ b/spine-ts/spine-pixi-v8/example/events-example.html
@@ -39,7 +39,7 @@
         await PIXI.Assets.load(["spineboyData", "spineboyAtlas"]);
 
         // Create the Spine display object
-        const spineboy = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas",
+        const spineboy = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas",
           scale: 0.5,
         });
 

--- a/spine-ts/spine-pixi-v8/example/index.html
+++ b/spine-ts/spine-pixi-v8/example/index.html
@@ -28,7 +28,7 @@
         await PIXI.Assets.load(["spineboyData", "spineboyAtlas"]);
 
         // Create the spine display object
-        const spineboy = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas",
+        const spineboy = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas",
           scale: 0.5,
         });
 

--- a/spine-ts/spine-pixi-v8/example/inline-loading.html
+++ b/spine-ts/spine-pixi-v8/example/inline-loading.html
@@ -52,7 +52,7 @@
         await PIXI.Assets.load(["skelBase64", "atlasBase64"]);
 
         // creating spine game object with base64 data
-		    const base64GameObject = spine.Spine.from({skeleton: "skelBase64", atlas: "atlasBase64" });
+		    const base64GameObject = new spine.Spine({skeleton: "skelBase64", atlas: "atlasBase64" });
         app.stage.addChild(base64GameObject);
         base64GameObject.state.setAnimation(0, "animation", true);
         base64GameObject.position.set(window.innerWidth / 3, window.innerHeight / 2);
@@ -90,7 +90,7 @@
         await PIXI.Assets.load(["skelBlob", "atlasBlob"]);
 
         // creating spine game object
-        const blobGameObject = spine.Spine.from({skeleton: "skelBase64", atlas: "atlasBase64" });
+        const blobGameObject = new spine.Spine({skeleton: "skelBase64", atlas: "atlasBase64" });
         app.stage.addChild(blobGameObject);
         blobGameObject.state.setAnimation(0, "animation", true);
         blobGameObject.position.set(window.innerWidth / 3 * 2, window.innerHeight / 2);

--- a/spine-ts/spine-pixi-v8/example/mix-and-match-example.html
+++ b/spine-ts/spine-pixi-v8/example/mix-and-match-example.html
@@ -28,7 +28,7 @@
         await PIXI.Assets.load(["mixAndMatchData", "mixAndMatchAtlas"]);
 
         // Create the Spine display object
-        const mixAndMatch = spine.Spine.from({skeleton: "mixAndMatchData", atlas: "mixAndMatchAtlas",
+        const mixAndMatch = new spine.Spine({skeleton: "mixAndMatchData", atlas: "mixAndMatchAtlas",
           scale: 0.5,
         });
 

--- a/spine-ts/spine-pixi-v8/example/mouse-following.html
+++ b/spine-ts/spine-pixi-v8/example/mouse-following.html
@@ -28,7 +28,7 @@
                 await PIXI.Assets.load(["spineboyData", "spineboyAtlas"]);
 
                 // Create the spine display object
-                const spineboy = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas",
+                const spineboy = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas",
                     scale: 0.5,
                 });
 

--- a/spine-ts/spine-pixi-v8/example/physics.html
+++ b/spine-ts/spine-pixi-v8/example/physics.html
@@ -28,7 +28,7 @@
         await PIXI.Assets.load(["sackData", "sackAtlas"]);
 
         // Create the spine display object
-        const sack = spine.Spine.from({skeleton: "sackData", atlas: "sackAtlas",
+        const sack = new spine.Spine({skeleton: "sackData", atlas: "sackAtlas",
           scale: 0.2,
         });
 

--- a/spine-ts/spine-pixi-v8/example/physics2.html
+++ b/spine-ts/spine-pixi-v8/example/physics2.html
@@ -28,7 +28,7 @@
         await PIXI.Assets.load(["girlData", "girlAtlas"]);
 
         // Create the spine display object
-        const girl = spine.Spine.from({skeleton: "girlData", atlas: "girlAtlas",
+        const girl = new spine.Spine({skeleton: "girlData", atlas: "girlAtlas",
           scale: 0.2,
         });
 

--- a/spine-ts/spine-pixi-v8/example/physics3.html
+++ b/spine-ts/spine-pixi-v8/example/physics3.html
@@ -28,7 +28,7 @@
         await PIXI.Assets.load(["snowglobeData", "snowglobeAtlas"]);
 
         // Create the spine display object
-        const snowglobe = spine.Spine.from({skeleton: "snowglobeData", atlas: "snowglobeAtlas",
+        const snowglobe = new spine.Spine({skeleton: "snowglobeData", atlas: "snowglobeAtlas",
           scale: 0.25,
         });
 

--- a/spine-ts/spine-pixi-v8/example/physics4.html
+++ b/spine-ts/spine-pixi-v8/example/physics4.html
@@ -28,7 +28,7 @@
         await PIXI.Assets.load(["cloudPotData", "cloudPotAtlas"]);
 
         // Create the spine display object
-        const cloudPot = spine.Spine.from({skeleton: "cloudPotData", atlas: "cloudPotAtlas",
+        const cloudPot = new spine.Spine({skeleton: "cloudPotData", atlas: "cloudPotAtlas",
           scale: 0.25,
         });
 

--- a/spine-ts/spine-pixi-v8/example/simple-input.html
+++ b/spine-ts/spine-pixi-v8/example/simple-input.html
@@ -28,7 +28,7 @@
         await PIXI.Assets.load(["spineboyData", "spineboyAtlas"]);
 
         // Create the spine display object
-        const spineboy = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas",
+        const spineboy = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas",
           scale: 0.5,
         });
 

--- a/spine-ts/spine-pixi-v8/example/slot-objects-scale-rotation.html
+++ b/spine-ts/spine-pixi-v8/example/slot-objects-scale-rotation.html
@@ -35,7 +35,7 @@
         PIXI.Assets.cache.set("spineboyAtlas", textureAtlas);
 
         // creating spine game object
-        const spineGO = spine.Spine.from({skeleton: "jsonSkel", atlas: "spineboyAtlas" });
+        const spineGO = new spine.Spine({ skeleton: "jsonSkel", atlas: "spineboyAtlas" });
         spineGO.position.set(300, 300);
         app.stage.addChild(spineGO);
 

--- a/spine-ts/spine-pixi-v8/example/slot-objects.html
+++ b/spine-ts/spine-pixi-v8/example/slot-objects.html
@@ -29,7 +29,7 @@
         await PIXI.Assets.load(["spineboyData", "spineboyAtlas", "raptor_jaw"]);
 
         // Create the spine display object
-        const spineboy = spine.Spine.from({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: 0.25 });
+        const spineboy = new spine.Spine({skeleton: "spineboyData", atlas: "spineboyAtlas", scale: 0.25 });
 
         // Set the default mix time to use when transitioning
         // from one animation to the next.

--- a/spine-ts/spine-pixi-v8/example/typescript/index.ts
+++ b/spine-ts/spine-pixi-v8/example/typescript/index.ts
@@ -1,5 +1,5 @@
-import { Application, Assets } from 'pixi.js';
 import { Spine } from '@esotericsoftware/spine-pixi-v8';
+import { Application, Assets } from 'pixi.js';
 
 /** The PixiJS app Application instance, shared across the project */
 export const app = new Application();
@@ -25,7 +25,7 @@ async function init () {
 	await Assets.load(["spineboyData", "spineboyAtlas"]);
 
 	// Create the spine display object
-	const spineboy = Spine.from({
+	const spineboy = new Spine({
 		atlas: "spineboyAtlas",
 		skeleton: "spineboyData",
 		scale: 0.5,

--- a/spine-ts/spine-pixi-v8/src/Spine.ts
+++ b/spine-ts/spine-pixi-v8/src/Spine.ts
@@ -292,7 +292,8 @@ const maskPool = new Pool<Graphics>(() => new Graphics);
 
 /**
  * The class to instantiate a {@link Spine} game object in Pixi.
- * The static method {@link Spine.from} should be used to instantiate a Spine game object.
+ * Create and customize the default configuration using the static method {@link Spine.createOptions},
+ * then pass it to the constructor.
  */
 export class Spine extends ViewContainer {
 	// Pixi properties
@@ -384,14 +385,11 @@ export class Spine extends ViewContainer {
 	}
 
 	private hasNeverUpdated = true;
-	constructor (options: SpineOptions | SkeletonData) {
-		if (options instanceof SkeletonData) {
-			options = {
-				skeletonData: options,
-			};
-		}
-
+	constructor (options: SpineOptions | SpineFromOptions) {
 		super({});
+
+		if ("skeleton" in options)
+			options = new.target.createOptions(options);
 
 		this.allowChildren = true;
 
@@ -1065,14 +1063,20 @@ export class Spine extends ViewContainer {
 	}
 
 	/**
-	 * Prepares the initialization data for creating a Spine game object.
-	 * Handles skeleton data parsing and caching. If the skeleton data is already cached, returns the cached version.
-	 * Otherwise, loads and parses the skeleton and atlas assets, then caches the result.
+	 * Get a convenient initialization configuration for your Spine game object.
+	 * Before instantiating a Spine game object, the skeleton (`.skel` or `.json`) and the atlas text files must be loaded into the {@link Assets}. For example:
+	 * ```
+	 * PIXI.Assets.add("sackData", "/assets/sack-pro.skel");
+	 * PIXI.Assets.add("sackAtlas", "/assets/sack-pma.atlas");
+	 * await PIXI.Assets.load(["sackData", "sackAtlas"]);
+	 * ```
+	 * Once a Spine game object is created, its skeleton data is cached into {@link Cache} using the key:
+	 * `${skeletonAssetName}-${atlasAssetName}-${options?.scale ?? 1}`
 	 *
 	 * @param options - Options to configure the Spine game object. See {@link SpineFromOptions}
-	 * @returns {SpineOptions} The initialization options object ready to be passed to the Spine constructor
+	 * @returns {SpineOptions} The configuration ready to be passed to the Spine constructor
 	 */
-	static getSpineInitData ({ skeleton, atlas, scale = 1, darkTint, autoUpdate = true, boundsProvider, allowMissingRegions = false }: SpineFromOptions): SpineOptions {
+	static createOptions ({ skeleton, atlas, scale = 1, darkTint, autoUpdate = true, boundsProvider, allowMissingRegions = false }: SpineFromOptions): SpineOptions {
 		const cacheKey = `${skeleton}-${atlas}-${scale}`;
 
 		if (Cache.has(cacheKey)) {
@@ -1084,10 +1088,11 @@ export class Spine extends ViewContainer {
 			};
 		}
 
-		const skeletonAsset = Assets.get<any | Uint8Array>(skeleton);
-
 		const atlasAsset = Assets.get<TextureAtlas>(atlas);
 		const attachmentLoader = new AtlasAttachmentLoader(atlasAsset, allowMissingRegions);
+
+		// biome-ignore lint/suspicious/noExplicitAny: json skeleton data is any
+		const skeletonAsset = Assets.get<any | Uint8Array>(skeleton);
 		const parser = skeletonAsset instanceof Uint8Array
 			? new SkeletonBinary(attachmentLoader)
 			: new SkeletonJson(attachmentLoader);
@@ -1106,6 +1111,7 @@ export class Spine extends ViewContainer {
 	}
 
 	/**
+	 * @deprecated Use directly the Spine constructor or {@link createOptions} to make options and customize it to pass to the constructor
 	 * Use this method to instantiate a Spine game object.
 	 * Before instantiating a Spine game object, the skeleton (`.skel` or `.json`) and the atlas text files must be loaded into the Assets. For example:
 	 * ```
@@ -1120,6 +1126,6 @@ export class Spine extends ViewContainer {
 	 * @returns {Spine} The Spine game object instantiated
 	 */
 	static from (options: SpineFromOptions) {
-		return new Spine(Spine.getSpineInitData(options));
+		return new Spine(Spine.createOptions(options));
 	}
 }

--- a/spine-ts/spine-pixi-v8/src/Spine.ts
+++ b/spine-ts/spine-pixi-v8/src/Spine.ts
@@ -43,7 +43,7 @@ import {
 	SkeletonBinary,
 	SkeletonBounds,
 	SkeletonClipping,
-	SkeletonData,
+	type SkeletonData,
 	SkeletonJson,
 	Skin,
 	type Slot,
@@ -393,24 +393,20 @@ export class Spine extends ViewContainer {
 
 		this.allowChildren = true;
 
-		const skeletonData = options instanceof SkeletonData ? options : options.skeletonData;
-
+		const { autoUpdate, boundsProvider, darkTint, skeletonData } = options;
 		this.skeleton = new Skeleton(skeletonData);
 		this.state = new AnimationState(new AnimationStateData(skeletonData));
-		this.autoUpdate = options?.autoUpdate ?? true;
+		this.autoUpdate = autoUpdate ?? true;
+		this._boundsProvider = boundsProvider;
 
 		// dark tint can be enabled by options, otherwise is enable if at least one slot has tint black
-		this.darkTint = options?.darkTint === undefined
+		this.darkTint = darkTint === undefined
 			? this.skeleton.slots.some(slot => !!slot.data.setup.darkColor)
-			: options?.darkTint;
+			: darkTint;
 
 		const slots = this.skeleton.slots;
-
-		for (let i = 0; i < slots.length; i++) {
+		for (let i = 0; i < slots.length; i++)
 			this.attachmentCacheData[i] = Object.create(null);
-		}
-
-		this._boundsProvider = options.boundsProvider;
 	}
 
 	/** If {@link Spine.autoUpdate} is `false`, this method allows to update the AnimationState and the Skeleton with the given delta. */

--- a/spine-ts/spine-pixi-v8/src/Spine.ts
+++ b/spine-ts/spine-pixi-v8/src/Spine.ts
@@ -1065,29 +1065,23 @@ export class Spine extends ViewContainer {
 	}
 
 	/**
-	 * Use this method to instantiate a Spine game object.
-	 * Before instantiating a Spine game object, the skeleton (`.skel` or `.json`) and the atlas text files must be loaded into the Assets. For example:
-	 * ```
-	 * PIXI.Assets.add("sackData", "/assets/sack-pro.skel");
-	 * PIXI.Assets.add("sackAtlas", "/assets/sack-pma.atlas");
-	 * await PIXI.Assets.load(["sackData", "sackAtlas"]);
-	 * ```
-	 * Once a Spine game object is created, its skeleton data is cached into {@link Cache} using the key:
-	 * `${skeletonAssetName}-${atlasAssetName}-${options?.scale ?? 1}`
+	 * Prepares the initialization data for creating a Spine game object.
+	 * Handles skeleton data parsing and caching. If the skeleton data is already cached, returns the cached version.
+	 * Otherwise, loads and parses the skeleton and atlas assets, then caches the result.
 	 *
 	 * @param options - Options to configure the Spine game object. See {@link SpineFromOptions}
-	 * @returns {Spine} The Spine game object instantiated
+	 * @returns {SpineOptions} The initialization options object ready to be passed to the Spine constructor
 	 */
-	static from ({ skeleton, atlas, scale = 1, darkTint, autoUpdate = true, boundsProvider, allowMissingRegions = false }: SpineFromOptions) {
+	static getSpineInitData ({ skeleton, atlas, scale = 1, darkTint, autoUpdate = true, boundsProvider, allowMissingRegions = false }: SpineFromOptions): SpineOptions {
 		const cacheKey = `${skeleton}-${atlas}-${scale}`;
 
 		if (Cache.has(cacheKey)) {
-			return new Spine({
+			return {
 				skeletonData: Cache.get<SkeletonData>(cacheKey),
 				darkTint,
 				autoUpdate,
 				boundsProvider,
-			});
+			};
 		}
 
 		const skeletonAsset = Assets.get<any | Uint8Array>(skeleton);
@@ -1103,11 +1097,29 @@ export class Spine extends ViewContainer {
 
 		Cache.set(cacheKey, skeletonData);
 
-		return new Spine({
+		return {
 			skeletonData,
 			darkTint,
 			autoUpdate,
 			boundsProvider,
-		});
+		};
+	}
+
+	/**
+	 * Use this method to instantiate a Spine game object.
+	 * Before instantiating a Spine game object, the skeleton (`.skel` or `.json`) and the atlas text files must be loaded into the Assets. For example:
+	 * ```
+	 * PIXI.Assets.add("sackData", "/assets/sack-pro.skel");
+	 * PIXI.Assets.add("sackAtlas", "/assets/sack-pma.atlas");
+	 * await PIXI.Assets.load(["sackData", "sackAtlas"]);
+	 * ```
+	 * Once a Spine game object is created, its skeleton data is cached into {@link Cache} using the key:
+	 * `${skeletonAssetName}-${atlasAssetName}-${options?.scale ?? 1}`
+	 *
+	 * @param options - Options to configure the Spine game object. See {@link SpineFromOptions}
+	 * @returns {Spine} The Spine game object instantiated
+	 */
+	static from (options: SpineFromOptions) {
+		return new Spine(Spine.getSpineInitData(options));
 	}
 }


### PR DESCRIPTION
Previously, the `from` method handled both data preparation and instance creation. This made it difficult to extend the `Spine` class or reuse its initialization logic.
With this change, all data preparation (asset loading, parsing, and caching) is now handled inside `getSpineInitData`, while `from` only creates a new instance using the returned data.

* [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).
