### PR TITLE
[unity] Fix SkeletonGraphic memory leak caused by missing base.OnDestroy()

### DIFF
--- a/spine-unity/Assets/Spine/Runtime/spine-unity/Components/SkeletonGraphic.cs
+++ b/spine-unity/Assets/Spine/Runtime/spine-unity/Components/SkeletonGraphic.cs
@@ -425,6 +425,8 @@ namespace Spine.Unity {
 			ClearSkeletonState();
 			rendererBuffers.Dispose();
 			valid = false;
+
+			base.OnDestroy();
 		}
 
 		protected void OnCullStateChanged (bool culled) {


### PR DESCRIPTION
# Summary

Call base.OnDestroy() from SkeletonGraphic.OnDestroy().
This appears to be a regression in spine-unity 4.3. The call to base.OnDestroy() was present in [the 4.2 implementation](https://github.com/EsotericSoftware/spine-runtimes/blob/4.2/spine-unity/Assets/Spine/Runtime/spine-unity/Components/SkeletonGraphic.cs#L325-L328), but is missing in 4.3.
SkeletonGraphic derives from UnityEngine.UI.Graphic. Without calling the base implementation, destroyed SkeletonGraphic instances remain registered in Unity’s static GraphicRegistry.

# Environment

* Unity 6000.3.11f1
* spine-unity 4.3

- [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).