### PR TITLE
Bugfixes

### DIFF
--- a/.github/actions/setup-godot-deps-3/action.yml
+++ b/.github/actions/setup-godot-deps-3/action.yml
@@ -3,7 +3,7 @@ description: Setup python, install the pip version of scons.
 inputs:
   python-version:
     description: The python version to use.
-    default: "3.x"
+    default: "3.12"
   python-arch:
     description: The python architecture.
     default: "x64"

--- a/.github/actions/setup-godot-deps-3/action.yml
+++ b/.github/actions/setup-godot-deps-3/action.yml
@@ -3,7 +3,7 @@ description: Setup python, install the pip version of scons.
 inputs:
   python-version:
     description: The python version to use.
-    default: "3.12"
+    default: "3.x"
   python-arch:
     description: The python architecture.
     default: "x64"
@@ -23,7 +23,7 @@ runs:
       shell: bash
       run: |
         python -c "import sys; print(sys.version)"
-        python -m pip install scons==4.4.0
+        python -m pip install scons==4.7.0
         scons --version
 
     - name: Setup dotnet 6

--- a/.github/actions/setup-godot-deps-4/action.yml
+++ b/.github/actions/setup-godot-deps-4/action.yml
@@ -3,7 +3,7 @@ description: Setup python, install the pip version of scons.
 inputs:
   python-version:
     description: The python version to use.
-    default: "3.x"
+    default: "3.12"
   python-arch:
     description: The python architecture.
     default: "x64"

--- a/.github/actions/setup-godot-deps-4/action.yml
+++ b/.github/actions/setup-godot-deps-4/action.yml
@@ -3,7 +3,7 @@ description: Setup python, install the pip version of scons.
 inputs:
   python-version:
     description: The python version to use.
-    default: "3.12"
+    default: "3.x"
   python-arch:
     description: The python architecture.
     default: "x64"

--- a/.github/workflows/spine-godot-extension-v4.yml
+++ b/.github/workflows/spine-godot-extension-v4.yml
@@ -253,7 +253,7 @@ jobs:
           mkdir -p bin/{windows,linux,macos/macos.framework,ios,android,web}
 
           # Ensure gdextension file is in root
