### PR TITLE
fix: support phaser v4 esm runtime

### DIFF
--- a/spine-ts/spine-phaser-v4/src/SpineGameObject.ts
+++ b/spine-ts/spine-phaser-v4/src/SpineGameObject.ts
@@ -27,6 +27,7 @@
  * THE SPINE RUNTIMES, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
+import * as Phaser from "phaser";
 import {
 	AnimationState,
 	AnimationStateData,

--- a/spine-ts/spine-phaser-v4/src/mixins.ts
+++ b/spine-ts/spine-phaser-v4/src/mixins.ts
@@ -26,6 +26,8 @@ SOFTWARE.
 
 // biome-ignore-all lint: ignore biome for this file
 
+import * as Phaser from "phaser";
+
 const components = (Phaser.GameObjects.Components as any);
 export const ComputedSize = components.ComputedSize;
 export const Depth = components.Depth;
@@ -35,6 +37,87 @@ export const Transform = components.Transform;
 export const Visible = components.Visible;
 export const Origin = components.Origin;
 export const Alpha = components.Alpha;
+
+function hasGetterOrSetter (definition: Record<string, unknown>) {
+	return typeof definition.get === "function" || typeof definition.set === "function";
+}
+
+function getMixinProperty (definition: Record<string, unknown>, key: string) {
+	let property = Object.getOwnPropertyDescriptor(definition, key);
+
+	if (!property) {
+		return false;
+	}
+
+	if ("value" in property && property.value && typeof property.value === "object") {
+		property = property.value as PropertyDescriptor;
+	}
+
+	if (!property || !hasGetterOrSetter(property as Record<string, unknown>)) {
+		return false;
+	}
+
+	if (typeof property.enumerable === "undefined") {
+		property.enumerable = true;
+	}
+
+	if (typeof property.configurable === "undefined") {
+		property.configurable = true;
+	}
+
+	return property;
+}
+
+function hasNonConfigurable (target: object, key: string) {
+	let property = Object.getOwnPropertyDescriptor(target, key);
+
+	if (!property) {
+		return false;
+	}
+
+	if ("value" in property && property.value && typeof property.value === "object") {
+		property = property.value as PropertyDescriptor;
+	}
+
+	return property.configurable === false;
+}
+
+function extendPrototype (target: { prototype: object }, definition: Record<string, unknown>) {
+	for (const key of Object.keys(definition)) {
+		const property = getMixinProperty(definition, key);
+
+		if (property !== false) {
+			if (hasNonConfigurable(target.prototype, key)) {
+				continue;
+			}
+
+			Object.defineProperty(target.prototype, key, property);
+			continue;
+		}
+
+		(target.prototype as Record<string, unknown>)[key] = definition[key];
+	}
+}
+
+function mixin (target: { prototype: object }, mixins: unknown) {
+	if (!mixins) {
+		return;
+	}
+
+	const mixinList = Array.isArray(mixins) ? mixins : [mixins];
+
+	for (const currentMixin of mixinList) {
+		const definition = typeof currentMixin === "function"
+			? currentMixin.prototype as Record<string, unknown> | undefined
+			: currentMixin as Record<string, unknown> | undefined;
+
+		if (!definition) {
+			continue;
+		}
+
+		extendPrototype(target, definition);
+	}
+}
 
 export interface Type<
 	T,
@@ -56,7 +139,7 @@ export function createMixin<
 	...component: GameObjectComponent[]
 ): Mixin<GameObjectComponent, GameObjectConstraint> {
 	return (BaseGameObject) => {
-		(Phaser as any).Class.mixin(BaseGameObject, component);
+		mixin(BaseGameObject, component);
 		return BaseGameObject as any;
 	};
 }


### PR DESCRIPTION
# `[phaser-v4] Fix ESM runtime initialization in Vite/TypeScript projects`

Fixes #3055.

## Summary

This fixes the Phaser 4 ESM runtime path for `spine-phaser-v4` in a plain Vite/TypeScript setup.

Before this change, the package could build successfully but still fail at runtime with:

```text
ReferenceError: Phaser is not defined
```

The problem was that the runtime mixed module-based Phaser usage with free global `Phaser` references.

## Root cause

- `SpinePlugin.ts` already works as a normal Phaser module import.
- `SpineGameObject.ts` still referenced `Phaser` without importing it.
- `mixins.ts` also depended on a free `Phaser` global.
- `mixins.ts` called `Phaser.Class.mixin(...)`, but Phaser's ESM build does not expose `Class`.

That combination breaks a normal setup like:

```ts
import * as Phaser from "phaser";
import { SpinePlugin } from "@esotericsoftware/spine-phaser-v4";
```

## Changes

- Add an explicit Phaser import in `SpineGameObject.ts`.
- Add an explicit Phaser import in `mixins.ts`.
- Replace `Phaser.Class.mixin(...)` with a small local mixin helper.
- Preserve getter/setter descriptors and skip non-configurable properties, matching the expected mixin behavior for Phaser game object components.

## Validation

- Built the `spine-ts` workspace successfully on `4.3-beta`.
- Verified the fix against a minimal Phaser 4 + Vite + TypeScript repro.
- Confirmed the repro now loads and renders correctly without:
  - `window.Phaser`
  - a custom bootstrap shim
  - vendored browser/IIFE runtime files

## Contributor checklist

- [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).

