### PR TITLE
[godot] Make spine-runtime branch 4.2 compatible with godot version 4.5.1-stable.

### DIFF
--- a/spine-godot/spine_godot/SpineAnimation.cpp
+++ b/spine-godot/spine_godot/SpineAnimation.cpp
@@ -48,7 +48,7 @@ void SpineAnimation::_bind_methods() {
 String SpineAnimation::get_name() {
 	SPINE_CHECK(get_spine_object(), "")
 	String name;
-	name.parse_utf8(get_spine_object()->getName().buffer());
+	name = String::utf8(get_spine_object()->getName().buffer());
 	return name;
 }
 

--- a/spine-godot/spine_godot/SpineAnimationTrack.cpp
+++ b/spine-godot/spine_godot/SpineAnimationTrack.cpp
@@ -40,8 +40,8 @@
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_node.h"
-#include "editor/plugins/animation_player_editor_plugin.h"
-#include "editor/plugins/animation_tree_editor_plugin.h"
+#include "editor/animation/animation_player_editor_plugin.h"
+#include "editor/animation/animation_tree_editor_plugin.h"
 #endif
 
 void SpineAnimationTrack::_bind_methods() {
@@ -251,7 +251,7 @@ Ref<Animation> SpineAnimationTrack::create_animation(spine::Animation *animation
 	Ref<Animation> animation_ref;
 	INSTANTIATE(animation_ref);
 	String name;
-	name.parse_utf8(animation->getName().buffer());
+	name = String::utf8(animation->getName().buffer());
 	animation_ref->set_name(name + (loop ? "" : "_looped"));
 #if VERSION_MAJOR > 3
 	// animation_ref->set_loop(!loop);
@@ -301,7 +301,7 @@ void SpineAnimationTrack::update_animation_state(const Variant &variant_sprite) 
 			auto current_entry = animation_state->getCurrent(track_index);
 			bool should_set_mix = mix_duration >= 0;
 			String other_name;
-			if (current_entry) other_name.parse_utf8(current_entry->getAnimation()->getName().buffer());
+			if (current_entry) other_name = String::utf8(current_entry->getAnimation()->getName().buffer());
 			bool should_set_animation = !current_entry || (animation_name != other_name || current_entry->getLoop() != loop);
 
 			if (should_set_animation) {
@@ -428,7 +428,7 @@ void SpineAnimationTrack::update_animation_state(const Variant &variant_sprite) 
 			auto current_entry = animation_state->getCurrent(track_index);
 			bool should_set_mix = mix_duration >= 0;
 			String other_name;
-			if (current_entry) other_name.parse_utf8(current_entry->getAnimation()->getName().buffer());
+			if (current_entry) other_name = String::utf8(current_entry->getAnimation()->getName().buffer());
 			bool should_set_animation = !current_entry || (animation_name != other_name || current_entry->getLoop() != loop) || animation_changed;
 			animation_changed = false;
 

--- a/spine-godot/spine_godot/SpineAtlasResource.cpp
+++ b/spine-godot/spine_godot/SpineAtlasResource.cpp
@@ -51,7 +51,7 @@
 #ifdef SPINE_GODOT_EXTENSION
 #include <godot_cpp/classes/editor_file_system.hpp>
 #else
-#include "editor/editor_file_system.h"
+#include "editor/file_system/editor_file_system.h"
 #endif
 #endif
 
@@ -143,7 +143,7 @@ public:
 
 	void load(spine::AtlasPage &page, const spine::String &path) override {
 		String fixed_path;
-		fixed_path.parse_utf8(path.buffer());
+		fixed_path = String::utf8(path.buffer());
 		bool is_resource = fix_path(fixed_path);
 
 		import_image_resource(fixed_path);
@@ -292,7 +292,7 @@ Error SpineAtlasResource::load_from_atlas_file_internal(const String &path, bool
 	clear();
 	texture_loader = new GodotSpineTextureLoader(&textures, &normal_maps, &specular_maps, normal_map_prefix, specular_map_prefix, is_importing);
 	auto atlas_utf8 = atlas_data.utf8();
-	atlas = new spine::Atlas(atlas_utf8, atlas_utf8.length(), source_path.get_base_dir().utf8(), texture_loader);
+	atlas = new spine::Atlas(atlas_utf8.get_data(), atlas_utf8.length(), source_path.get_base_dir().utf8().get_data(), texture_loader);
 	if (atlas) return OK;
 
 	clear();
@@ -335,7 +335,7 @@ Error SpineAtlasResource::load_from_file(const String &path) {
 	clear();
 	texture_loader = new GodotSpineTextureLoader(&textures, &normal_maps, &specular_maps, normal_map_prefix, specular_map_prefix, false);
 	auto utf8 = atlas_data.utf8();
-	atlas = new spine::Atlas(utf8.ptr(), utf8.size(), source_path.get_base_dir().utf8(), texture_loader);
+	atlas = new spine::Atlas(utf8.ptr(), utf8.size(), source_path.get_base_dir().utf8().get_data(), texture_loader);
 	if (atlas) return OK;
 
 	clear();

--- a/spine-godot/spine_godot/SpineAttachment.cpp
+++ b/spine-godot/spine_godot/SpineAttachment.cpp
@@ -42,7 +42,7 @@ SpineAttachment::~SpineAttachment() {
 String SpineAttachment::get_attachment_name() {
 	SPINE_CHECK(get_spine_object(), "")
 	String name;
-	name.parse_utf8(get_spine_object()->getName().buffer());
+	name = String::utf8(get_spine_object()->getName().buffer());
 	return name;
 }
 

--- a/spine-godot/spine_godot/SpineBoneData.cpp
+++ b/spine-godot/spine_godot/SpineBoneData.cpp
@@ -69,7 +69,7 @@ int SpineBoneData::get_index() {
 String SpineBoneData::get_bone_name() {
 	SPINE_CHECK(get_spine_object(), "")
 	String name;
-	name.parse_utf8(get_spine_object()->getName().buffer());
+	name = String::utf8(get_spine_object()->getName().buffer());
 	return name;
 }
 

--- a/spine-godot/spine_godot/SpineCommon.h
+++ b/spine-godot/spine_godot/SpineCommon.h
@@ -96,8 +96,8 @@ using namespace godot;
 		return ret;                                \
 	}
 
-#define SPINE_STRING(x) spine::String((x).utf8())
-#define SPINE_STRING_TMP(x) spine::String((x).utf8(), true, false)
+#define SPINE_STRING(x) spine::String((x).utf8().get_data())
+#define SPINE_STRING_TMP(x) spine::String((x).utf8().get_data(), true, false)
 
 // Can't do template classes with Godot's object model :(
 class SpineObjectWrapper : public REFCOUNTED {

--- a/spine-godot/spine_godot/SpineConstraintData.cpp
+++ b/spine-godot/spine_godot/SpineConstraintData.cpp
@@ -42,7 +42,7 @@ void SpineConstraintData::_bind_methods() {
 String SpineConstraintData::get_constraint_name() {
 	SPINE_CHECK(get_spine_object(), "")
 	String name;
-	name.parse_utf8(get_spine_object()->getName().buffer());
+	name = String::utf8(get_spine_object()->getName().buffer());
 	return name;
 }
 

--- a/spine-godot/spine_godot/SpineEditorPlugin.h
+++ b/spine-godot/spine_godot/SpineEditorPlugin.h
@@ -44,8 +44,8 @@
 #include <godot_cpp/classes/editor_property.hpp>
 #else
 #include "editor/editor_node.h"
-#include "editor/editor_properties.h"
-#include "editor/editor_properties_array_dict.h"
+#include "editor/inspector/editor_properties.h"
+#include "editor/inspector/editor_properties_array_dict.h"
 #endif
 
 class SpineAtlasResourceImportPlugin : public EditorImportPlugin {

--- a/spine-godot/spine_godot/SpineEvent.cpp
+++ b/spine-godot/spine_godot/SpineEvent.cpp
@@ -85,7 +85,7 @@ String SpineEvent::get_string_value() {
 
 void SpineEvent::set_string_value(const String &v) {
 	SPINE_CHECK(get_spine_object(), )
-	get_spine_object()->setStringValue(spine::String(v.utf8()));
+	get_spine_object()->setStringValue(spine::String(v.utf8().get_data()));
 }
 
 float SpineEvent::get_volume() {

--- a/spine-godot/spine_godot/SpineEventData.cpp
+++ b/spine-godot/spine_godot/SpineEventData.cpp
@@ -49,7 +49,7 @@ void SpineEventData::_bind_methods() {
 String SpineEventData::get_event_name() {
 	SPINE_CHECK(get_spine_object(), "")
 	String name;
-	name.parse_utf8(get_spine_object()->getName().buffer());
+	name = String::utf8(get_spine_object()->getName().buffer());
 	return name;
 }
 
@@ -80,7 +80,7 @@ String SpineEventData::get_string_value() {
 
 void SpineEventData::set_string_value(const String &v) {
 	SPINE_CHECK(get_spine_object(), )
-	get_spine_object()->setStringValue(spine::String(v.utf8()));
+	get_spine_object()->setStringValue(spine::String(v.utf8().get_data()));
 }
 
 String SpineEventData::get_audio_path() {
@@ -90,7 +90,7 @@ String SpineEventData::get_audio_path() {
 
 void SpineEventData::set_audio_path(const String &v) {
 	SPINE_CHECK(get_spine_object(), )
-	get_spine_object()->setAudioPath(spine::String(v.utf8()));
+	get_spine_object()->setAudioPath(spine::String(v.utf8().get_data()));
 }
 
 float SpineEventData::get_volume() {

--- a/spine-godot/spine_godot/SpineSkeletonDataResource.cpp
+++ b/spine-godot/spine_godot/SpineSkeletonDataResource.cpp
@@ -48,7 +48,7 @@
 #ifdef SPINE_GODOT_EXTENSION
 #include <godot_cpp/classes/editor_file_system.hpp>
 #else
-#include "editor/editor_file_system.h"
+#include "editor/file_system/editor_file_system.h"
 #endif
 #endif
 
@@ -335,7 +335,7 @@ void SpineSkeletonDataResource::load_resources(spine::Atlas *atlas,
 	spine::SkeletonData *data;
 	if (!EMPTY(json)) {
 		spine::SkeletonJson skeletonJson(atlas);
-		data = skeletonJson.readSkeletonData(json.utf8());
+		data = skeletonJson.readSkeletonData(json.utf8().get_data());
 		if (!data) {
 			ERR_PRINT(String("Error while loading skeleton data: ") + get_path());
 			ERR_PRINT(String("Error message: ") + skeletonJson.getError().buffer());
@@ -392,7 +392,7 @@ void SpineSkeletonDataResource::get_animation_names(Vector<String> &animation_na
 	for (size_t i = 0; i < animations.size(); ++i) {
 		auto animation = animations[i];
 		String name;
-		name.parse_utf8(animation->getName().buffer());
+		name = String::utf8(animation->getName().buffer());
 		animation_names.push_back(name);
 	}
 }
@@ -409,7 +409,7 @@ void SpineSkeletonDataResource::get_skin_names(Vector<String> &skin_names) const
 	for (size_t i = 0; i < skins.size(); ++i) {
 		auto skin = skins[i];
 		String name;
-		name.parse_utf8(skin->getName().buffer());
+		name = String::utf8(skin->getName().buffer());
 		skin_names.push_back(name);
 	}
 }
@@ -426,7 +426,7 @@ void SpineSkeletonDataResource::get_slot_names(Vector<String> &slot_names) {
 	for (size_t i = 0; i < slots.size(); ++i) {
 		auto slot = slots[i];
 		String name;
-		name.parse_utf8(slot->getName().buffer());
+		name = String::utf8(slot->getName().buffer());
 		slot_names.push_back(name);
 	}
 }
@@ -443,7 +443,7 @@ void SpineSkeletonDataResource::get_bone_names(Vector<String> &bone_names) {
 	for (size_t i = 0; i < bones.size(); ++i) {
 		auto bone = bones[i];
 		String name;
-		name.parse_utf8(bone->getName().buffer());
+		name = String::utf8(bone->getName().buffer());
 		bone_names.push_back(name);
 	}
 }
@@ -628,7 +628,7 @@ SpineSkeletonDataResource::find_physics_constraint(
 String SpineSkeletonDataResource::get_skeleton_name() const {
 	SPINE_CHECK(skeleton_data, "")
 	String name;
-	name.parse_utf8(skeleton_data->getName().buffer());
+	name = String::utf8(skeleton_data->getName().buffer());
 	return name;
 }
 

--- a/spine-godot/spine_godot/SpineSkeletonFileResource.cpp
+++ b/spine-godot/spine_godot/SpineSkeletonFileResource.cpp
@@ -135,7 +135,7 @@ Error SpineSkeletonFileResource::load_from_file(const String &path) {
 		json = FileAccess::get_file_as_string(path, &error);
 		if (error != OK) return error;
 #endif
-		if (!checkJson(json.utf8())) return ERR_INVALID_DATA;
+		if (!checkJson(json.utf8().get_data())) return ERR_INVALID_DATA;
 	} else {
 #ifdef SPINE_GODOT_EXTENSION
 		binary = FileAccess::get_file_as_bytes(path);

--- a/spine-godot/spine_godot/SpineSkin.cpp
+++ b/spine-godot/spine_godot/SpineSkin.cpp
@@ -125,7 +125,7 @@ Array SpineSkin::find_attachments_for_slot(int slot_index) {
 String SpineSkin::get_name() {
 	SPINE_CHECK(get_spine_object(), "")
 	String name;
-	name.parse_utf8(get_spine_object()->getName().buffer());
+	name = String::utf8(get_spine_object()->getName().buffer());
 	return name;
 }
 

--- a/spine-godot/spine_godot/SpineSlotData.cpp
+++ b/spine-godot/spine_godot/SpineSlotData.cpp
@@ -54,7 +54,7 @@ int SpineSlotData::get_index() {
 String SpineSlotData::get_name() {
 	SPINE_CHECK(get_spine_object(), String(""))
 	String name;
-	name.parse_utf8(get_spine_object()->getName().buffer());
+	name = String::utf8(get_spine_object()->getName().buffer());
 	return name;
 }
 

--- a/spine-godot/spine_godot/SpineSprite.cpp
+++ b/spine-godot/spine_godot/SpineSprite.cpp
@@ -1227,7 +1227,7 @@ void SpineSprite::draw() {
 	Vector<String> hover_text_lines;
 	if (hovered_slot) {
 		String name;
-		name.parse_utf8(hovered_slot->getData().getName().buffer());
+		name = String::utf8(hovered_slot->getData().getName().buffer());
 		hover_text_lines.push_back(String("Slot: ") + name);
 	}
 
@@ -1237,7 +1237,7 @@ void SpineSprite::draw() {
 		draw_bone(hovered_bone, Color(debug_bones_color.r, debug_bones_color.g, debug_bones_color.b, 1));
 		debug_bones_thickness = thickness;
 		String name;
-		name.parse_utf8(hovered_bone->getData().getName().buffer());
+		name = String::utf8(hovered_bone->getData().getName().buffer());
 		hover_text_lines.push_back(String("Bone: ") + name);
 	}
 


### PR DESCRIPTION
Compilation errors have been resolved to ensure compatibility with [godot 4.5.1-stable](https://github.com/godotengine/godot/releases/tag/4.5.1-stable).

Fixes #2977

* [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).
