### PR TITLE
Add boundsProvider parameter to renderToImage function

### DIFF
--- a/spine-ios/Sources/Spine/Extensions/SkeletonDrawableWrapper+CGImage.swift
+++ b/spine-ios/Sources/Spine/Extensions/SkeletonDrawableWrapper+CGImage.swift
@@ -39,9 +39,10 @@ public extension SkeletonDrawableWrapper {
     ///     - size: The size of the `CGImage` that should be rendered.
     ///     - backgroundColor: the background color of the image
     ///     - scaleFactor: The scale factor. Set this to `UIScreen.main.scale` if you want to show the image in a view
-    func renderToImage(size: CGSize, backgroundColor: UIColor, scaleFactor: CGFloat = 1) throws -> CGImage? {
+    func renderToImage(size: CGSize, boundsProvider: BoundsProvider = SetupPoseBounds(), backgroundColor: UIColor, scaleFactor: CGFloat = 1) throws -> CGImage? {
         let spineView = SpineUIView(
             controller: SpineController(disposeDrawableOnDeInit: false), // Doesn't own the drawable
+            boundsProvider: boundsProvider,
             backgroundColor: backgroundColor
         )
         spineView.frame = CGRect(origin: .zero, size: size)


### PR DESCRIPTION
Since boundsProvider will be specified in actual development, but it is not specified in the renderToImage method of SkeletonDrawableWrapper, this will cause the actual display to be inconsistent with the screenshot. It is hoped that the boundsProvider parameter can be added, as shown below：
func renderToImage(size: CGSize, boundsProvider: BoundsProvider = SetupPoseBounds(), backgroundColor: UIColor, scaleFactor: CGFloat = 1) throws -> CGImage? {
let spineView = SpineUIView(
controller: SpineController(disposeDrawableOnDeInit: false), // Doesn't own the drawable
boundsProvider: boundsProvider,
backgroundColor: backgroundColor
)
...