### PR TITLE
[ts][phaser-v3] fix atlas page url duplication when using file:// + baseURL

### DIFF
--- a/spine-ts/spine-phaser-v3/src/SpinePlugin.ts
+++ b/spine-ts/spine-phaser-v3/src/SpinePlugin.ts
@@ -374,7 +374,9 @@ class SpineAtlasFile extends Phaser.Loader.MultiFile {
 					}
 				}
 
-				let basePath = (file.url.match(/^.*\//) ?? "").toString();
+				let fileUrl = file.url;
+				if (typeof fileUrl === "object") fileUrl = file.src;
+				let basePath = (fileUrl.match(/^.*\//) ?? "").toString();
 				if (this.loader.path && this.loader.path.length > 0 && basePath.startsWith(this.loader.path))
 					basePath = basePath.slice(this.loader.path.length);
 

--- a/spine-ts/spine-phaser-v3/src/SpinePlugin.ts
+++ b/spine-ts/spine-phaser-v3/src/SpinePlugin.ts
@@ -374,7 +374,7 @@ class SpineAtlasFile extends Phaser.Loader.MultiFile {
 					}
 				}
 
-				let basePath = (file.src.match(/^.*\//) ?? "").toString();
+				let basePath = (file.url.match(/^.*\//) ?? "").toString();
 				if (this.loader.path && this.loader.path.length > 0 && basePath.startsWith(this.loader.path))
 					basePath = basePath.slice(this.loader.path.length);
 

--- a/spine-ts/spine-phaser-v4/src/SpinePlugin.ts
+++ b/spine-ts/spine-phaser-v4/src/SpinePlugin.ts
@@ -366,7 +366,9 @@ class SpineAtlasFile extends Phaser.Loader.MultiFile {
 					}
 				}
 
-				let basePath = (file.src.match(/^.*\//) ?? "").toString();
+				let fileUrl = file.url;
+				if (typeof fileUrl === "object") fileUrl = file.src;
+				let basePath = (fileUrl.match(/^.*\//) ?? "").toString();
 				if (this.loader.path && this.loader.path.length > 0 && basePath.startsWith(this.loader.path))
 					basePath = basePath.slice(this.loader.path.length);
 


### PR DESCRIPTION
#### 🧩 Summary
When loading Spine atlases under the **`file://` protocol** with a `baseURL` set, atlas page PNGs still produce double-prefixed URLs like:

```
file:///Users/.../spine--demo.../file:///Users/.../assets/spine/spineboy-pma.png
```

All other assets load correctly — only Spine atlas **page images** (`.png` listed in the `.atlas` file) are affected.

This happens because the plugin uses `file.src` to determine the atlas base directory. In this case `file.src` already includes the `baseURL`, so the loader prepends `baseURL` again.

---

#### 🧠 Relation to Phaser issue [#6642](https://github.com/phaserjs/phaser/issues/6642)
Phaser core loader fixed the same issue in [#6642](https://github.com/phaserjs/phaser/issues/6642), replacing `file.src` with `file.url` inside `GetURL()` to avoid double baseURL concatenation.

However, this Spine plugin (`spine-phaser-v3`) still uses `file.src` in `onFileComplete()`, so the duplication persists when running under `file://` with `setBaseURL()`.

---

#### 🧾 Changes
```diff
// src/SpinePlugin.ts (method onFileComplete)

- let basePath = (file.src.match(/^.*\//) ?? "").toString();
+ let basePath = (file.url.match(/^.*\//) ?? "").toString();
```

This aligns the plugin with the Phaser core fix from #6642 and ensures consistent behavior across protocols.

---

#### ✅ Results

| Environment       | Case                         | `file.url`                                  | `file.src`                                          | Outcome |
|-------------------|------------------------------|---------------------------------------------|-----------------------------------------------------|---------|
| HTTP / HTTPS      | Any asset                    | `assets/bg.png`                             | `http://localhost/.../assets/bg.png`                | ✅ OK   |
| `file://` (before)| Spine atlas page `.png`      | `file:///Users/.../assets/spineboy-pma.png` | `file:///base/file:///Users/.../spineboy-pma.png`   | ❌ BAD  |
| `file://` (after) | Spine atlas page `.png`      | `file:///Users/.../assets/spineboy-pma.png` | `file:///Users/.../assets/spineboy-pma.png`         | ✅ OK   |

---


#### 📝 Notes
- No impact on HTTP(S) or other environments.
- Fixes `file:// + baseURL` compatibility for atlas page PNGs.
- Brings plugin behavior in line with Phaser core loader fix (#6642).
- Verified on Phaser 3.90.0, macOS + Chrome.

---

* [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).
