### PR TITLE
[ios] feat(spine-ios): add per-view texture filter (nearest / linear)

### DIFF
--- a/spine-ios/Sources/SpineiOS/Metal/SpineRenderer.swift
+++ b/spine-ios/Sources/SpineiOS/Metal/SpineRenderer.swift
@@ -81,7 +81,8 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
         commandQueue: MTLCommandQueue,
         pixelFormat: MTLPixelFormat,
         atlasPages: [UIImage],
-        pma: Bool
+        pma: Bool,
+        textureFilter: TextureFilter = .nearest
     ) throws {
         self.device = device
         self.commandQueue = commandQueue
@@ -95,6 +96,7 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
         #endif
 
         let defaultLibrary = try device.makeDefaultLibrary(bundle: bundle)
+        let fragmentFunctionName = Self.fragmentFunctionName(for: textureFilter)
         let textureLoader = MTKTextureLoader(device: device)
         textures =
             try atlasPages
@@ -118,7 +120,7 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
         for blendMode in blendModes {
             let descriptor = MTLRenderPipelineDescriptor()
             descriptor.vertexFunction = defaultLibrary.makeFunction(name: "vertexShader")
-            descriptor.fragmentFunction = defaultLibrary.makeFunction(name: "fragmentShader")
+            descriptor.fragmentFunction = defaultLibrary.makeFunction(name: fragmentFunctionName)
             descriptor.colorAttachments[0].pixelFormat = pixelFormat
             descriptor.colorAttachments[0].apply(
                 blendMode: blendMode,
@@ -307,6 +309,10 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
             )
             vertexStart += vertices.count
         }
+    }
+
+    private static func fragmentFunctionName(for textureFilter: TextureFilter) -> String {
+        textureFilter == .linear ? "fragmentShaderLinear" : "fragmentShader"
     }
 
     private func getPipelineState(blendMode: BlendMode) -> MTLRenderPipelineState? {

--- a/spine-ios/Sources/SpineiOS/Metal/SpineShaders.metal
+++ b/spine-ios/Sources/SpineiOS/Metal/SpineShaders.metal
@@ -56,3 +56,15 @@ fragmentShader(RasterizerData in [[stage_in]],
     
     return simd_float4(colorSample) * in.color;
 }
+
+fragment simd_float4
+fragmentShaderLinear(RasterizerData in [[stage_in]],
+                     texture2d<half> colorTexture [[ texture(SpineTextureIndexBaseColor) ]])
+{
+    constexpr sampler textureSampler (mag_filter::linear,
+                                      min_filter::linear);
+    
+    const half4 colorSample = colorTexture.sample(textureSampler, in.textureCoordinate);
+    
+    return simd_float4(colorSample) * in.color;
+}

--- a/spine-ios/Sources/SpineiOS/SpineUIView.swift
+++ b/spine-ios/Sources/SpineiOS/SpineUIView.swift
@@ -46,6 +46,7 @@ public final class SpineUIView: MTKView {
     let mode: SpineContentMode
     let alignment: SpineAlignment
     let boundsProvider: BoundsProvider
+    public let linearTextureFilter: Bool
 
     internal var computedBounds: CGRect = .zero
     internal var renderer: SpineRenderer?
@@ -55,12 +56,14 @@ public final class SpineUIView: MTKView {
         mode: SpineContentMode = .fit,
         alignment: SpineAlignment = .center,
         boundsProvider: BoundsProvider = SetupPoseBounds(),
-        backgroundColor: UIColor = .clear
+        backgroundColor: UIColor = .clear,
+        linearTextureFilter: Bool = false
     ) {
         self.controller = controller
         self.mode = mode
         self.alignment = alignment
         self.boundsProvider = boundsProvider
+        self.linearTextureFilter = linearTextureFilter
 
         super.init(frame: .zero, device: SpineObjects.shared.device)
         clearColor = MTLClearColor(backgroundColor)
@@ -87,9 +90,10 @@ public final class SpineUIView: MTKView {
         mode: SpineContentMode = .fit,
         alignment: SpineAlignment = .center,
         boundsProvider: BoundsProvider = SetupPoseBounds(),
-        backgroundColor: UIColor = .clear
+        backgroundColor: UIColor = .clear,
+        linearTextureFilter: Bool = false
     ) {
-        self.init(controller: controller, mode: mode, alignment: alignment, boundsProvider: boundsProvider, backgroundColor: backgroundColor)
+        self.init(controller: controller, mode: mode, alignment: alignment, boundsProvider: boundsProvider, backgroundColor: backgroundColor, linearTextureFilter: linearTextureFilter)
         Task.detached(priority: .high) {
             do {
                 let drawable = try await source.loadDrawable()
@@ -153,11 +157,12 @@ public final class SpineUIView: MTKView {
         mode: SpineContentMode = .fit,
         alignment: SpineAlignment = .center,
         boundsProvider: BoundsProvider = SetupPoseBounds(),
-        backgroundColor: UIColor = .clear
+        backgroundColor: UIColor = .clear,
+        linearTextureFilter: Bool = false
     ) {
         self.init(
             from: .file(atlasFile: atlasFile, skeletonFile: skeletonFile), controller: controller, mode: mode, alignment: alignment,
-            boundsProvider: boundsProvider, backgroundColor: backgroundColor)
+            boundsProvider: boundsProvider, backgroundColor: backgroundColor, linearTextureFilter: linearTextureFilter)
     }
 
     /// A convenience initializer that constructs a new ``SpineUIView`` from HTTP.
@@ -255,7 +260,8 @@ extension SpineUIView {
             commandQueue: SpineObjects.shared.commandQueue,
             pixelFormat: colorPixelFormat,
             atlasPages: atlasPages,
-            pma: pmaFlag
+            pma: pmaFlag,
+            textureFilter: linearTextureFilter ? .linear : .nearest
         )
         renderer?.delegate = controller
         renderer?.dataSource = controller

--- a/spine-ios/Sources/SpineiOS/SpineView.swift
+++ b/spine-ios/Sources/SpineiOS/SpineView.swift
@@ -47,6 +47,7 @@ public struct SpineView: UIViewRepresentable {
     private let alignment: SpineAlignment
     private let boundsProvider: BoundsProvider
     private let backgroundColor: UIColor  // Not using `SwiftUI.Color`, as briging to `UIColor` prior iOS 14 might not always work.
+    private let linearTextureFilter: Bool
 
     @Binding
     private var isRendering: Bool?
@@ -65,6 +66,7 @@ public struct SpineView: UIViewRepresentable {
     ///     - alignment: How the skeleton is alignment inside ``SpineUIView``. Per default, it is `.center`
     ///     - boundsProvider: The skeleton bounds must be computed via a ``BoundsProvider``. Per default, ``SetupPoseBounds`` is used.
     ///     - backgroundColor: The background color of the view. Per defaut, `UIColor.clear` is used
+    ///     - linearTextureFilter: Use linear texture filter when `true`. Per default, `false` (nearest).
     ///     - isRendering: Bindgin to disable or enable rendering. Disable it when the spine view is out of bounds and you want to preserve CPU/GPU resources.
     ///
     /// - Returns: A new instance of ``SpineView``.
@@ -75,6 +77,7 @@ public struct SpineView: UIViewRepresentable {
         alignment: SpineAlignment = .center,
         boundsProvider: BoundsProvider = SetupPoseBounds(),
         backgroundColor: UIColor = .clear,
+        linearTextureFilter: Bool = false,
         isRendering: Binding<Bool?> = .constant(nil)
     ) {
         self.source = source
@@ -83,6 +86,7 @@ public struct SpineView: UIViewRepresentable {
         self.alignment = alignment
         self.boundsProvider = boundsProvider
         self.backgroundColor = backgroundColor
+        self.linearTextureFilter = linearTextureFilter
         _isRendering = isRendering
     }
 
@@ -93,7 +97,8 @@ public struct SpineView: UIViewRepresentable {
             mode: mode,
             alignment: alignment,
             boundsProvider: boundsProvider,
-            backgroundColor: backgroundColor
+            backgroundColor: backgroundColor,
+            linearTextureFilter: linearTextureFilter
         )
     }
 


### PR DESCRIPTION
Add fragmentShaderLinear and linearTextureFilter on SpineUIView and SpineView. SpineRenderer selects the fragment function at pipeline creation time. Default remains nearest for backward compatibility.

### Summary

This PR adds **per-view texture filter configuration** to spine-ios Metal rendering, allowing callers to choose between **nearest** (default) and **linear** without changing global behavior.

### Motivation

Different use cases may require different texture filters: some content looks best with **nearest**, others with **linear**. The current Metal shader hard-codes `nearest`, and there is no public API to override it per `SpineUIView`.

### Solution

1. **Metal shaders** — Keep `fragmentShader` (nearest) and add `fragmentShaderLinear` (linear).
2. **`SpineRenderer`** — Accept `textureFilter: TextureFilter` (default `.nearest`) and select the fragment function at pipeline creation time.
3. **`SpineUIView`** — Expose `linearTextureFilter: Bool` (default `false`) on initializers; map to `TextureFilter` internally. Uses `Bool` for `@objc` interoperability.
4. **`SpineView` (SwiftUI)** — Forward `linearTextureFilter` to `SpineUIView`.

### API

```swift
let view = SpineUIView(from: source)                          // nearest (default)
let view = SpineUIView(from: source, linearTextureFilter: true) // linear
SpineView(from: source, linearTextureFilter: true)
```

Objective-C: `linearTextureFilter:YES` on `@objc` initializers.

### Changed files

| File | Change |
|------|--------|
| `spine-ios/Sources/SpineiOS/Metal/SpineShaders.metal` | Add `fragmentShaderLinear` |
| `spine-ios/Sources/SpineiOS/Metal/SpineRenderer.swift` | `textureFilter` init parameter; dynamic fragment function name |
| `spine-ios/Sources/SpineiOS/SpineUIView.swift` | `linearTextureFilter: Bool` property and initializer parameters |
| `spine-ios/Sources/SpineiOS/SpineView.swift` | Pass `linearTextureFilter` through to `SpineUIView` |

### Backward compatibility

- Default remains **`nearest`** (`linearTextureFilter: false`).
- No changes required for existing call sites.

- [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).
