### PR TITLE
[unity] Fix SkeletonSubmeshGraphic issue with multiple Graphics compo…

### DIFF
--- a/spine-unity/Assets/Spine/Runtime/spine-unity/Components/Internal/SkeletonSubmeshGraphic.cs
+++ b/spine-unity/Assets/Spine/Runtime/spine-unity/Components/Internal/SkeletonSubmeshGraphic.cs
@@ -27,7 +27,9 @@
  * THE SPINE RUNTIMES, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
+using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Pool;
 using UnityEngine.UI;
 
 namespace Spine.Unity {
@@ -52,6 +54,17 @@ namespace Spine.Unity {
 		protected override void OnEnable () {
 			base.OnEnable();
 			this.canvasRenderer.cull = false;
+		}
+
+		public Material UpdateModifiedMaterial (Material baseMaterial) {
+			List<IMaterialModifier> components = ListPool<IMaterialModifier>.Get();
+			GetComponents<IMaterialModifier>(components);
+
+			Material currentMat = baseMaterial;
+			for (var i = 0; i < components.Count; i++)
+				currentMat = (components[i] as IMaterialModifier).GetModifiedMaterial(currentMat);
+			ListPool<IMaterialModifier>.Release(components);
+			return currentMat;
 		}
 	}
 }

--- a/spine-unity/Assets/Spine/Runtime/spine-unity/Components/SkeletonGraphic.cs
+++ b/spine-unity/Assets/Spine/Runtime/spine-unity/Components/SkeletonGraphic.cs
@@ -1024,7 +1024,7 @@ namespace Spine.Unity {
 							usedMaterial = multiplyMaterial;
 						else if (blendMode == BlendMode.Screen && screenMaterial)
 							usedMaterial = screenMaterial;
-						usedMaterialItems[i] = submeshGraphics[i].GetModifiedMaterial(usedMaterial);
+						usedMaterialItems[i] = submeshGraphics[i].UpdateModifiedMaterial(usedMaterial);
 					}
 				} else {
 					Texture originalTexture = submeshMaterial.mainTexture;
@@ -1035,7 +1035,7 @@ namespace Spine.Unity {
 					if (!customTextureOverride.TryGetValue(originalTexture, out usedTexture))
 						usedTexture = originalTexture;
 
-					usedMaterialItems[i] = submeshGraphics[i].GetModifiedMaterial(usedMaterial);
+					usedMaterialItems[i] = submeshGraphics[i].UpdateModifiedMaterial(usedMaterial);
 					usedTextureItems[i] = usedTexture;
 				}
 			}


### PR DESCRIPTION
…nents

**Environment**  

- Unity 6000.2.6f2  
- spine-csharp Runtime 4.2.97  
- spine-unity Runtime 4.2.110  

I'm using the [SoftMask](https://github.com/mob-sakai/SoftMaskForUGUI) plugin, which enables SoftMask support for UI.  
In general, SoftMask works fine with `SkeletonGraphic`.  
However, when `SkeletonGraphic` uses *Multiple CanvasRenderers*, SoftMask stops working and falls back to a regular mask.  

By modifying the material update logic in [`SkeletonGraphic.UpdateMaterialsMultipleCanvasRenderers`](https://github.com/EsotericSoftware/spine-runtimes/blob/95ff960cf5e597d8910dcdde4799858759c7040c/spine-unity/Assets/Spine/Runtime/spine-unity/Components/SkeletonGraphic.cs#L996C1-L997C1) as shown in this PR, the issue is resolved and SoftMask now works correctly.  

<img width="1120" height="365" alt="image" src="https://github.com/user-attachments/assets/795464eb-36e0-41c5-9f51-0a52358fa0dd" />
 
The newly added function in `SkeletonSubmeshGraphic.cs` follows the exact implementation of Unity’s [Graphic.materialForRendering](https://docs.unity3d.com/ja/2018.4/ScriptReference/UI.Graphic-materialForRendering.html) property.

Attached below are videos comparing the behavior before and after the fix, as well as the reproduction project used for testing.  

- **Before** – [main branch](https://github.com/sr4dev/Spine-MultipleCanvasRenderersWithSoftMaskIssue)  
  <div><video controls src="https://github.com/user-attachments/assets/941fe640-ee6b-4fa4-8615-fca943159ec5" muted="false"></video></div>  

- **After** – [fixed branch](https://github.com/sr4dev/Spine-MultipleCanvasRenderersWithSoftMaskIssue/tree/fixed)  
  <div><video controls src="https://github.com/user-attachments/assets/81fc6f17-a772-4196-b23a-e16229b27c97" muted="false"></video></div>  

If there are no concerns with this change, please consider approving the PR.  

* [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).  

I've already submitted the CLA via email previously.  
Please refer to the following discussion for confirmation:  
https://ja.esotericsoftware.com/forum/d/11476-unity-nested-prefab-overrides/9