-          cp ../spine-godot/spine_godot_extension.gdextension bin/
+          cp ../spine-godot/spine_godot_extension.gdextension .
 
           # Move artifacts to their correct locations
           mv gdextension-windows-$GODOT_TAG/* bin/windows/

--- a/spine-godot/build/build.sh
+++ b/spine-godot/build/build.sh
@@ -57,7 +57,7 @@ if [ `uname` == 'Darwin' ] && [ $dev = "false" ]; then
 	chmod +x Godot.app/Contents/MacOS/Godot
 	popd
 else
-	if [ "$OSTYPE" = "msys" ] || [ "$RUNNER_OS" = "Windows" ]; then
+	if [ "$OSTYPE" = "msys" ]; then
 		target="$target vsproj=yes livepp=$LIVEPP"
 	fi
 	scons $target compiledb=yes custom_modules="../spine_godot" --jobs=$cpus

--- a/spine-godot/spine_godot/SpineCommon.h
+++ b/spine-godot/spine_godot/SpineCommon.h
@@ -123,6 +123,9 @@ class SpineObjectWrapper : public REFCOUNTED {
 
 	Object *spine_owner;
 	void *spine_object;
+#if VERSION_MAJOR <= 3
+	ObjectID spine_owner_id;
+#endif
 
 protected:
 	static void _bind_methods() {
@@ -141,6 +144,15 @@ protected:
 	SpineObjectWrapper() : spine_owner(nullptr), spine_object(nullptr) {
 	}
 
+#if VERSION_MAJOR <= 3
+	~SpineObjectWrapper() {
+		if (!spine_object) return;
+		auto owner = ObjectDB::get_instance(spine_owner_id);
+		if (!owner) return;
+		owner->disconnect(SNAME("_internal_spine_objects_invalidated"), this, SNAME("_internal_spine_objects_invalidated"));
+	}
+#endif
+
 	template<typename OWNER, typename OBJECT>
 	void _set_spine_object_internal(const OWNER *_owner, OBJECT *_object) {
 		if (spine_owner) {
@@ -157,6 +169,9 @@ protected:
 		}
 
 		spine_owner = (Object *) _owner;
+#if VERSION_MAJOR <= 3
+		spine_owner_id = spine_owner->get_instance_id();
+#endif
 		spine_object = _object;
 #if VERSION_MAJOR > 3
 		spine_owner->connect(SNAME("_internal_spine_objects_invalidated"), callable_mp(this, &SpineObjectWrapper::spine_objects_invalidated));

--- a/spine-godot/spine_godot/SpineSkeleton.cpp
+++ b/spine-godot/spine_godot/SpineSkeleton.cpp
@@ -99,6 +99,8 @@ SpineSkeleton::~SpineSkeleton() {
 void SpineSkeleton::set_spine_sprite(SpineSprite *_sprite) {
 	delete skeleton;
 	skeleton = nullptr;
+	_cached_bones.clear();
+	_cached_slots.clear();
 	sprite = _sprite;
 	if (!sprite || !sprite->get_skeleton_data_res().is_valid() || !sprite->get_skeleton_data_res()->is_skeleton_data_loaded()) return;
 	skeleton = new spine::Skeleton(*sprite->get_skeleton_data_res()->get_skeleton_data());

--- a/spine-godot/spine_godot/SpineSkeleton.cpp
+++ b/spine-godot/spine_godot/SpineSkeleton.cpp
@@ -310,10 +310,10 @@ Array SpineSkeleton::get_ik_constraints() {
 	int size = 0;
 	for (int i = 0; i < constraints.size(); ++i) {
 		auto constraint = constraints[i];
-		if (!constraint->getRTTI().isExactly(spine::IkConstraint::rtti) == false) continue;
+		if (!constraint->getRTTI().isExactly(spine::IkConstraint::rtti)) continue;
 		Ref<SpineIkConstraint> constraint_ref(memnew(SpineIkConstraint));
 		constraint_ref->set_spine_object(sprite, static_cast<spine::IkConstraint *>(constraint));
-		result[i] = constraint_ref;
+		result[size] = constraint_ref;
 		size++;
 	}
 	result.resize(size);
@@ -328,10 +328,10 @@ Array SpineSkeleton::get_transform_constraints() {
 	int size = 0;
 	for (int i = 0; i < constraints.size(); ++i) {
 		auto constraint = constraints[i];
-		if (!constraint->getRTTI().isExactly(spine::TransformConstraint::rtti) == false) continue;
+		if (!constraint->getRTTI().isExactly(spine::TransformConstraint::rtti)) continue;
 		Ref<SpineTransformConstraint> constraint_ref(memnew(SpineTransformConstraint));
 		constraint_ref->set_spine_object(sprite, static_cast<spine::TransformConstraint *>(constraint));
-		result[i] = constraint_ref;
+		result[size] = constraint_ref;
 		size++;
 	}
 	result.resize(size);
@@ -346,10 +346,10 @@ Array SpineSkeleton::get_path_constraints() {
 	int size = 0;
 	for (int i = 0; i < constraints.size(); ++i) {
 		auto constraint = constraints[i];
-		if (!constraint->getRTTI().isExactly(spine::PathConstraint::rtti) == false) continue;
+		if (!constraint->getRTTI().isExactly(spine::PathConstraint::rtti)) continue;
 		Ref<SpinePathConstraint> constraint_ref(memnew(SpinePathConstraint));
 		constraint_ref->set_spine_object(sprite, static_cast<spine::PathConstraint *>(constraint));
-		result[i] = constraint_ref;
+		result[size] = constraint_ref;
 		size++;
 	}
 	result.resize(size);

--- a/spine-godot/spine_godot/SpineSkin.cpp
+++ b/spine-godot/spine_godot/SpineSkin.cpp
@@ -81,7 +81,7 @@ void SpineSkin::set_attachment(int slot_index, const String &placeholder, Ref<Sp
 Ref<SpineAttachment> SpineSkin::get_attachment(int slot_index, const String &placeholder) {
 	SPINE_CHECK(get_spine_object(), nullptr)
 	auto attachment = get_spine_object()->getAttachment(slot_index, SPINE_STRING(placeholder));
-	if (attachment) return nullptr;
+	if (!attachment) return nullptr;
 	Ref<SpineAttachment> attachment_ref(memnew(SpineAttachment));
 	attachment_ref->set_spine_object(get_spine_owner(), attachment);
 	return attachment_ref;

--- a/spine-godot/spine_godot/SpineSlotNode.cpp
+++ b/spine-godot/spine_godot/SpineSlotNode.cpp
@@ -65,20 +65,20 @@ void SpineSlotNode::_bind_methods() {
 				 "get_screen_material");
 }
 
-SpineSlotNode::SpineSlotNode() : slot_index(-1) {
+SpineSlotNode::SpineSlotNode() : slot_index(-1), spine_sprite(nullptr) {
 }
 
 void SpineSlotNode::_notification(int what) {
 	switch (what) {
 		case NOTIFICATION_PARENTED: {
-			SpineSprite *sprite = cast_to<SpineSprite>(get_parent());
-			if (sprite) {
+			spine_sprite = cast_to<SpineSprite>(get_parent());
+			if (spine_sprite) {
 #if VERSION_MAJOR > 3
-				sprite->connect(SNAME("world_transforms_changed"), callable_mp(this, &SpineSlotNode::on_world_transforms_changed));
+				spine_sprite->connect(SNAME("world_transforms_changed"), callable_mp(this, &SpineSlotNode::on_world_transforms_changed));
 #else
-				sprite->connect(SNAME("world_transforms_changed"), this, SNAME("_on_world_transforms_changed"));
+				spine_sprite->connect(SNAME("world_transforms_changed"), this, SNAME("_on_world_transforms_changed"));
 #endif
-				update_transform(sprite);
+				update_transform(spine_sprite);
 #if VERSION_MAJOR == 3
 				_change_notify("transform/translation");
 				_change_notify("transform/rotation");
@@ -95,13 +95,13 @@ void SpineSlotNode::_notification(int what) {
 			break;
 		}
 		case NOTIFICATION_UNPARENTED: {
-			SpineSprite *sprite = cast_to<SpineSprite>(get_parent());
-			if (sprite) {
+			if (spine_sprite) {
 #if VERSION_MAJOR > 3
-				sprite->disconnect(SNAME("world_transforms_changed"), callable_mp(this, &SpineSlotNode::on_world_transforms_changed));
+				spine_sprite->disconnect(SNAME("world_transforms_changed"), callable_mp(this, &SpineSlotNode::on_world_transforms_changed));
 #else
-				sprite->disconnect(SNAME("world_transforms_changed"), this, SNAME("_on_world_transforms_changed"));
+				spine_sprite->disconnect(SNAME("world_transforms_changed"), this, SNAME("_on_world_transforms_changed"));
 #endif
+				spine_sprite = nullptr;
 			}
 			break;
 		}

--- a/spine-godot/spine_godot/SpineSlotNode.h
+++ b/spine-godot/spine_godot/SpineSlotNode.h
@@ -44,6 +44,7 @@ class SpineSlotNode : public Node2D {
 protected:
 	String slot_name;
 	int slot_index;
+	SpineSprite *spine_sprite;
 	Ref<Material> normal_material;
 	Ref<Material> additive_material;
 	Ref<Material> multiply_material;

--- a/spine-godot/spine_godot/SpineSprite.cpp
+++ b/spine-godot/spine_godot/SpineSprite.cpp
@@ -629,6 +629,8 @@ void SpineSprite::remove_meshes() {
 }
 
 void SpineSprite::sort_slot_nodes() {
+	if (get_child_count() <= (int) mesh_instances.size()) return;
+
 	for (int i = 0; i < (int) slot_nodes.size(); i++) {
 		slot_nodes[i].setSize(0, nullptr);
 	}
@@ -638,7 +640,7 @@ void SpineSprite::sort_slot_nodes() {
 		auto child = cast_to<Node2D>(get_child(i));
 		if (!child) continue;
 		// Needed so that debug drawables are rendered in front of attachments and other nodes under the sprite.
-		child->set_draw_behind_parent(true);
+		if (!child->is_draw_behind_parent_enabled()) child->set_draw_behind_parent(true);
 		auto slot_node = Object::cast_to<SpineSlotNode>(get_child(i));
 		if (!slot_node) continue;
 		if (slot_node->get_slot_index() == -1 || slot_node->get_slot_index() >= (int) draw_order.size()) {
@@ -653,7 +655,7 @@ void SpineSprite::sort_slot_nodes() {
 		spine::Array<SpineSlotNode *> &nodes = slot_nodes[slot_index];
 		for (int j = 0; j < (int) nodes.size(); j++) {
 			auto node = nodes[j];
-			move_child(node, mesh_index + 1);
+			if (node->get_index() != mesh_index + 1) move_child(node, mesh_index + 1);
 		}
 	}
 }

--- a/spine-godot/spine_godot/SpineSprite.cpp
+++ b/spine-godot/spine_godot/SpineSprite.cpp
@@ -1038,7 +1038,7 @@ void createLinesFromMesh(Vector<Vector2> &scratch_points, spine::Array<unsigned 
 }
 
 void SpineSprite::draw() {
-	if (!animation_state.is_valid() && !skeleton.is_valid()) return;
+	if (!skeleton.is_valid()) return;
 	if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) return;
 
 	auto &statics = SpineSpriteStatics::instance();
@@ -1371,7 +1371,7 @@ void SpineSprite::callback(spine::AnimationState *state, spine::EventType type, 
 }
 
 Transform2D SpineSprite::get_global_bone_transform(const String &bone_name) {
-	if (!animation_state.is_valid() && !skeleton.is_valid()) return get_global_transform();
+	if (!skeleton.is_valid()) return get_global_transform();
 	auto bone = skeleton->find_bone(bone_name);
 	if (!bone.is_valid()) {
 		return get_global_transform();
@@ -1380,7 +1380,7 @@ Transform2D SpineSprite::get_global_bone_transform(const String &bone_name) {
 }
 
 void SpineSprite::set_global_bone_transform(const String &bone_name, Transform2D transform) {
-	if (!animation_state.is_valid() && !skeleton.is_valid()) return;
+	if (!skeleton.is_valid()) return;
 	auto bone = skeleton->find_bone(bone_name);
 	if (!bone.is_valid()) return;
 	bone->set_global_transform(transform);

--- a/spine-godot/spine_godot/SpineSprite.cpp
+++ b/spine-godot/spine_godot/SpineSprite.cpp
@@ -1272,14 +1272,16 @@ void SpineSprite::draw() {
 	draw_set_transform(mouse_position + Vector2(20, 0), -get_global_rotation(),
 					   Vector2(inverse_zoom * (1 / global_scale.x), inverse_zoom * (1 / global_scale.y)));
 
-	Ref<Font> default_font;
-	auto control = memnew(Control);
+	if (!debug_font.is_valid()) {
+		auto control = memnew(Control);
 #if VERSION_MAJOR > 3
-	default_font = control->get_theme_default_font();
+		debug_font = control->get_theme_default_font();
 #else
-	default_font = control->get_font(SNAME("font"), SNAME("Label"));
+		debug_font = control->get_font(SNAME("font"), SNAME("Label"));
 #endif
-	memdelete(control);
+		memdelete(control);
+	}
+	Ref<Font> default_font = debug_font;
 
 #if VERSION_MAJOR > 3
 #ifdef SPINE_GODOT_EXTENSION

--- a/spine-godot/spine_godot/SpineSprite.cpp
+++ b/spine-godot/spine_godot/SpineSprite.cpp
@@ -1281,7 +1281,7 @@ void SpineSprite::draw() {
 #endif
 		memdelete(control);
 	}
-	Ref<Font> default_font = debug_font;
+	const Ref<Font> &default_font = debug_font;
 
 #if VERSION_MAJOR > 3
 #ifdef SPINE_GODOT_EXTENSION

--- a/spine-godot/spine_godot/SpineSprite.h
+++ b/spine-godot/spine_godot/SpineSprite.h
@@ -161,6 +161,7 @@ protected:
 
 	spine::Array<spine::Array<SpineSlotNode *>> slot_nodes;
 	Vector<SpineMesh2D *> mesh_instances;
+	Ref<Font> debug_font;
 	Ref<Material> normal_material;
 	Ref<Material> additive_material;
 	Ref<Material> multiply_material;

--- a/spine-godot/spine_godot/docs/SpineAnimation.xml
+++ b/spine-godot/spine_godot/docs/SpineAnimation.xml
@@ -17,10 +17,12 @@
 			<argument index="3" name="loop" type="bool" />
 			<argument index="4" name="events" type="Array" />
 			<argument index="5" name="alpha" type="float" />
-			<argument index="6" name="blend" type="int" enum="SpineConstant.MixBlend" />
-			<argument index="7" name="direction" type="int" enum="SpineConstant.MixDirection" />
+			<argument index="6" name="from_setup" type="bool" />
+			<argument index="7" name="add" type="bool" />
+			<argument index="8" name="out" type="bool" />
+			<argument index="9" name="appliedPose" type="bool" />
 			<description>
-				Applies the animation's timelines to the specified skeleton.
+				Applies the animation's timelines to the specified skeleton. [code]from_setup[/code] controls whether mixing starts from the setup pose. [code]add[/code] controls whether values are added to the current pose. [code]out[/code] controls the mix direction. [code]appliedPose[/code] controls whether the applied pose is used.
 			</description>
 		</method>
 		<method name="get_duration">

--- a/spine-godot/spine_godot/docs/SpineAnimationState.xml
+++ b/spine-godot/spine_godot/docs/SpineAnimationState.xml
@@ -42,7 +42,7 @@
 		</method>
 		<method name="clear_track">
 			<return type="void" />
-			<argument index="0" name="arg0" type="int" />
+			<argument index="0" name="track_id" type="int" />
 			<description>
 				Removes all animations from the track, leaving skeletons in their current pose.
 				It may be desired to use [code]set_empty_animation()[/code] to mix the skeletons back to the setup pose, rather than leaving them in their current pose.
@@ -67,13 +67,6 @@
 				Resumes the emission of any animation state events.
 			</description>
 		</method>
-		<method name="get_current">
-			<return type="SpineTrackEntry" />
-			<argument index="0" name="track_id" type="int" />
-			<description>
-				Returns the track entry for the animation currently playing on the track, or null if no animation is currently playing.
-			</description>
-		</method>
 		<method name="get_num_tracks">
 			<return type="int" />
 			<description>
@@ -84,6 +77,13 @@
 			<return type="float" />
 			<description>
 				Multiplier for the delta time when the animation state is updated, causing time for all animations and mixes to play slower or faster. Defaults to 1.
+			</description>
+		</method>
+		<method name="get_track">
+			<return type="SpineTrackEntry" />
+			<argument index="0" name="track_id" type="int" />
+			<description>
+				Returns the track entry for the animation currently playing on the track, or null if no animation is currently playing.
 			</description>
 		</method>
 		<method name="set_animation">

--- a/spine-godot/spine_godot/docs/SpineBone.xml
+++ b/spine-godot/spine_godot/docs/SpineBone.xml
@@ -113,13 +113,6 @@
 				Updates this bone. This is called internally when the skeleton's world transform is computed and should typically not be called directly. The physics parameter determines how physics are applied. See [enum SpineConstant.Physics].
 			</description>
 		</method>
-		<method name="apply_world_transform_2d">
-			<return type="void" />
-			<param index="0" name="o" type="Variant" />
-			<description>
-				Applies a world transform to this bone from a Node2D or Bone2D object.
-			</description>
-		</method>
 		<method name="get_transform">
 			<return type="Transform2D" />
 			<description>
@@ -128,7 +121,7 @@
 		</method>
 		<method name="set_transform">
 			<return type="void" />
-			<param index="0" name="transform" type="Transform2D" />
+			<param index="0" name="local_transform" type="Transform2D" />
 			<description>
 				Sets the bone transform to the Godot Transform2D relative to the SpineSprite.
 			</description>
@@ -141,7 +134,7 @@
 		</method>
 		<method name="set_global_transform">
 			<return type="void" />
-			<param index="0" name="trans" type="Transform2D" />
+			<param index="0" name="global_transform" type="Transform2D" />
 			<description>
 				Sets the bone's transform to the global Godot Transform2D.
 			</description>

--- a/spine-godot/spine_godot/docs/SpineConstant.xml
+++ b/spine-godot/spine_godot/docs/SpineConstant.xml
@@ -136,6 +136,15 @@
 		<constant name="BlendMode_Screen" value="3" enum="BlendMode">
 			Screen blending.
 		</constant>
+		<constant name="ScaleYMode_None" value="0" enum="ScaleYMode">
+			No Y-scale mode adjustment.
+		</constant>
+		<constant name="ScaleYMode_Uniform" value="1" enum="ScaleYMode">
+			Uniform Y-scale mode.
+		</constant>
+		<constant name="ScaleYMode_Volume" value="2" enum="ScaleYMode">
+			Volume-preserving Y-scale mode.
+		</constant>
 		<constant name="UpdateMode_Process" value="0" enum="UpdateMode">
 			Update during the process step.
 		</constant>
@@ -162,6 +171,21 @@
 		</constant>
 		<constant name="Physics_Pose" value="3" enum="Physics">
 			Physics are not updated but the pose from physics is applied.
+		</constant>
+		<constant name="MixInterpolation_Linear" value="0" enum="MixInterpolation">
+			Linear interpolation between mix values.
+		</constant>
+		<constant name="MixInterpolation_Smooth" value="1" enum="MixInterpolation">
+			Smooth (ease in/out) interpolation between mix values.
+		</constant>
+		<constant name="MixInterpolation_SlowFast" value="2" enum="MixInterpolation">
+			Slow-to-fast interpolation between mix values.
+		</constant>
+		<constant name="MixInterpolation_FastSlow" value="3" enum="MixInterpolation">
+			Fast-to-slow interpolation between mix values.
+		</constant>
+		<constant name="MixInterpolation_Circle" value="4" enum="MixInterpolation">
+			Circular interpolation between mix values.
 		</constant>
 	</constants>
 </class>

--- a/spine-godot/spine_godot/docs/SpinePathConstraint.xml
+++ b/spine-godot/spine_godot/docs/SpinePathConstraint.xml
@@ -10,6 +10,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_applied_pose">
+			<return type="SpinePathConstraintPose" />
+			<description>
+				The constraint's applied pose data.
+			</description>
+		</method>
 		<method name="get_bones">
 			<return type="Array" />
 			<description>
@@ -22,45 +28,16 @@
 				The path constraint's setup pose data.
 			</description>
 		</method>
-		<method name="get_mix_rotate">
-			<return type="float" />
+		<method name="get_pose">
+			<return type="SpinePathConstraintPose" />
 			<description>
-				A percentage (0-1) that controls the mix between the constrained and unconstrained rotation.
+				The constraint's pose data.
 			</description>
 		</method>
-		<method name="get_mix_x">
-			<return type="float" />
-			<description>
-				A percentage (0-1) that controls the mix between the constrained and unconstrained translation X.
-			</description>
-		</method>
-		<method name="get_mix_y">
-			<return type="float" />
-			<description>
-				A percentage (0-1) that controls the mix between the constrained and unconstrained translation Y.
-			</description>
-		</method>
-		<method name="get_order">
-			<return type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="get_position">
-			<return type="float" />
-			<description>
-				The position along the path.
-			</description>
-		</method>
-		<method name="get_spacing">
-			<return type="float" />
-			<description>
-				The spacing between bones.
-			</description>
-		</method>
-		<method name="get_target">
+		<method name="get_slot">
 			<return type="SpineSlot" />
 			<description>
-				The slot whose path attachment will be used to constrained the bones.
+				The slot whose path attachment will be used to constrain the bones.
 			</description>
 		</method>
 		<method name="is_active">
@@ -74,37 +51,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_mix_rotate">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_mix_x">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_mix_y">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_position">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_spacing">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_target">
+		<method name="set_slot">
 			<return type="void" />
 			<argument index="0" name="v" type="SpineSlot" />
 			<description>
@@ -112,6 +59,7 @@
 		</method>
 		<method name="update">
 			<return type="void" />
+			<argument index="0" name="skeleton" type="SpineSkeleton" />
 			<description>
 			</description>
 		</method>

--- a/spine-godot/spine_godot/docs/SpineSkeleton.xml
+++ b/spine-godot/spine_godot/docs/SpineSkeleton.xml
@@ -31,11 +31,25 @@
 				Finds a path constraint by comparing each path constraint's name. It is more efficient to cache the results of this method than to call it repeatedly.
 			</description>
 		</method>
+		<method name="find_physics_constraint">
+			<return type="SpinePhysicsConstraint" />
+			<argument index="0" name="constraint_name" type="String" />
+			<description>
+				Finds a physics constraint by comparing each physics constraint's name. It is more efficient to cache the results of this method than to call it repeatedly.
+			</description>
+		</method>
 		<method name="find_slot">
 			<return type="SpineSlot" />
 			<argument index="0" name="slot_name" type="String" />
 			<description>
 				Finds a slot by comparing each slot's name. It is more efficient to cache the results of this method than to call it repeatedly.
+			</description>
+		</method>
+		<method name="find_slider">
+			<return type="SpineSlider" />
+			<argument index="0" name="slider_name" type="String" />
+			<description>
+				Finds a slider by comparing each slider's name. It is more efficient to cache the results of this method than to call it repeatedly.
 			</description>
 		</method>
 		<method name="find_transform_constraint">
@@ -105,6 +119,12 @@
 				The skeleton's path constraints. Modifying the array has no effect.
 			</description>
 		</method>
+		<method name="get_physics_constraints">
+			<return type="Array" />
+			<description>
+				The skeleton's physics constraints. Modifying the array has no effect.
+			</description>
+		</method>
 		<method name="get_root_bone">
 			<return type="SpineBone" />
 			<description>
@@ -131,10 +151,22 @@
 				The skeleton's current skin.
 			</description>
 		</method>
+		<method name="get_sliders">
+			<return type="Array" />
+			<description>
+				The skeleton's sliders. Modifying the array has no effect.
+			</description>
+		</method>
 		<method name="get_slots">
 			<return type="Array" />
 			<description>
 				The skeleton's slots. Modifying the array has no effect.
+			</description>
+		</method>
+		<method name="get_time">
+			<return type="float" />
+			<description>
+				Returns the skeleton's current time. This is used to evaluate physics constraints.
 			</description>
 		</method>
 		<method name="get_transform_constraints">
@@ -153,8 +185,25 @@
 		<method name="get_y">
 			<return type="float" />
 			<description>
-				Sets the skeleton Y position, which is added to the root bone worldX position. Relative to the [code]SpineSprite[/code].
+				Sets the skeleton Y position, which is added to the root bone worldY position. Relative to the [code]SpineSprite[/code].
 				Bones that do not inherit translation are still affected by this property.
+			</description>
+		</method>
+		<method name="physics_rotate">
+			<return type="void" />
+			<argument index="0" name="x" type="float" />
+			<argument index="1" name="y" type="float" />
+			<argument index="2" name="degrees" type="float" />
+			<description>
+				Calls [code]PhysicsConstraint.rotate()[/code] for each physics constraint with the specified position and rotation.
+			</description>
+		</method>
+		<method name="physics_translate">
+			<return type="void" />
+			<argument index="0" name="x" type="float" />
+			<argument index="1" name="y" type="float" />
+			<description>
+				Calls [code]PhysicsConstraint.translate()[/code] for each physics constraint with the specified position.
 			</description>
 		</method>
 		<method name="set_attachment">
@@ -224,6 +273,13 @@
 				Sets the slots and draw order to their setup pose values.
 			</description>
 		</method>
+		<method name="set_time">
+			<return type="void" />
+			<argument index="0" name="time" type="float" />
+			<description>
+				Sets the skeleton's current time. This is used to evaluate physics constraints.
+			</description>
+		</method>
 		<method name="set_to_setup_pose">
 			<return type="void" />
 			<description>
@@ -242,12 +298,20 @@
 			<return type="void" />
 			<argument index="0" name="v" type="float" />
 			<description>
-				Sets the skeleton Y position, which is added to the root bone worldX position.
+				Sets the skeleton Y position, which is added to the root bone worldY position.
 				Bones that do not inherit translation are still affected by this property.
+			</description>
+		</method>
+		<method name="update">
+			<return type="void" />
+			<argument index="0" name="delta" type="float" />
+			<description>
+				Increments the skeleton's time and updates physics constraints.
 			</description>
 		</method>
 		<method name="update_world_transform">
 			<return type="void" />
+			<argument index="0" name="physics" type="int" enum="SpineConstant.Physics" />
 			<description>
 				Updates the world transform for each bone and applies all constraints.
 				See [url]http://esotericsoftware.com/spine-runtime-skeletons#World-transforms[/url] in the Spine Runtimes Guide.

--- a/spine-godot/spine_godot/docs/SpineSkeletonDataResource.xml
+++ b/spine-godot/spine_godot/docs/SpineSkeletonDataResource.xml
@@ -45,6 +45,13 @@
 				Finds a path constraint by comparing each path constraint's name. It is more efficient to cache the results of this method than to call it multiple times.
 			</description>
 		</method>
+		<method name="find_physics_constraint_data" qualifiers="const">
+			<return type="SpinePhysicsConstraintData" />
+			<argument index="0" name="constraint_name" type="String" />
+			<description>
+				Finds a physics constraint by comparing each physics constraint's name. It is more efficient to cache the results of this method than to call it multiple times.
+			</description>
+		</method>
 		<method name="find_skin" qualifiers="const">
 			<return type="SpineSkin" />
 			<argument index="0" name="skin_name" type="String" />
@@ -133,6 +140,18 @@
 				The skeleton's path constraints. Modifying the array has no effect.
 			</description>
 		</method>
+		<method name="get_physics_constraints" qualifiers="const">
+			<return type="Array" />
+			<description>
+				The skeleton's physics constraints. Returns an Array of SpinePhysicsConstraintData. Modifying the array has no effect.
+			</description>
+		</method>
+		<method name="get_reference_scale" qualifiers="const">
+			<return type="float" />
+			<description>
+				The reference scale of the skeleton data as defined in Spine.
+			</description>
+		</method>
 		<method name="get_skeleton_name" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -192,6 +211,19 @@
 			<argument index="0" name="skin" type="SpineSkin" />
 			<description>
 				Sets the skeleton's default skin.
+			</description>
+		</method>
+		<method name="set_reference_scale">
+			<return type="void" />
+			<argument index="0" name="reference_scale" type="float" />
+			<description>
+				Sets the reference scale of the skeleton data.
+			</description>
+		</method>
+		<method name="update_skeleton_data">
+			<return type="void" />
+			<description>
+				Reloads the skeleton data from the assigned atlas and skeleton file resources. Call this after changing atlas_res or skeleton_file_res programmatically.
 			</description>
 		</method>
 	</methods>

--- a/spine-godot/spine_godot/docs/SpineSliderData.xml
+++ b/spine-godot/spine_godot/docs/SpineSliderData.xml
@@ -78,6 +78,32 @@
 				Sets the offset value for this slider.
 			</description>
 		</method>
+		<method name="get_max">
+			<return type="float" />
+			<description>
+				Returns the maximum value for this slider.
+			</description>
+		</method>
+		<method name="set_max">
+			<return type="void" />
+			<param index="0" name="value" type="float" />
+			<description>
+				Sets the maximum value for this slider.
+			</description>
+		</method>
+		<method name="get_local">
+			<return type="bool" />
+			<description>
+				Returns whether this slider operates in local space.
+			</description>
+		</method>
+		<method name="set_local">
+			<return type="void" />
+			<param index="0" name="value" type="bool" />
+			<description>
+				Sets whether this slider operates in local space.
+			</description>
+		</method>
 		<method name="get_setup_pose">
 			<return type="SpineSliderPose" />
 			<description>

--- a/spine-godot/spine_godot/docs/SpineSlot.xml
+++ b/spine-godot/spine_godot/docs/SpineSlot.xml
@@ -7,6 +7,12 @@
 		Stores a slot's current pose. Slots organize attachments for skeleton draw order purposes and provide a place to store state for an attachment. State cannot be stored in an attachment itself because attachments are stateless and may be shared across multiple skeletons.
 	</description>
 	<methods>
+		<method name="set_to_setup_pose">
+			<return type="void" />
+			<description>
+				Sets this slot to the setup pose.
+			</description>
+		</method>
 		<method name="get_data">
 			<return type="SpineSlotData" />
 			<description>
@@ -25,103 +31,10 @@
 				Returns the current pose for this slot, containing color, attachment, and deform data.
 			</description>
 		</method>
-		<method name="get_color">
-			<return type="Color" />
+		<method name="get_applied_pose">
+			<return type="SpineSlotPose" />
 			<description>
-				Returns the color used to tint the slot's attachment. If dark color is set, this is used as the light color for two color tinting.
-			</description>
-		</method>
-		<method name="set_color">
-			<return type="void" />
-			<param index="0" name="v" type="Color" />
-			<description>
-				Sets the color used to tint the slot's attachment. If dark color is set, this is used as the light color for two color tinting.
-			</description>
-		</method>
-		<method name="get_dark_color">
-			<return type="Color" />
-			<description>
-				Returns the dark color used to tint the slot's attachment for two color tinting, or null if two color tinting is not used. The dark color's alpha is not used.
-			</description>
-		</method>
-		<method name="set_dark_color">
-			<return type="void" />
-			<param index="0" name="v" type="Color" />
-			<description>
-				Sets the dark color used to tint the slot's attachment for two color tinting. The dark color's alpha is not used.
-			</description>
-		</method>
-		<method name="has_dark_color">
-			<return type="bool" />
-			<description>
-				Returns whether the slot has a dark color for two color tinting.
-			</description>
-		</method>
-		<method name="set_has_dark_color">
-			<return type="void" />
-			<param index="0" name="v" type="bool" />
-			<description>
-				Sets whether the slot has a dark color for two color tinting.
-			</description>
-		</method>
-		<method name="get_attachment">
-			<return type="SpineAttachment" />
-			<description>
-				Returns the current attachment for the slot, or null if the slot has no attachment.
-			</description>
-		</method>
-		<method name="set_attachment">
-			<return type="void" />
-			<param index="0" name="v" type="SpineAttachment" />
-			<description>
-				Sets the slot's attachment and, if the attachment changed, resets sequence_index and clears the deform. The deform is not cleared if the old attachment has the same timeline attachment as the specified attachment.
-			</description>
-		</method>
-		<method name="get_sequence_index">
-			<return type="int" />
-			<description>
-				Returns the index of the texture region to display when the slot's attachment has a Sequence. -1 represents the setup index.
-			</description>
-		</method>
-		<method name="set_sequence_index">
-			<return type="void" />
-			<param index="0" name="v" type="int" />
-			<description>
-				Sets the index of the texture region to display when the slot's attachment has a Sequence. -1 represents the setup index.
-			</description>
-		</method>
-		<method name="get_attachment_state">
-			<return type="int" />
-			<description>
-				Returns the attachment state for this slot.
-			</description>
-		</method>
-		<method name="set_attachment_state">
-			<return type="void" />
-			<param index="0" name="v" type="int" />
-			<description>
-				Sets the attachment state for this slot.
-			</description>
-		</method>
-		<method name="get_deform">
-			<return type="PackedFloat32Array" />
-			<description>
-				Returns values to deform the slot's attachment. For an unweighted mesh, the entries are local positions for each vertex. For a weighted mesh, the entries are an offset for each vertex which will be added to the mesh's local vertex positions.
-
-				See VertexAttachment.computeWorldVertices and DeformTimeline.
-			</description>
-		</method>
-		<method name="set_deform">
-			<return type="void" />
-			<param index="0" name="v" type="PackedFloat32Array" />
-			<description>
-				Sets values to deform the slot's attachment. For an unweighted mesh, the entries are local positions for each vertex. For a weighted mesh, the entries are an offset for each vertex which will be added to the mesh's local vertex positions.
-			</description>
-		</method>
-		<method name="set_to_setup_pose">
-			<return type="void" />
-			<description>
-				Sets this slot to the setup pose.
+				Returns the applied pose for this slot, containing color, attachment, and deform data as last applied by the animation state.
 			</description>
 		</method>
 	</methods>

--- a/spine-godot/spine_godot/docs/SpineSprite.xml
+++ b/spine-godot/spine_godot/docs/SpineSprite.xml
@@ -39,6 +39,12 @@
 				Returns the skeleton.
 			</description>
 		</method>
+		<method name="get_time_scale">
+			<return type="float" />
+			<description>
+				Returns the time scale applied to animation state and skeleton updates.
+			</description>
+		</method>
 		<method name="new_skin">
 			<return type="SpineSkin" />
 			<argument index="0" name="name" type="String" />
@@ -57,6 +63,13 @@
 			<argument index="1" name="global_transform" type="Transform2D" />
 			<description>
 				Sets a bone's global transform. This must be done before the skeleton world transforms are computed.
+			</description>
+		</method>
+		<method name="set_time_scale">
+			<return type="void" />
+			<argument index="0" name="v" type="float" />
+			<description>
+				Sets the time scale applied to animation state and skeleton updates.
 			</description>
 		</method>
 		<method name="update_skeleton">
@@ -100,9 +113,15 @@
 		</member>
 		<member name="regions_color" type="Color" setter="set_debug_regions_color" getter="get_debug_regions_color" default="Color( 0, 0, 1, 0.5 )">
 		</member>
+		<member name="root" type="bool" setter="set_debug_root" getter="get_debug_root" default="false">
+		</member>
+		<member name="root_color" type="Color" setter="set_debug_root_color" getter="get_debug_root_color" default="Color( 1, 1, 1, 0.5 )">
+		</member>
 		<member name="screen_material" type="Material" setter="set_screen_material" getter="get_screen_material">
 		</member>
 		<member name="skeleton_data_res" type="SpineSkeletonDataResource" setter="set_skeleton_data_res" getter="get_skeleton_data_res">
+		</member>
+		<member name="time_scale" type="float" setter="set_time_scale" getter="get_time_scale" default="1.0">
 		</member>
 		<member name="update_mode" type="int" setter="set_update_mode" getter="get_update_mode" enum="SpineConstant.UpdateMode" default="0">
 		</member>

--- a/spine-godot/spine_godot/docs/SpineTrackEntry.xml
+++ b/spine-godot/spine_godot/docs/SpineTrackEntry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="SpineTrackEntry" inherits="SpineObjectWrapper" version="3.4">
+<class name="SpineTrackEntry" inherits="SpineObjectWrapper" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>
@@ -9,11 +9,10 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_alpha">
-			<return type="float" />
+		<method name="get_track_index">
+			<return type="int" />
 			<description>
-				Values &lt; 1 mix this animation with the skeleton's current pose (usually the pose resulting from lower tracks). Defaults to 1, which overwrites the skeleton's current pose with this animation.
-				Typically track 0 is used to completely pose the skeleton, then alpha is used on higher tracks. It doesn't make sense to use alpha on track 0 if the skeleton pose is from the last frame render.
+				The index of the track where this track entry is either current or queued.
 			</description>
 		</method>
 		<method name="get_animation">
@@ -22,36 +21,59 @@
 				The animation to apply for this track entry.
 			</description>
 		</method>
-		<method name="get_animation_end">
-			<return type="float" />
+		<method name="get_previous">
+			<return type="SpineTrackEntry" />
 			<description>
-				Seconds for the last frame of this animation. Non-looping animations won't play past this time. Looping animations will loop back to animation start at this time. Defaults to the animation duration.
+				The animation queued to play before this animation, or null. previous makes up a doubly linked list.
 			</description>
 		</method>
-		<method name="get_animation_last">
-			<return type="float" />
+		<method name="get_loop">
+			<return type="bool" />
 			<description>
-				The time in seconds this animation was last applied. Some timelines use this for one-time triggers. Eg, when this animation is applied, event timelines will fire all events between the [code]animationLast[/code] time (exclusive) and [code]animationTime[/code](inclusive). Defaults to -1 to ensure triggers on frame 0 happen the first time this animation is applied.
+				If true, the animation will repeat. If false it will not, instead its last frame is applied if played beyond its duration.
 			</description>
 		</method>
-		<method name="get_animation_start">
-			<return type="float" />
+		<method name="set_loop">
+			<return type="void" />
+			<param index="0" name="v" type="bool" />
 			<description>
-				Seconds when this animation starts, both initially and after looping. Defaults to 0.
-				When changing the animation start time, it often makes sense to set animation last to the same value to prevent timeline keys before the start time from triggering.
 			</description>
 		</method>
-		<method name="get_animation_time">
-			<return type="float" />
+		<method name="get_additive">
+			<return type="bool" />
 			<description>
-				Uses [code]get_track_time()[/code] to compute the animation time. When the track time is 0, the animation time is equal to the animation start time.
-				The animation time is between [code]get_animation_start()[/code] and [code]get_animation_end()[/code], except if this track entry is non-looping and [code]get_animation_end()[/code] is &gt;= to the animation duration, then animation time continues to increase past [code]get_animation_end()[/code].
+				If true, the animation will be applied additively, adding to the current pose rather than replacing it.
 			</description>
 		</method>
-		<method name="get_attachment_threshold">
-			<return type="float" />
+		<method name="set_additive">
+			<return type="void" />
+			<param index="0" name="v" type="bool" />
 			<description>
-				When the mix percentage ([code]get_mix_time()[/code] / [code]get_mix_duration()[/code]) is less than the attachment threshold, attachment timelines are applied while this animation is being mixed out. Defaults to 0, so attachment timelines are not applied while this animation is being mixed out.
+			</description>
+		</method>
+		<method name="get_reverse">
+			<return type="bool" />
+			<description>
+				If true, the animation will be applied in reverse. Events are not fired when an animation is applied in reverse.
+			</description>
+		</method>
+		<method name="set_reverse">
+			<return type="void" />
+			<param index="0" name="v" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="get_shortest_rotation">
+			<return type="bool" />
+			<description>
+				If true, mixing rotation between tracks always uses the shortest rotation direction. If the rotation is animated, the shortest rotation direction may change during the mix.
+				If false, the shortest rotation direction is remembered when the mix starts and the same direction is used for the rest of the mix. Defaults to false.
+			</description>
+		</method>
+		<method name="set_shortest_rotation">
+			<return type="void" />
+			<param index="0" name="v" type="bool" />
+			<description>
 			</description>
 		</method>
 		<method name="get_delay">
@@ -62,10 +84,108 @@
 				When using [code]AnimationState.add_animation()[/code] with a delay &lt;= 0, the delay is set using the mix duration from the skeleton data resource. If mix duration is set afterward, the delay may need to be adjusted.
 			</description>
 		</method>
-		<method name="get_draw_order_threshold">
+		<method name="set_delay">
+			<return type="void" />
+			<param index="0" name="v" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="get_track_time">
 			<return type="float" />
 			<description>
-				When the mix percentage ([code]get_mix_time()[/code] / [code]get_mix_duration()[/code]) is less than the draw order threshold, draw order timelines are applied while this animation is being mixed out. Defaults to 0, so draw order timelines are not applied while this animation is being mixed out.
+				Current time in seconds this track entry has been the current track entry. The track time determines [code]get_animation_time()[/code]. The track time can be set to start the animation at a time other than 0, without affecting looping.
+			</description>
+		</method>
+		<method name="set_track_time">
+			<return type="void" />
+			<param index="0" name="v" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="get_track_end">
+			<return type="float" />
+			<description>
+				The track time in seconds when this animation will be removed from the track. Defaults to the highest possible float value, meaning the animation will be applied until a new animation is set or the track is cleared. If the track end time is reached, no other animations are queued for playback, and mixing from any previous animations is complete, then the properties keyed by the animation are set to the setup pose and the track is cleared.
+				It may be desired to use [code]AnimationState.add_empty_animation()[/code] rather than have the animation abruptly cease being applied.
+			</description>
+		</method>
+		<method name="set_track_end">
+			<return type="void" />
+			<param index="0" name="v" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="get_animation_start">
+			<return type="float" />
+			<description>
+				Seconds when this animation starts, both initially and after looping. Defaults to 0.
+				When changing the animation start time, it often makes sense to set animation last to the same value to prevent timeline keys before the start time from triggering.
+			</description>
+		</method>
+		<method name="set_animation_start">
+			<return type="void" />
+			<param index="0" name="v" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="get_animation_end">
+			<return type="float" />
+			<description>
+				Seconds for the last frame of this animation. Non-looping animations won't play past this time. Looping animations will loop back to animation start at this time. Defaults to the animation duration.
+			</description>
+		</method>
+		<method name="set_animation_end">
+			<return type="void" />
+			<param index="0" name="v" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="get_animation_last">
+			<return type="float" />
+			<description>
+				The time in seconds this animation was last applied. Some timelines use this for one-time triggers. Eg, when this animation is applied, event timelines will fire all events between the [code]animationLast[/code] time (exclusive) and [code]animationTime[/code] (inclusive). Defaults to -1 to ensure triggers on frame 0 happen the first time this animation is applied.
+			</description>
+		</method>
+		<method name="set_animation_last">
+			<return type="void" />
+			<param index="0" name="v" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="get_animation_time">
+			<return type="float" />
+			<description>
+				Uses [code]get_track_time()[/code] to compute the animation time. When the track time is 0, the animation time is equal to the animation start time.
+				The animation time is between [code]get_animation_start()[/code] and [code]get_animation_end()[/code], except if this track entry is non-looping and [code]get_animation_end()[/code] is &gt;= to the animation duration, then animation time continues to increase past [code]get_animation_end()[/code].
+			</description>
+		</method>
+		<method name="get_time_scale">
+			<return type="float" />
+			<description>
+				Multiplier for the delta time when this track entry is updated, causing time for this animation to pass slower or faster. Defaults to 1.
+				Values &lt; 0 are not supported. To play an animation in reverse, use [code]get_reverse()[/code].
+				[code]get_mix_time()[/code] is not affected by track entry time scale, so [code]get_mix_duration()[/code] may need to be adjusted to match the animation speed.
+				When using [code]AnimationState.add_animation()[/code] with a delay &lt;= 0, the delay is set using the mix duration from the skeleton data resource, assuming time scale to be 1. If the time scale is not 1, the delay may need to be adjusted.
+				See [code]AnimationState.get_time_scale()[/code] for affecting all animations.
+			</description>
+		</method>
+		<method name="set_time_scale">
+			<return type="void" />
+			<param index="0" name="v" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="get_alpha">
+			<return type="float" />
+			<description>
+				Values &lt; 1 mix this animation with the skeleton's current pose (usually the pose resulting from lower tracks). Defaults to 1, which overwrites the skeleton's current pose with this animation.
+				Typically track 0 is used to completely pose the skeleton, then alpha is used on higher tracks. It doesn't make sense to use alpha on track 0 if the skeleton pose is from the last frame render.
+			</description>
+		</method>
+		<method name="set_alpha">
+			<return type="void" />
+			<param index="0" name="v" type="float" />
+			<description>
 			</description>
 		</method>
 		<method name="get_event_threshold">
@@ -74,39 +194,105 @@
 				When the mix percentage ([code]get_mix_time()[/code] / [code]get_mix_duration()[/code]) is less than the event threshold, event timelines are applied while this animation is being mixed out. Defaults to 0, so event timelines are not applied while this animation is being mixed out.
 			</description>
 		</method>
-		<method name="get_hold_previous">
-			<return type="bool" />
+		<method name="set_event_threshold">
+			<return type="void" />
+			<param index="0" name="v" type="float" />
 			<description>
-				If true, when mixing from the previous animation to this animation, the previous animation is applied as normal instead of being mixed out.
-				When mixing between animations that key the same property, if a lower track also keys that property then the value will briefly dip toward the lower track value during the mix. This happens because the first animation mixes from 100% to 0% while the second animation mixes from 0% to 100%. Setting hold previous to true applies the first animation at 100% during the mix so the lower track value is overwritten. Such dipping does not occur on the lowest track which keys the property, only when a higher track also keys the property.
-				Snapping will occur if hold previous is true and this animation does not key all the same properties as the previous animation.
 			</description>
 		</method>
-		<method name="get_loop">
-			<return type="bool" />
-			<description>
-				If true, the animation will repeat. If false it will not, instead its last frame is applied if played beyond its duration.
-			</description>
-		</method>
-		<method name="get_mix_blend">
-			<return type="int" enum="SpineConstant.MixBlend" />
-			<description>
-				Controls how properties keyed in the animation are mixed with lower tracks. Defaults to [code]MixBlend.replace[/code]. Track entries on track 0 ignore this setting and always use [code]MixBlend.first[/code].
-				The mix blend can be set for a new track entry only before [code]AnimationState.apply()[/code] is first called.
-			</description>
-		</method>
-		<method name="get_mix_duration">
+		<method name="get_mix_attachment_threshold">
 			<return type="float" />
 			<description>
-				Seconds for mixing from the previous animation to this animation. Defaults to the value provided by the skeleton data resource based on the animation before this animation (if any).
-				A mix duration of 0 still mixes out over one frame to provide the track entry being mixed out a chance to revert the properties it was animating. The mix duration can be set manually rather than use the value from the skeleton data resource. In that case, themix duration can be set for a new track entry only before [code]AnimationState#update()[/code] is first called.
-				When using [code]AnimationState.add_animation()[/code] with a delay &lt;= 0, the delay is set using the mix duration from the skeleton data resource. If mix duration is set afterward, the delay may need to be adjusted.
+				When the mix percentage ([code]get_mix_time()[/code] / [code]get_mix_duration()[/code]) is less than the attachment threshold, attachment timelines are applied while this animation is being mixed out. Defaults to 0, so attachment timelines are not applied while this animation is being mixed out.
+			</description>
+		</method>
+		<method name="set_mix_attachment_threshold">
+			<return type="void" />
+			<param index="0" name="v" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="get_mix_draw_order_threshold">
+			<return type="float" />
+			<description>
+				When the mix percentage ([code]get_mix_time()[/code] / [code]get_mix_duration()[/code]) is less than the draw order threshold, draw order timelines are applied while this animation is being mixed out. Defaults to 0, so draw order timelines are not applied while this animation is being mixed out.
+			</description>
+		</method>
+		<method name="set_mix_draw_order_threshold">
+			<return type="void" />
+			<param index="0" name="v" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="get_alpha_attachment_threshold">
+			<return type="float" />
+			<description>
+				When the alpha value is less than the alpha attachment threshold, attachment timelines are not applied. Defaults to 0.
+			</description>
+		</method>
+		<method name="set_alpha_attachment_threshold">
+			<return type="void" />
+			<param index="0" name="v" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="get_next">
+			<return type="SpineTrackEntry" />
+			<description>
+				The animation queued to start after this animation, or null if there is none. Next makes up a doubly linked list.
+				See [code]AnimationState.clear_next()[/code] to truncate the list.
+			</description>
+		</method>
+		<method name="is_complete">
+			<return type="bool" />
+			<description>
+				Returns true if at least one loop has been completed.
 			</description>
 		</method>
 		<method name="get_mix_time">
 			<return type="float" />
 			<description>
 				Seconds from 0 to the mix duration when mixing from the previous animation to this animation. May be slightly more than mix duration when the mix is complete.
+			</description>
+		</method>
+		<method name="set_mix_time">
+			<return type="void" />
+			<param index="0" name="v" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="get_mix_duration">
+			<return type="float" />
+			<description>
+				Seconds for mixing from the previous animation to this animation. Defaults to the value provided by the skeleton data resource based on the animation before this animation (if any).
+				A mix duration of 0 still mixes out over one frame to provide the track entry being mixed out a chance to revert the properties it was animating. The mix duration can be set manually rather than use the value from the skeleton data resource. In that case, the mix duration can be set for a new track entry only before [code]AnimationState.update()[/code] is first called.
+				When using [code]AnimationState.add_animation()[/code] with a delay &lt;= 0, the delay is set using the mix duration from the skeleton data resource. If mix duration is set afterward, the delay may need to be adjusted.
+			</description>
+		</method>
+		<method name="set_mix_duration">
+			<return type="void" />
+			<param index="0" name="v" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="set_mix_duration_and_delay">
+			<return type="void" />
+			<param index="0" name="v" type="float" />
+			<param index="1" name="delay" type="float" />
+			<description>
+				Sets the mix duration and simultaneously adjusts the delay to keep the mix synchronized. This is a convenience over setting mix duration and delay separately.
+			</description>
+		</method>
+		<method name="get_mix_interpolation">
+			<return type="int" enum="SpineConstant.MixInterpolation" />
+			<description>
+				The interpolation function used for mixing. Defaults to [code]MixInterpolation.linear[/code].
+			</description>
+		</method>
+		<method name="set_mix_interpolation">
+			<return type="void" />
+			<param index="0" name="mix_interpolation" type="int" enum="SpineConstant.MixInterpolation" />
+			<description>
 			</description>
 		</method>
 		<method name="get_mixing_from">
@@ -121,40 +307,11 @@
 				The track entry for the next animation when mixing from this animation to the next animation, or null if no mixing is currently occuring. When mixing to multiple animations, mixing to makes up a linked list.
 			</description>
 		</method>
-		<method name="get_next">
-			<return type="SpineTrackEntry" />
+		<method name="reset_rotation_directions">
+			<return type="void" />
 			<description>
-				The animation queued to start after this animation, or null if there is none. Next makes up a doubly linked list.
-				See [code]AnimationState.clear_next()[/code] to truncate the list.
-			</description>
-		</method>
-		<method name="get_previous">
-			<return type="SpineTrackEntry" />
-			<description>
-				The animation queued to play before this animation, or null. previous makes up a doubly linked list.
-			</description>
-		</method>
-		<method name="get_reverse">
-			<return type="bool" />
-			<description>
-				If true, the animation will be applied in reverse. Events are not fired when an animation is applied in reverse.
-			</description>
-		</method>
-		<method name="get_shortest_rotation">
-			<return type="bool" />
-			<description>
-				If true, mixing rotation between tracks always uses the shortest rotation direction. If the rotation is animated, the shortest rotation direction may change during the mix.
-				If false, the shortest rotation direction is remembered when the mix starts and the same direction is used for the rest of the mix. Defaults to false.
-			</description>
-		</method>
-		<method name="get_time_scale">
-			<return type="float" />
-			<description>
-				Multiplier for the delta time when this track entry is updated, causing time for this animation to pass slower or faster. Defaults to 1.
-				Values &lt; 0 are not supported. To play an animation in reverse, use {@link #getReverse()}.
-				[code]get_mix_time()[/code] is not affected by track entry time scale, so [code]get_mix_duration()[/code] may need to be adjusted to match the animation speed.
-				When using [code]AnimationState.add_animation()[/code]with a delay &lt;= 0, the delay is set using the mix duration from the skeleton data resource, assuming time scale to be 1. If the time scale is not 1, the delay may need to be adjusted.
-				See [code]AnimationState.get_time_scale()[/code] for affecting all animations.
+				Resets the rotation directions for mixing this entry's rotate timelines. This can be useful to avoid bones rotating the long way around when using alpha and starting animations on other tracks.
+				Mixing with [code]MixBlend.replace[/code] involves finding a rotation between two others, which has two possible solutions: the short way or the long way around. The two rotations likely change over time, so which direction is the short or long way also changes. If the short way was always chosen, bones would flip to the other side when that direction became the long way. TrackEntry chooses the short way the first time it is applied and remembers that direction.
 			</description>
 		</method>
 		<method name="get_track_complete">
@@ -163,143 +320,22 @@
 				If this track entry is non-looping, the track time in seconds when [code]get_animation_end()[/code] is reached, or the current [code]get_track_time()[/code] if it has already been reached. If this track entry is looping, the track time when this animation will reach its next [code]get_animation_end()[/code] (the next loop completion).
 			</description>
 		</method>
-		<method name="get_track_end">
-			<return type="float" />
-			<description>
-				The track time in seconds when this animation will be removed from the track. Defaults to the highest possible float value, meaning the animation will be applied until a new animation is set or the track is cleared. If the track end time is reached, no other animations are queued for playback, and mixing from any previous animations is complete, then the properties keyed by the animation are set to the setup pose and the track is cleared.
-				It may be desired to use {@link AnimationState#addEmptyAnimation(int, float, float)} rather than have the animation abruptly cease being applied.
-			</description>
-		</method>
-		<method name="get_track_index">
-			<return type="int" />
-			<description>
-				The index of the track where this track entry is either current or queued.
-			</description>
-		</method>
-		<method name="get_track_time">
-			<return type="float" />
-			<description>
-				Current time in seconds this track entry has been the current track entry. The track time determines [code]get_animation_time()[/code]. The track time can be set to start the animation at a time other than 0, without affecting looping.
-			</description>
-		</method>
-		<method name="is_complete">
+		<method name="was_applied">
 			<return type="bool" />
 			<description>
-				Returns true if at least one loop has been completed.
+				Returns true if this track entry was applied during the last [code]AnimationState.apply()[/code] call.
 			</description>
 		</method>
-		<method name="reset_rotation_directions">
-			<return type="void" />
+		<method name="get_mix_blend">
+			<return type="int" enum="SpineConstant.MixBlend" />
 			<description>
-				Resets the rotation directions for mixing this entry's rotate timelines. This can be useful to avoid bones rotating the long way around when using {@link #alpha} and starting animations on other tracks.
-				Mixing with [code]MixBlend.replace[/code] involves finding a rotation between two others, which has two possible solutions: the short way or the long way around. The two rotations likely change over time, so which direction is the short or long way also changes. If the short way was always chosen, bones would flip to the other side when that direction became the long way. TrackEntry chooses the short way the first time it is applied and remembers that direction.
-			</description>
-		</method>
-		<method name="set_alpha">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_animation_end">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_animation_last">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_animation_start">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_attachment_threshold">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_delay">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_draw_order_threshold">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_event_threshold">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_hold_previous">
-			<return type="void" />
-			<argument index="0" name="v" type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="set_loop">
-			<return type="void" />
-			<argument index="0" name="v" type="bool" />
-			<description>
+				Controls how properties keyed in the animation are mixed with lower tracks. Defaults to [code]MixBlend.replace[/code]. Track entries on track 0 ignore this setting and always use [code]MixBlend.first[/code].
+				The mix blend can be set for a new track entry only before [code]AnimationState.apply()[/code] is first called.
 			</description>
 		</method>
 		<method name="set_mix_blend">
 			<return type="void" />
-			<argument index="0" name="v" type="int" enum="SpineConstant.MixBlend" />
-			<description>
-			</description>
-		</method>
-		<method name="set_mix_duration">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_mix_time">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_reverse">
-			<return type="void" />
-			<argument index="0" name="v" type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="set_shortest_rotation">
-			<return type="void" />
-			<argument index="0" name="v" type="bool" />
-			<description>
-			</description>
-		</method>
-		<method name="set_time_scale">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_track_end">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_track_time">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
+			<param index="0" name="v" type="int" enum="SpineConstant.MixBlend" />
 			<description>
 			</description>
 		</method>

--- a/spine-godot/spine_godot/docs/SpineTransformConstraint.xml
+++ b/spine-godot/spine_godot/docs/SpineTransformConstraint.xml
@@ -4,12 +4,18 @@
 		Stores the current pose for a transform constraint.
 	</brief_description>
 	<description>
-		Stores the current pose for a transform constraint. A transform constraint adjusts the world transform of the constrained bones to match that of the target bone.
+		Stores the current pose for a transform constraint. A transform constraint adjusts the world transform of the constrained bones to match that of the source bone.
 		See [url]http://esotericsoftware.com/spine-transform-constraints[/url] in the Spine User Guide.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_applied_pose">
+			<return type="SpineTransformConstraintPose" />
+			<description>
+				The constraint's applied pose data.
+			</description>
+		</method>
 		<method name="get_bones">
 			<return type="Array" />
 			<description>
@@ -22,46 +28,16 @@
 				The transform constraint's setup pose data.
 			</description>
 		</method>
-		<method name="get_mix_rotate">
-			<return type="float" />
+		<method name="get_pose">
+			<return type="SpineTransformConstraintPose" />
 			<description>
-				A percentage (0-1) that controls the mix between the constrained and unconstrained rotation.
+				The constraint's pose data.
 			</description>
 		</method>
-		<method name="get_mix_scale_x">
-			<return type="float" />
-			<description>
-				A percentage (0-1) that controls the mix between the constrained and unconstrained scale X.
-			</description>
-		</method>
-		<method name="get_mix_scale_y">
-			<return type="float" />
-			<description>
-				A percentage (0-1) that controls the mix between the constrained and unconstrained scale X.
-			</description>
-		</method>
-		<method name="get_mix_shear_y">
-			<return type="float" />
-			<description>
-				A percentage (0-1) that controls the mix between the constrained and unconstrained shear Y.
-			</description>
-		</method>
-		<method name="get_mix_x">
-			<return type="float" />
-			<description>
-				A percentage (0-1) that controls the mix between the constrained and unconstrained translation X.
-			</description>
-		</method>
-		<method name="get_mix_y">
-			<return type="float" />
-			<description>
-				A percentage (0-1) that controls the mix between the constrained and unconstrained translation Y.
-			</description>
-		</method>
-		<method name="get_target">
+		<method name="get_source">
 			<return type="SpineBone" />
 			<description>
-				The target bone whose world transform will be copied to the constrained bones.
+				The source bone whose world transform will be copied to the constrained bones.
 			</description>
 		</method>
 		<method name="is_active">
@@ -75,43 +51,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="set_mix_rotate">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_mix_scale_x">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_mix_scale_y">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_mix_shear_y">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_mix_x">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_mix_y">
-			<return type="void" />
-			<argument index="0" name="v" type="float" />
-			<description>
-			</description>
-		</method>
-		<method name="set_target">
+		<method name="set_source">
 			<return type="void" />
 			<argument index="0" name="v" type="SpineBone" />
 			<description>
@@ -119,6 +59,7 @@
 		</method>
 		<method name="update">
 			<return type="void" />
+			<argument index="0" name="skeleton" type="SpineSkeleton" />
 			<description>
 			</description>
 		</method>


### PR DESCRIPTION
* [X] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).

[Godot] Bug fixes, performance improvements, and documentation updates
Bug fixes
SpineSkin.get_attachment() always returned null — inverted null check caused the function to return null when an attachment was found and crash when it wasn't.

SpineSkeleton.get_ik_constraints(), get_transform_constraints(), get_path_constraints() returned wrong types — a double-negated RTTI filter (!X == false) caused the functions to skip matching constraints and process wrong-type ones instead, producing invalid wrapper objects and crashes on property access. Array packing was also broken (result[i] instead of result[size]), leaving null entries when matching constraints weren't at index 0.

SpineSprite.draw(), get_global_bone_transform(), set_global_bone_transform() could dereference an invalid skeleton — validity guards used && instead of ||, only bailing out when both refs were invalid. Since animation_state is unused in these functions, the guards now check only skeleton.

SpineSlotNode signal not disconnected on unparent (Godot 4) — NOTIFICATION_UNPARENTED fires after the parent pointer is cleared in Godot 4, so get_parent() returned null and the world_transforms_changed disconnect was never called, leaving a dangling connection. The parent is now stored at connect time and used at disconnect time.

SpineObjectWrapper signal connection outlived the wrapper (Godot 3) — in Godot 3, signal connections hold a raw Object* with no reference bump. Dropping the last Ref<> to a wrapper while still connected freed the wrapper but left a live connection on the owner, causing a crash on the next signal emission. A destructor now safely disconnects using ObjectDB::get_instance to guard against an already-freed owner.

Stale bone/slot cache after skeleton rebuild — SpineSkeleton._cached_bones and _cached_slots were not cleared when set_spine_sprite() deleted and rebuilt the skeleton. A new skeleton could reuse the same memory addresses, causing find_bone() and find_slot() to return stale wrappers pointing to freed spine-cpp objects.

Performance improvements
sort_slot_nodes() — reduced per-frame scene-tree churn — the function now early-exits when no user children exist beyond the mesh instances. move_child() is skipped when a node is already at the correct index. set_draw_behind_parent() is skipped when already set. Together these eliminate redundant scene-tree notifications on every frame when draw order is stable.

Debug overlay font lookup — eliminated per-frame heap allocation — the editor hover tooltip previously allocated and immediately freed a Control node on every draw call to obtain the default font. The font is now fetched once and cached for the lifetime of the sprite.

Documentation
Updated 12 XML API documentation files to match the current C++ implementation:

SpineSlot — complete rewrite; the documented flat API (color, attachment, deform getters/setters) was replaced in a prior refactor by get_pose() and get_applied_pose() returning a SpineSlotPose, but the doc was never updated.
SpinePathConstraint — complete rewrite; mix/position/spacing methods removed, pose-based API documented.
SpineTrackEntry — get_attachment_threshold and get_draw_order_threshold renamed to their correct get_mix_* names; get_hold_previous (not bound) removed; 7 missing methods added including get_additive, get_mix_interpolation, was_applied, and set_mix_duration_and_delay.
SpineTransformConstraint — get_target/set_target corrected to get_source/set_source; 6 unbound mix setter/getter pairs removed; get_pose/get_applied_pose and the skeleton argument on update() added.
SpineSkeleton — physics argument added to update_world_transform; 9 missing methods added (find_physics_constraint, find_slider, get_physics_constraints, get_sliders, get_time, set_time, update, physics_translate, physics_rotate); "worldX" typo in get_y/set_y descriptions corrected.
SpineConstant — MixInterpolation (5 values) and ScaleYMode (3 values) enums were missing entirely.
SpineAnimationState — get_current corrected to get_track; clear_track argument name fixed from arg0 to track_id.
SpineSkeletonDataResource — 5 missing methods added: find_physics_constraint_data, get_physics_constraints, get_reference_scale, set_reference_scale, update_skeleton_data.
SpineAnimation — apply() signature corrected from 8 arguments to 10.
SpineSprite — time_scale, debug_root, and debug_root_color properties were missing from the members section.
SpineBone — set_transform and set_global_transform argument names corrected to match their bindings; unbound apply_world_transform_2d removed.
SpineSliderData — 4 missing methods added: get_max, set_max, get_local, set_local.