### PR TITLE
[cpp] fix RGB2Timeline Applying wrong bezierValue

### DIFF
--- a/spine-cpp/spine-cpp/src/spine/ColorTimeline.cpp
+++ b/spine-cpp/spine-cpp/src/spine/ColorTimeline.cpp
@@ -458,11 +458,11 @@ void RGB2Timeline::apply(Skeleton &skeleton, float lastTime, float time, Vector<
 			b = getBezierValue(time, i, RGB2Timeline::B,
 							   curveType + RGB2Timeline::BEZIER_SIZE * 2 - RGB2Timeline::BEZIER);
 			r2 = getBezierValue(time, i, RGB2Timeline::R2,
-								curveType + RGB2Timeline::BEZIER_SIZE * 4 - RGB2Timeline::BEZIER);
+								curveType + RGB2Timeline::BEZIER_SIZE * 3 - RGB2Timeline::BEZIER);
 			g2 = getBezierValue(time, i, RGB2Timeline::G2,
-								curveType + RGB2Timeline::BEZIER_SIZE * 5 - RGB2Timeline::BEZIER);
+								curveType + RGB2Timeline::BEZIER_SIZE * 4 - RGB2Timeline::BEZIER);
 			b2 = getBezierValue(time, i, RGB2Timeline::B2,
-								curveType + RGB2Timeline::BEZIER_SIZE * 6 - RGB2Timeline::BEZIER);
+								curveType + RGB2Timeline::BEZIER_SIZE * 5 - RGB2Timeline::BEZIER);
 		}
 	}
 	Color &light = slot->_color, &dark = slot->_darkColor;


### PR DESCRIPTION
Releated Issue: #2886

It looks like someone just copy and pasted RGBA2Timeline implementation to RGB2Timeline apply implementation. In SkeletonBinary/Json parser assign r2, g2, b2 bezier value to 3, 4, 5 while current implementation is reading r2, g2, b2 from 4, 5, 6 see
 SkeletonBinary.cpp line 1034 ~ 1037
 https://github.com/EsotericSoftware/spine-runtimes/blob/4.2/spine-cpp/spine-cpp/src/spine/SkeletonBinary.cpp#L1035-L1037
 
 SkeletonJson.cpp line 1088 ~ 1090
https://github.com/EsotericSoftware/spine-runtimes/blob/4.2/spine-cpp/spine-cpp/src/spine/SkeletonBinary.cpp#L1035-L1037

* [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).
