### PR TITLE
[ios] backport from 4.3-beta: expose explict module for c & cpp

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,10 @@ let package = Package(
         .library(
             name: "Spine",
             targets: ["SpineModule"]
+        ),
+        .library(
+            name: "SpineCppLite",
+            targets: ["SpineCppLite"]
         )
     ],
     targets: [

--- a/spine-ios/Sources/SpineCppLite/include/module.modulemap
+++ b/spine-ios/Sources/SpineCppLite/include/module.modulemap
@@ -1,4 +1,13 @@
 module SpineCppLite {
-    header "spine-cpp-lite.h"
-    export *
+    use c
+    export c
+    explicit module cpp {
+        umbrella header "spine/spine.h"
+        requires cplusplus11
+        export *
+    }
+    explicit module c {
+        header "spine-cpp-lite.h"
+        export *
+    }
 }


### PR DESCRIPTION
- this is the backport version of  #2906 to spine-4.2
- In addition, expose spine-cpp module directly like spine 4.3-beta
- standard user can import spine-c based api as usual
- dedicated swift/cpp user can import cpp interface with explict import and enabling cpp interp
- objective-c user can import cpp using objective-c++

* [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).

