### PR TITLE
[iOS][4.3-beta] move `SpineiOS` target behind `SpineiOSWrapper`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,10 +25,17 @@ let package = Package(
         ),
         .library(
             name: "SpineiOS",
-            targets: ["SpineiOS"]
+            targets: ["SpineiOSWrapper"]
         ),
     ],
     targets: [
+        .target(
+            name: "SpineiOSWrapper",
+            dependencies: [
+                .target(name: "SpineiOS", condition: .when(platforms: [.iOS, .visionOS, .tvOS, .macCatalyst ]))
+            ],
+            path: "spine-ios/Sources/SpineiOSWrapper"
+        ),
         .target(
             name: "SpineiOS",
             dependencies: [

--- a/spine-ios/Sources/SpineiOSWrapper/stub.swift
+++ b/spine-ios/Sources/SpineiOSWrapper/stub.swift
@@ -1,0 +1,7 @@
+//
+//  stub.swift
+//  spine-ios
+//
+//  Created by pbk20191 on 11/7/25.
+//
+


### PR DESCRIPTION

* [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).

There is no good way to conditionally add Swift package Product in single project Target  (Multiplatform Target). 


previous 4.2 does not falls to build failure when building Multiplatform Target even if Spine is not supported (macOS)
It is just gated `SpineModule` https://github.com/EsotericSoftware/spine-runtimes/blob/4.2/Package.swift#L24-L37

which drops actual module `Spine`. So there is no issue.

But for 4.3 beta gating module is gone, and now it is not possible to build Multiplatform Target, since xcode always tries to compile spine where it is not supported (like trying to compile SpineiOS for macOS instead of just dropping the target, even if the user guarded with macro)

So I added the gating module again to fix this problem