### PR TITLE
[ios] add AppKit (macOS) support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .tvOS(.v13),
         .macCatalyst(.v13),
         .visionOS(.v1),
-        .macOS(.v10_15),
+        .macOS(.v12),
         .watchOS(.v6),
     ],
     products: [
@@ -32,7 +32,7 @@ let package = Package(
         .target(
             name: "SpineiOSWrapper",
             dependencies: [
-                .target(name: "SpineiOS", condition: .when(platforms: [.iOS, .visionOS, .tvOS, .macCatalyst]))
+                .target(name: "SpineiOS", condition: .when(platforms: [.iOS, .visionOS, .tvOS, .macCatalyst, .macOS]))
             ],
             path: "spine-ios/Sources/SpineiOSWrapper"
         ),

--- a/spine-ios/Sources/SpineiOS/Extensions/MTLClearColor+UIColor.swift
+++ b/spine-ios/Sources/SpineiOS/Extensions/MTLClearColor+UIColor.swift
@@ -29,19 +29,15 @@
 
 import MetalKit
 
-#if canImport(UIKit)
-    import UIKit
+extension MTLClearColor {
+    init(_ color: SpineUIColor) {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
 
-    extension MTLClearColor {
-        init(_ color: UIColor) {
-            var red: CGFloat = 0
-            var green: CGFloat = 0
-            var blue: CGFloat = 0
-            var alpha: CGFloat = 0
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
-            color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-
-            self.init(red: Double(red), green: Double(green), blue: Double(blue), alpha: Double(alpha))
-        }
+        self.init(red: Double(red), green: Double(green), blue: Double(blue), alpha: Double(alpha))
     }
-#endif
+}

--- a/spine-ios/Sources/SpineiOS/Extensions/SkeletonDrawableWrapper+CGImage.swift
+++ b/spine-ios/Sources/SpineiOS/Extensions/SkeletonDrawableWrapper+CGImage.swift
@@ -30,76 +30,78 @@
 import CoreGraphics
 import Foundation
 
+import Metal
+
+extension SkeletonDrawableWrapper {
+    
+    /// Render the ``Skeleton`` to a `CGImage`
+    ///
+    /// Parameters:
+    ///     - size: The size of the `CGImage` that should be rendered.
+    ///     - boundsProvider: The skeleton bounds provider used to compute fitting and positioning.
+    ///     - backgroundColor: the background color of the image
+    ///     - scaleFactor: The scale factor. Set this to `UIScreen.main.scale` if you want to show the image in a view
+    public func renderToImage(
+        size: CGSize,
+        boundsProvider: BoundsProvider = SetupPoseBounds(),
+        backgroundColor: SpineUIColor,
+        scaleFactor: CGFloat = 1
+    ) throws -> CGImage? {
+        let controller = SpineController(disposeDrawableOnDeInit: false)  // Doesn't own the drawable
+        let spineView = SpineUIView(
+            controller: controller,
+            boundsProvider: boundsProvider,
+            backgroundColor: backgroundColor
+        )
+        spineView.frame = CGRect(origin: .zero, size: size)
+        spineView.isPaused = false
+        spineView.enableSetNeedsDisplay = false
+        spineView.framebufferOnly = false
+        
 #if canImport(UIKit)
-    import UIKit
-
-    extension SkeletonDrawableWrapper {
-
-        /// Render the ``Skeleton`` to a `CGImage`
-        ///
-        /// Parameters:
-        ///     - size: The size of the `CGImage` that should be rendered.
-        ///     - boundsProvider: The skeleton bounds provider used to compute fitting and positioning.
-        ///     - backgroundColor: the background color of the image
-        ///     - scaleFactor: The scale factor. Set this to `UIScreen.main.scale` if you want to show the image in a view
-        public func renderToImage(
-            size: CGSize,
-            boundsProvider: BoundsProvider = SetupPoseBounds(),
-            backgroundColor: UIColor,
-            scaleFactor: CGFloat = 1
-        ) throws -> CGImage? {
-            let controller = SpineController(disposeDrawableOnDeInit: false)  // Doesn't own the drawable
-            let spineView = SpineUIView(
-                controller: controller,
-                boundsProvider: boundsProvider,
-                backgroundColor: backgroundColor
-            )
-            spineView.frame = CGRect(origin: .zero, size: size)
-            spineView.isPaused = false
-            spineView.enableSetNeedsDisplay = false
-            spineView.framebufferOnly = false
-            spineView.contentScaleFactor = scaleFactor
-
-            defer {
-                controller.drawable = nil
-                spineView.delegate = nil
-                spineView.renderer = nil
-            }
-
-            try spineView.load(drawable: self)
-            spineView.renderer?.waitUntilCompleted = true
-
-            spineView.delegate?.draw(in: spineView)
-
-            guard let texture = spineView.currentDrawable?.texture else {
-                throw SpineError("Could not read texture.")
-            }
-            let width = texture.width
-            let height = texture.height
-            let rowBytes = width * 4
-            let data = UnsafeMutableRawPointer.allocate(byteCount: rowBytes * height, alignment: MemoryLayout<UInt8>.alignment)
-            defer {
-                data.deallocate()
-            }
-
-            let region = MTLRegionMake2D(0, 0, width, height)
-            texture.getBytes(data, bytesPerRow: rowBytes, from: region, mipmapLevel: 0)
-
-            let bitmapInfo = CGBitmapInfo(
-                rawValue: CGImageAlphaInfo.premultipliedFirst.rawValue
-            ).union(.byteOrder32Little)
-
-            let colorSpace = CGColorSpaceCreateDeviceRGB()
-            guard
-                let context = CGContext(
-                    data: data, width: width, height: height, bitsPerComponent: 8, bytesPerRow: rowBytes, space: colorSpace,
-                    bitmapInfo: bitmapInfo.rawValue),
-                let cgImage = context.makeImage()
-            else {
-                throw SpineError("Could not create image.")
-            }
-            return cgImage
-        }
-    }
-
+        spineView.contentScaleFactor = scaleFactor
 #endif
+        
+        
+        defer {
+            controller.drawable = nil
+            spineView.delegate = nil
+            spineView.renderer = nil
+        }
+        
+        try spineView.load(drawable: self)
+        spineView.renderer?.waitUntilCompleted = true
+        
+        spineView.delegate?.draw(in: spineView)
+        
+        guard let texture = spineView.currentDrawable?.texture else {
+            throw SpineError("Could not read texture.")
+        }
+        let width = texture.width
+        let height = texture.height
+        let rowBytes = width * 4
+        let data = UnsafeMutableRawPointer.allocate(byteCount: rowBytes * height, alignment: MemoryLayout<UInt8>.alignment)
+        defer {
+            data.deallocate()
+        }
+        
+        let region = MTLRegionMake2D(0, 0, width, height)
+        texture.getBytes(data, bytesPerRow: rowBytes, from: region, mipmapLevel: 0)
+        
+        let bitmapInfo = CGBitmapInfo(
+            rawValue: CGImageAlphaInfo.premultipliedFirst.rawValue
+        ).union(.byteOrder32Little)
+        
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard
+            let context = CGContext(
+                data: data, width: width, height: height, bitsPerComponent: 8, bytesPerRow: rowBytes, space: colorSpace,
+                bitmapInfo: bitmapInfo.rawValue),
+            let cgImage = context.makeImage()
+        else {
+            throw SpineError("Could not create image.")
+        }
+        return cgImage
+    }
+}
+

--- a/spine-ios/Sources/SpineiOS/Metal/SpineRenderer.swift
+++ b/spine-ios/Sources/SpineiOS/Metal/SpineRenderer.swift
@@ -80,7 +80,7 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
         device: MTLDevice,
         commandQueue: MTLCommandQueue,
         pixelFormat: MTLPixelFormat,
-        atlasPages: [UIImage],
+        atlasPages: [SpineUIImage],
         pma: Bool
     ) throws {
         self.device = device
@@ -98,7 +98,13 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
         let textureLoader = MTKTextureLoader(device: device)
         textures =
             try atlasPages
-            .compactMap { $0.cgImage }
+            .compactMap {
+#if canImport(UIKit)
+                $0.cgImage
+#elseif canImport(AppKit)
+                $0.cgImage(forProposedRect: nil, context: nil, hints: [:])
+#endif
+            }
             .map {
                 try textureLoader.newTexture(
                     cgImage: $0,
@@ -134,8 +140,11 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
 
     func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
         guard let spineView = view as? SpineUIView else { return }
+        
+        // FIXME: support multi-head display
+        let screenScaleFactor = SpineUIScreen.main?.scale ?? 1.0
 
-        sizeInPoints = CGSize(width: size.width / UIScreen.main.scale, height: size.height / UIScreen.main.scale)
+        sizeInPoints = CGSize(width: size.width / screenScaleFactor, height: size.height / screenScaleFactor)
         viewPortSize = vector_uint2(UInt32(size.width), UInt32(size.height))
         setTransform(
             bounds: spineView.computedBounds,
@@ -187,6 +196,9 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
     }
 
     private func setTransform(bounds: CGRect, mode: SpineContentMode, alignment: SpineAlignment) {
+        // FIXME: support multi-head display
+        let screenScaleFactor = SpineUIScreen.main?.scale ?? 1.0
+        
         let x = -bounds.minX - bounds.width / 2.0
         let y = -bounds.minY - bounds.height / 2.0
 
@@ -207,8 +219,8 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
 
         transform = SpineTransform(
             translation: vector_float2(Float(x), Float(y)),
-            scale: vector_float2(Float(scaleX * UIScreen.main.scale), Float(scaleY * UIScreen.main.scale)),
-            offset: vector_float2(Float(offsetX * UIScreen.main.scale), Float(offsetY * UIScreen.main.scale))
+            scale: vector_float2(Float(scaleX * screenScaleFactor), Float(scaleY * screenScaleFactor)),
+            offset: vector_float2(Float(offsetX * screenScaleFactor), Float(offsetY * screenScaleFactor))
         )
 
         delegate?.spineRendererDidUpdate(

--- a/spine-ios/Sources/SpineiOS/SkeletonDrawableWrapper.swift
+++ b/spine-ios/Sources/SpineiOS/SkeletonDrawableWrapper.swift
@@ -30,7 +30,12 @@
 import CoreGraphics
 import Foundation
 import SpineSwift
+
+#if canImport(UIKit)
 import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 /// A ``SkeletonDrawableWrapper`` with ``SkeletonDrawable`` bundle loading, updating, and rendering an ``Atlas``, ``Skeleton``, and ``AnimationState``
 /// into a single easy to use class.
@@ -55,7 +60,7 @@ import UIKit
 public final class SkeletonDrawableWrapper: NSObject {
 
     public let atlas: Atlas
-    public let atlasPages: [UIImage]
+    public let atlasPages: [SpineUIImage]
     public let skeletonData: SkeletonData
 
     public let skeletonDrawable: SkeletonDrawable
@@ -115,7 +120,7 @@ public final class SkeletonDrawableWrapper: NSObject {
         )
     }
 
-    public init(atlas: Atlas, atlasPages: [UIImage], skeletonData: SkeletonData) throws {
+    public init(atlas: Atlas, atlasPages: [SpineUIImage], skeletonData: SkeletonData) throws {
         self.atlas = atlas
         self.atlasPages = atlasPages
         self.skeletonData = skeletonData

--- a/spine-ios/Sources/SpineiOS/SpineController.swift
+++ b/spine-ios/Sources/SpineiOS/SpineController.swift
@@ -31,7 +31,12 @@ import CoreGraphics
 import Foundation
 import QuartzCore
 import SpineSwift
+
+#if canImport(UIKit)
 import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 public typealias SpineControllerCallback = (_ controller: SpineController) -> Void
 

--- a/spine-ios/Sources/SpineiOS/SpinePlatformTypes+AppKit.swift
+++ b/spine-ios/Sources/SpineiOS/SpinePlatformTypes+AppKit.swift
@@ -1,0 +1,22 @@
+//
+//  SpinePlatformTypes+AppKit.swift
+//  spine-ios
+//
+//  Created by Gyuhwan Park on 5/22/26.
+//
+
+#if canImport(AppKit)
+import AppKit
+import SwiftUI
+
+public typealias SpineUIImage = NSImage
+public typealias SpineUIColor = NSColor
+public typealias SpineUIScreen = NSScreen
+
+extension SpineUIScreen {
+    // UIKit-compatible accessor
+    var scale: CGFloat {
+        backingScaleFactor
+    }
+}
+#endif

--- a/spine-ios/Sources/SpineiOS/SpinePlatformTypes+UIKit.swift
+++ b/spine-ios/Sources/SpineiOS/SpinePlatformTypes+UIKit.swift
@@ -1,0 +1,15 @@
+//
+//  SpinePlatformTypes+UIKit.swift
+//  spine-ios
+//
+//  Created by Gyuhwan Park on 5/22/26.
+//
+
+#if canImport(UIKit)
+import UIKit
+import SwiftUI
+
+public typealias SpineUIImage = UIImage
+public typealias SpineUIColor = UIColor
+public typealias SpineUIScreen = UIScreen
+#endif

--- a/spine-ios/Sources/SpineiOS/SpineSwiftExtensions.swift
+++ b/spine-ios/Sources/SpineiOS/SpineSwiftExtensions.swift
@@ -30,7 +30,12 @@
 import Foundation
 import SpineSwift
 import SwiftUI
+
+#if canImport(UIKit)
 import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 // Re-export version info from SpineSwift
 public var version: String {
@@ -56,7 +61,7 @@ extension Atlas {
     /// Loads an ``Atlas`` from the file with name `atlasFileName` in the `main` bundle or the optionally provided [bundle].
     ///
     /// Throws an `Error` in case the atlas could not be loaded.
-    public static func fromBundle(_ atlasFileName: String, bundle: Bundle = .main) async throws -> (Atlas, [UIImage]) {
+    public static func fromBundle(_ atlasFileName: String, bundle: Bundle = .main) async throws -> (Atlas, [SpineUIImage]) {
         let data = try await FileSource.bundle(fileName: atlasFileName, bundle: bundle).load()
         return try await Self.fromData(data: data) { name in
             return try await FileSource.bundle(fileName: name, bundle: bundle).load()
@@ -66,7 +71,7 @@ extension Atlas {
     /// Loads an ``Atlas`` from the file URL `atlasFile`.
     ///
     /// Throws an `Error` in case the atlas could not be loaded.
-    public static func fromFile(_ atlasFile: URL) async throws -> (Atlas, [UIImage]) {
+    public static func fromFile(_ atlasFile: URL) async throws -> (Atlas, [SpineUIImage]) {
         let data = try await FileSource.file(atlasFile).load()
         return try await Self.fromData(data: data) { name in
             let dir = atlasFile.deletingLastPathComponent()
@@ -78,7 +83,7 @@ extension Atlas {
     /// Loads an ``Atlas`` from the http URL `atlasURL`.
     ///
     /// Throws an `Error` in case the atlas could not be loaded.
-    public static func fromHttp(_ atlasURL: URL) async throws -> (Atlas, [UIImage]) {
+    public static func fromHttp(_ atlasURL: URL) async throws -> (Atlas, [SpineUIImage]) {
         let data = try await FileSource.http(atlasURL).load()
         return try await Self.fromData(data: data) { name in
             let dir = atlasURL.deletingLastPathComponent()
@@ -87,7 +92,7 @@ extension Atlas {
         }
     }
 
-    private static func fromData(data: Data, loadFile: (_ name: String) async throws -> Data) async throws -> (Atlas, [UIImage]) {
+    private static func fromData(data: Data, loadFile: (_ name: String) async throws -> Data) async throws -> (Atlas, [SpineUIImage]) {
         guard let atlasData = String(data: data, encoding: .utf8) else {
             throw SpineError("Couldn't read atlas bytes as utf8 string")
         }
@@ -95,7 +100,7 @@ extension Atlas {
         // Use SpineSwift's loadAtlas function
         let atlas = try loadAtlas(atlasData)
 
-        var atlasPages = [UIImage]()
+        var atlasPages = [SpineUIImage]()
 
         // Load images for each atlas page
         let pages = atlas.pages
@@ -104,7 +109,7 @@ extension Atlas {
             let imagePath = page.texturePath
 
             let imageData = try await loadFile(imagePath)
-            guard let image = UIImage(data: imageData) else {
+            guard let image = SpineUIImage(data: imageData) else {
                 continue
             }
             atlasPages.append(image)

--- a/spine-ios/Sources/SpineiOS/SpineUIView.swift
+++ b/spine-ios/Sources/SpineiOS/SpineUIView.swift
@@ -68,9 +68,17 @@ public final class SpineUIView: MTKView {
         self.boundsProvider = boundsProvider
 
         super.init(frame: .zero, device: SpineObjects.shared.device)
-        clearColor = MTLClearColor(backgroundColor)
+        
+#if canImport(AppKit)
+        // in AppKit (macOS), MTLClearColor must be constructed with `NSColor.usingColorSpace()`
+        if let color = backgroundColor.usingColorSpace(.sRGB) {
+            clearColor = MTLClearColor(red: color.redComponent, green: color.greenComponent, blue: color.blueComponent, alpha: color.alphaComponent)
+        }
+        layer?.isOpaque = backgroundColor != .clear
+#endif
         
 #if canImport(UIKit)
+        clearColor = MTLClearColor(backgroundColor)
         isOpaque = backgroundColor != .clear
 #endif
     }

--- a/spine-ios/Sources/SpineiOS/SpineUIView.swift
+++ b/spine-ios/Sources/SpineiOS/SpineUIView.swift
@@ -29,7 +29,12 @@
 
 import MetalKit
 import SpineSwift
+
+#if canImport(UIKit)
 import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 /// A ``UIView`` to display a Spine skeleton. The skeleton can be loaded from a bundle, local files, http, or a pre-loaded ``SkeletonDrawableWrapper``.
 ///
@@ -55,7 +60,7 @@ public final class SpineUIView: MTKView {
         mode: SpineContentMode = .fit,
         alignment: SpineAlignment = .center,
         boundsProvider: BoundsProvider = SetupPoseBounds(),
-        backgroundColor: UIColor = .clear
+        backgroundColor: SpineUIColor = .clear
     ) {
         self.controller = controller
         self.mode = mode
@@ -64,7 +69,10 @@ public final class SpineUIView: MTKView {
 
         super.init(frame: .zero, device: SpineObjects.shared.device)
         clearColor = MTLClearColor(backgroundColor)
+        
+#if canImport(UIKit)
         isOpaque = backgroundColor != .clear
+#endif
     }
 
     /// An initializer that constructs a new ``SpineUIView`` from a ``SpineViewSource``.
@@ -87,7 +95,7 @@ public final class SpineUIView: MTKView {
         mode: SpineContentMode = .fit,
         alignment: SpineAlignment = .center,
         boundsProvider: BoundsProvider = SetupPoseBounds(),
-        backgroundColor: UIColor = .clear
+        backgroundColor: SpineUIColor = .clear
     ) {
         self.init(controller: controller, mode: mode, alignment: alignment, boundsProvider: boundsProvider, backgroundColor: backgroundColor)
         Task.detached(priority: .high) {
@@ -124,7 +132,7 @@ public final class SpineUIView: MTKView {
         mode: SpineContentMode = .fit,
         alignment: SpineAlignment = .center,
         boundsProvider: BoundsProvider = SetupPoseBounds(),
-        backgroundColor: UIColor = .clear
+        backgroundColor: SpineUIColor = .clear
     ) {
         self.init(
             from: .bundle(atlasFileName: atlasFileName, skeletonFileName: skeletonFileName, bundle: bundle), controller: controller, mode: mode,
@@ -153,7 +161,7 @@ public final class SpineUIView: MTKView {
         mode: SpineContentMode = .fit,
         alignment: SpineAlignment = .center,
         boundsProvider: BoundsProvider = SetupPoseBounds(),
-        backgroundColor: UIColor = .clear
+        backgroundColor: SpineUIColor = .clear
     ) {
         self.init(
             from: .file(atlasFile: atlasFile, skeletonFile: skeletonFile), controller: controller, mode: mode, alignment: alignment,
@@ -182,7 +190,7 @@ public final class SpineUIView: MTKView {
         mode: SpineContentMode = .fit,
         alignment: SpineAlignment = .center,
         boundsProvider: BoundsProvider = SetupPoseBounds(),
-        backgroundColor: UIColor = .clear
+        backgroundColor: SpineUIColor = .clear
     ) {
         self.init(
             from: .http(atlasURL: atlasURL, skeletonURL: skeletonURL), controller: controller, mode: mode, alignment: alignment,
@@ -208,7 +216,7 @@ public final class SpineUIView: MTKView {
         mode: SpineContentMode = .fit,
         alignment: SpineAlignment = .center,
         boundsProvider: BoundsProvider = SetupPoseBounds(),
-        backgroundColor: UIColor = .clear
+        backgroundColor: SpineUIColor = .clear
     ) {
         self.init(
             from: .drawable(drawable), controller: controller, mode: mode, alignment: alignment, boundsProvider: boundsProvider,
@@ -246,7 +254,7 @@ extension SpineUIView {
         controller.initialize()
     }
 
-    private func initRenderer(atlasPages: [UIImage]) throws {
+    private func initRenderer(atlasPages: [SpineUIImage]) throws {
         // Get PMA flag from first atlas page if available
         let pmaFlag = controller.atlas.pages.count > 0 ? (controller.atlas.pages[0]?.pma ?? false) : false
 

--- a/spine-ios/Sources/SpineiOS/SpineView+AppKit.swift
+++ b/spine-ios/Sources/SpineiOS/SpineView+AppKit.swift
@@ -1,0 +1,106 @@
+/******************************************************************************
+ * Spine Runtimes License Agreement
+ * Last updated April 5, 2025. Replaces all prior versions.
+ *
+ * Copyright (c) 2013-2025, Esoteric Software LLC
+ *
+ * Integration of the Spine Runtimes into software or otherwise creating
+ * derivative works of the Spine Runtimes is permitted under the terms and
+ * conditions of Section 2 of the Spine Editor License Agreement:
+ * http://esotericsoftware.com/spine-editor-license
+ *
+ * Otherwise, it is permitted to integrate the Spine Runtimes into software
+ * or otherwise create derivative works of the Spine Runtimes (collectively,
+ * "Products"), provided that each user of the Products must obtain their own
+ * Spine Editor license and redistribution of the Products in any form must
+ * include this license and copyright notice.
+ *
+ * THE SPINE RUNTIMES ARE PROVIDED BY ESOTERIC SOFTWARE LLC "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL ESOTERIC SOFTWARE LLC BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES,
+ * BUSINESS INTERRUPTION, OR LOSS OF USE, DATA, OR PROFITS) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THE SPINE RUNTIMES, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+
+#if canImport(AppKit)
+import SwiftUI
+
+/// A `SwiftUI` `View` to display a Spine skeleton. The skeleton can be loaded from a bundle, local files, http, or a pre-loaded ``SkeletonDrawableWrapper``.
+///
+/// The skeleton displayed by a ``SpineUIView`` can be controlled via a ``SpineController``.
+///
+/// The size of the widget can be derived from the bounds provided by a ``BoundsProvider``. If the view is not sized by the bounds
+/// computed by the ``BoundsProvider``, the widget will use the computed bounds to fit the skeleton inside the view's dimensions.
+///
+/// This is a ``UIViewRepresentable`` of `SpineUIView`.
+public struct SpineView: NSViewRepresentable {
+    public typealias NSViewType = SpineUIView
+
+    private let source: SpineViewSource
+    private let controller: SpineController
+    private let mode: SpineContentMode
+    private let alignment: SpineAlignment
+    private let boundsProvider: BoundsProvider
+    private let backgroundColor: SpineUIColor  // Not using `SwiftUI.Color`, as briging to `UIColor` prior iOS 14 might not always work.
+
+    @Binding
+    private var isRendering: Bool?
+
+    /// An initializer that constructs a new ``SpineView`` from a ``SpineViewSource``.
+    ///
+    /// After initialization is complete, the provided `controller` is invoked as per the ``SpineController`` semantics, to allow
+    /// modifying how the skeleton inside the widget is animated and rendered.
+    ///
+    /// - Parameters:
+    ///     - from: Specifies the ``SpineViewSource`` from which to load `atlas` and `skeleton` data.
+    ///     - controller: The ``SpineController`` used to modify how the skeleton inside the view is animated and rendered.
+    ///     - skeletonFileName: Specifies either a Skeleton `.json` or `.skel` file containing the skeleton data
+    ///     - bundle: Specifies from which bundle to load the files. Per default, it is `Bundle.main`
+    ///     - mode: How the skeleton is fitted inside ``SpineUIView``. Per default, it is `.fit`
+    ///     - alignment: How the skeleton is alignment inside ``SpineUIView``. Per default, it is `.center`
+    ///     - boundsProvider: The skeleton bounds must be computed via a ``BoundsProvider``. Per default, ``SetupPoseBounds`` is used.
+    ///     - backgroundColor: The background color of the view. Per defaut, `UIColor.clear` is used
+    ///     - isRendering: Bindgin to disable or enable rendering. Disable it when the spine view is out of bounds and you want to preserve CPU/GPU resources.
+    ///
+    /// - Returns: A new instance of ``SpineView``.
+    public init(
+        from source: SpineViewSource,
+        controller: SpineController = SpineController(),
+        mode: SpineContentMode = .fit,
+        alignment: SpineAlignment = .center,
+        boundsProvider: BoundsProvider = SetupPoseBounds(),
+        backgroundColor: SpineUIColor = .clear,
+        isRendering: Binding<Bool?> = .constant(nil)
+    ) {
+        self.source = source
+        self.controller = controller
+        self.mode = mode
+        self.alignment = alignment
+        self.boundsProvider = boundsProvider
+        self.backgroundColor = backgroundColor
+        _isRendering = isRendering
+    }
+
+    public func makeNSView(context: Context) -> SpineUIView {
+        return SpineUIView(
+            from: source,
+            controller: controller,
+            mode: mode,
+            alignment: alignment,
+            boundsProvider: boundsProvider,
+            backgroundColor: backgroundColor
+        )
+    }
+
+    public func updateNSView(_ uiView: SpineUIView, context: Context) {
+        if let isRendering {
+            uiView.isRendering = isRendering
+        }
+    }
+}
+#endif

--- a/spine-ios/Sources/SpineiOS/SpineView+UIKit.swift
+++ b/spine-ios/Sources/SpineiOS/SpineView+UIKit.swift
@@ -27,6 +27,7 @@
  * THE SPINE RUNTIMES, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
+#if canImport(UIKit)
 import SwiftUI
 
 /// A `SwiftUI` `View` to display a Spine skeleton. The skeleton can be loaded from a bundle, local files, http, or a pre-loaded ``SkeletonDrawableWrapper``.
@@ -38,7 +39,6 @@ import SwiftUI
 ///
 /// This is a ``UIViewRepresentable`` of `SpineUIView`.
 public struct SpineView: UIViewRepresentable {
-
     public typealias UIViewType = SpineUIView
 
     private let source: SpineViewSource
@@ -46,7 +46,7 @@ public struct SpineView: UIViewRepresentable {
     private let mode: SpineContentMode
     private let alignment: SpineAlignment
     private let boundsProvider: BoundsProvider
-    private let backgroundColor: UIColor  // Not using `SwiftUI.Color`, as briging to `UIColor` prior iOS 14 might not always work.
+    private let backgroundColor: SpineUIColor  // Not using `SwiftUI.Color`, as briging to `UIColor` prior iOS 14 might not always work.
 
     @Binding
     private var isRendering: Bool?
@@ -74,7 +74,7 @@ public struct SpineView: UIViewRepresentable {
         mode: SpineContentMode = .fit,
         alignment: SpineAlignment = .center,
         boundsProvider: BoundsProvider = SetupPoseBounds(),
-        backgroundColor: UIColor = .clear,
+        backgroundColor: SpineUIColor = .clear,
         isRendering: Binding<Bool?> = .constant(nil)
     ) {
         self.source = source
@@ -103,3 +103,4 @@ public struct SpineView: UIViewRepresentable {
         }
     }
 }
+#endif


### PR DESCRIPTION
<img width="3456" height="2160" alt="이미지 2026  5  22  02 09" src="https://github.com/user-attachments/assets/e9cd0015-7c04-4f74-90d7-ded110c04ed8" />

*An example of a macOS live wallpaper using SpineiOS (illustrated by @hoonkun)*

# DESCRIPTION

- **added support for AppKit-based platforms (like macOS)**
  - added platform-guarded typealiases / type mappings for UIKit-related types 

```diff
// pseudo code
+ #if macOS
+ typealias SpineUIImage = NSImage
+ #endif
 
+ #if iOS
+ typealias SpineUIImage = UIImage
+ #endif

- func someSpineFunction(which requires: UIImage)
+ func someSpineFunction(which requires: SpineUIImage)
```

# CLA AGREEMENT

* [ ] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).

> **조금만 자고 할게요**
>
> **한국 시간으로 02:11 AM이기 때문에 CLA 동의는 자고 일어나서 하겠습니다**

> **I'll do this after getting some sleep.** 
> 
> **It's currently 2:11 AM KST (Korean Standard Time) here, so I will agree to the CLA once I wake up.**

# AUTHORS

- [@hoonkun](https://github.com/hoonkun) - Gohoon Han (team unstablers Inc.)
- [@unstabler](https://github.com/unstabler) - Gyuhwan Park (team unstablers Inc.)