### PR TITLE
[godot] Resolves #2853, the inability to preview animations in the Godot Editor when the AnimationPlayer node was not parented to the scene's root node.

### DIFF
--- a/spine-godot/spine_godot/SpineAnimationTrack.cpp
+++ b/spine-godot/spine_godot/SpineAnimationTrack.cpp
@@ -368,8 +368,22 @@ void SpineAnimationTrack::update_animation_state(const Variant &variant_sprite) 
 		}
 
 		int found_track_index = -1;
-		auto scene_path = EditorNode::get_singleton()->get_edited_scene()->get_path();
-		auto animation_player_path = scene_path.rel_path_to(animation_player->get_path());
+		auto editing_player = player_editor->get_player();
+		if (!editing_player) {
+			skeleton->setToSetupPose();
+			animation_state->clearTracks();
+			animation_state->setTimeScale(1);
+			return;
+		}
+		auto root_node = editing_player->get_node(editing_player->get_root_node());
+		if (!root_node) {
+			skeleton->setToSetupPose();
+			animation_state->clearTracks();
+			animation_state->setTimeScale(1);
+			return;
+		}
+		auto animation_player_path = root_node->get_path().rel_path_to(animation_player->get_path());
+
 		for (int i = 0; i < edited_animation->get_track_count(); i++) {
 			auto path = edited_animation->track_get_path(i);
 			if (path == animation_player_path) {

--- a/spine-godot/spine_godot/SpineAnimationTrack.cpp
+++ b/spine-godot/spine_godot/SpineAnimationTrack.cpp
@@ -375,7 +375,11 @@ void SpineAnimationTrack::update_animation_state(const Variant &variant_sprite) 
 			animation_state->setTimeScale(1);
 			return;
 		}
+#if VERSION_MAJOR > 3
 		auto root_node = editing_player->get_node(editing_player->get_root_node());
+#else
+		auto root_node = editing_player->get_node(editing_player->get_root());
+#endif
 		if (!root_node) {
 			skeleton->setToSetupPose();
 			animation_state->clearTracks();


### PR DESCRIPTION
Tested against Godot 4.6.1-stable.