### PR TITLE
[ts] fix: on some devices, a canvas exceeding the maximum texture size can…

### DIFF
--- a/spine-ts/spine-webgl/src/SceneRenderer.ts
+++ b/spine-ts/spine-webgl/src/SceneRenderer.ts
@@ -52,6 +52,7 @@ export class SceneRenderer implements Disposable {
 	canvas: HTMLCanvasElement;
 	camera: OrthoCamera;
 	batcher: PolygonBatcher;
+	maxTextureSize: number;
 	private twoColorTint = false;
 	private batcherShader: Shader;
 	private shapes: ShapeRenderer;
@@ -71,6 +72,7 @@ export class SceneRenderer implements Disposable {
 		this.shapes = new ShapeRenderer(this.context);
 		this.skeletonRenderer = new SkeletonRenderer(this.context, twoColorTint);
 		this.skeletonDebugRenderer = new SkeletonDebugRenderer(this.context);
+		this.maxTextureSize = this.context.gl.getParameter(this.context.gl.MAX_TEXTURE_SIZE);
 	}
 
 	dispose () {
@@ -468,6 +470,14 @@ export class SceneRenderer implements Disposable {
 		var dpr = window.devicePixelRatio || 1;
 		var w = Math.round(canvas.clientWidth * dpr);
 		var h = Math.round(canvas.clientHeight * dpr);
+
+		// If the canvas size is larger than the max texture size, scale the canvas size to the max texture size
+        if (this.maxTextureSize && (w > this.maxTextureSize || h > this.maxTextureSize)) {
+            const max = Math.max(w, h);
+            const s = this.maxTextureSize / max;
+            w = Math.round(w * s);
+            h = Math.round(h * s);
+        }
 
 		if (canvas.width != w || canvas.height != h) {
 			canvas.width = w;


### PR DESCRIPTION
… cause rendering distortion.

* [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).

**Problem phenomenon**: On some foldable phones, due to the large screen width and DPR, the canvas width is set to be excessively large, exceeding the maximum size limit of the texture map, resulting in animation rendering distortion.

**Recurrence conditions**：Galaxy Z Fold7, maxTextureSize=4096, when canvas size lager than 4096, resulting in animation rendering distortion.

**Program Summary**: When the canvas size is larger than the maximum texture size requirement, the maximum texture size is selected as the boundary reference.
