### PR TITLE
Add overloads for SkeletonRendererCocos2dX methods findBone, findSlot and getAttachment accepting const char * instead of std::string.

### DIFF
--- a/spine-cocos2dx/spine-cocos2dx/src/spine/SkeletonRendererCocos2dX.cpp
+++ b/spine-cocos2dx/spine-cocos2dx/src/spine/SkeletonRendererCocos2dX.cpp
@@ -685,23 +685,38 @@ namespace spine {
 	}
 
 	Bone *SkeletonRendererCocos2dX::findBone(const std::string &boneName) const {
-		return _skeleton->findBone(boneName.c_str());
+		return findBone(boneName.empty() ? nullptr : boneName.c_str());
+	}
+	Bone *SkeletonRendererCocos2dX::findBone(const char *boneName) const {
+		const String spineBoneName{ boneName, true, false };
+		return _skeleton->findBone(spineBoneName);
 	}
 
 	Slot *SkeletonRendererCocos2dX::findSlot(const std::string &slotName) const {
-		return _skeleton->findSlot(slotName.c_str());
+		return findSlot(slotName.empty() ? nullptr : slotName.c_str());
+	}
+	Slot *SkeletonRendererCocos2dX::findSlot(const char *slotName) const {
+		const String spineSlotName{ slotName, true, false };
+		return _skeleton->findSlot(spineSlotName);
 	}
 
 	void SkeletonRendererCocos2dX::setSkin(const std::string &skinName) {
-		_skeleton->setSkin(skinName.empty() ? 0 : skinName.c_str());
+		_skeleton->setSkin(skinName.empty() ? nullptr : skinName.c_str());
 	}
 	void SkeletonRendererCocos2dX::setSkin(const char *skinName) {
+		const String spineSkinName{ skinName, true, false };
 		_skeleton->setSkin(skinName);
 	}
 
 	Attachment *SkeletonRendererCocos2dX::getAttachment(const std::string &slotName, const std::string &attachmentName) const {
-		return _skeleton->getAttachment(slotName.c_str(), attachmentName.c_str());
+		return getAttachment(slotName.c_str(), attachmentName.c_str());
 	}
+	Attachment *SkeletonRendererCocos2dX::getAttachment(const char *slotName, const char *attachmentName) const {
+		const String spineSlotName{ slotName, true, false };
+		const String spineAttachmentName{ attachmentName, true, false };
+		return _skeleton->getAttachment(spineSlotName, spineAttachmentName);
+	}
+
 	bool SkeletonRendererCocos2dX::setAttachment(const std::string &slotName, const std::string &attachmentName) {
 		bool result = _skeleton->getAttachment(slotName.c_str(), attachmentName.empty() ? 0 : attachmentName.c_str()) ? true : false;
 		_skeleton->setAttachment(slotName.c_str(), attachmentName.empty() ? 0 : attachmentName.c_str());

--- a/spine-cocos2dx/spine-cocos2dx/src/spine/SkeletonRendererCocos2dX.h
+++ b/spine-cocos2dx/spine-cocos2dx/src/spine/SkeletonRendererCocos2dX.h
@@ -79,8 +79,10 @@ namespace spine {
 
 		/* Returns 0 if the bone was not found. */
 		Bone *findBone(const std::string &boneName) const;
+		Bone *findBone(const char *boneName) const;
 		/* Returns 0 if the slot was not found. */
 		Slot *findSlot(const std::string &slotName) const;
+		Slot *findSlot(const char *slotName) const;
 
 		/* Sets the skin used to look up attachments not found in the SkeletonData defaultSkin. Attachments from the new skin are
 		 * attached if the corresponding attachment from the old skin was attached.
@@ -91,6 +93,7 @@ namespace spine {
 
 		/* Returns 0 if the slot or attachment was not found. */
 		Attachment *getAttachment(const std::string &slotName, const std::string &attachmentName) const;
+		Attachment *getAttachment(const char *slotName, const char *attachmentName) const;
 		/* Returns false if the slot or attachment was not found.
 		 * @param attachmentName May be empty string ("") for no attachment. */
 		bool setAttachment(const std::string &slotName, const std::string &attachmentName);


### PR DESCRIPTION
Those methods did not have const char * overloads, though setSkin() method has such overloads.
Also, existing methods accepting std::string were constructing spine::String implicitly which caused it to allocate a copy on the heap. This commit changes it so that spine::String is constructed without allocations/deallocations by passing constructor parameters own == true and tofree == false.

* [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).
