### PR TITLE
[cpp] fixed Memory access out of bounds error caused by unhandled null return of RegionAttachment when loading default skin

### DIFF
--- a/spine-cpp/spine-cpp/src/spine/SkeletonBinary.cpp
+++ b/spine-cpp/spine-cpp/src/spine/SkeletonBinary.cpp
@@ -279,6 +279,12 @@ SkeletonData *SkeletonBinary::readSkeletonData(const unsigned char *binary, cons
 		skeletonData->_defaultSkin = defaultSkin;
 		skeletonData->_skins.add(defaultSkin);
 	}
+	
+	if (!this->getError().isEmpty()) {
+		delete input;
+		delete skeletonData;
+		return NULL;
+	}
 
 	/* Skins. */
 	for (size_t i = 0, n = (size_t)readVarint(input, true); i < n; ++i) {


### PR DESCRIPTION
When the texture packer is set to ignore blank images and exports a binary animation with empty sprites,
during the loading of the default skin in the skeleton file, the RegionAttachment returns null,
but there is no error handling or early return,
so the parsing continues, leading to misalignment and corruption in subsequent reads.