### PR TITLE
[ios] Fix duplicate Metal shader compilation in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,10 +42,7 @@ let package = Package(
                 "SpineSwift",
                 "SpineShadersStructs",
             ],
-            path: "spine-ios/Sources/SpineiOS",
-            resources: [
-                .process("Metal/SpineShaders.metal")
-            ]
+            path: "spine-ios/Sources/SpineiOS"
         ),
         .target(
             name: "SpineC",


### PR DESCRIPTION
This PR fixes a build error #3155  where `SpineShaders.metal` was being compiled twice - once as source code and once as a resource file, causing "Unexpected duplicate tasks" errors in Xcode.

### Problem

When the Metal shader was declared in the `resources` section, SPM/Xcode tried to process it as a resource file. However, .metal files in the source path are automatically compiled as source code by the Metal compiler, resulting in duplicate compilation tasks:

```sh
error: Unexpected duplicate tasks
  note: Target 'spine-ios_SpineiOS' has compile command with input 'SpineShaders.metal'
  note: Target 'spine-ios_SpineiOS' has compile command with input 'SpineShaders.metal'
```

### Solution

Removed the `resources` section from the `SpineiOS` target definition. Metal shader files (`.metal`) are now correctly handled as source files only, not as resources.

### Changes

- Removed `resources: [.process("Metal/SpineShaders.metal")]` from `SpineiOS` target

- The Metal shader is now automatically compiled as source code (the correct behavior)




* [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).