### PR TITLE
[ios] Support offscreen and headless Metal rendering

### DIFF
--- a/spine-ios/Sources/SpineiOS/Metal/SpineRenderer.swift
+++ b/spine-ios/Sources/SpineiOS/Metal/SpineRenderer.swift
@@ -171,18 +171,29 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
 
     func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
         guard let spineView = view as? SpineUIView else { return }
-
-        backingScale = CGSize(
-            width: spineView.bounds.width > 0 && size.width > 0 ? size.width / spineView.bounds.width : 1,
-            height: spineView.bounds.height > 0 && size.height > 0 ? size.height / spineView.bounds.height : 1
-        )
-        sizeInPoints = CGSize(width: size.width / backingScale.width, height: size.height / backingScale.height)
-        viewPortSize = vector_uint2(UInt32(size.width), UInt32(size.height))
-        setTransform(
+        updateViewport(
+            sizeInPoints: spineView.bounds.size,
+            drawableSize: size,
             bounds: spineView.computedBounds,
             mode: spineView.mode,
             alignment: spineView.alignment
         )
+    }
+
+    func updateViewport(
+        sizeInPoints: CGSize,
+        drawableSize: CGSize,
+        bounds: CGRect,
+        mode: SpineContentMode,
+        alignment: SpineAlignment
+    ) {
+        backingScale = CGSize(
+            width: sizeInPoints.width > 0 && drawableSize.width > 0 ? drawableSize.width / sizeInPoints.width : 1,
+            height: sizeInPoints.height > 0 && drawableSize.height > 0 ? drawableSize.height / sizeInPoints.height : 1
+        )
+        self.sizeInPoints = sizeInPoints
+        viewPortSize = vector_uint2(UInt32(drawableSize.width), UInt32(drawableSize.height))
+        setTransform(bounds: bounds, mode: mode, alignment: alignment)
     }
 
     func draw(in view: MTKView) {
@@ -201,18 +212,15 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
     @discardableResult
     func draw(
         to texture: MTLTexture,
-        in view: SpineUIView,
+        pixelFormat: MTLPixelFormat,
         clearColor: MTLClearColor,
         completion: ((MTLCommandBuffer) -> Void)?
     ) -> Bool {
-        guard texture.pixelFormat == view.colorPixelFormat,
+        guard texture.pixelFormat == pixelFormat,
             texture.usage.contains(.renderTarget)
         else {
             return false
         }
-
-        let size = CGSize(width: texture.width, height: texture.height)
-        mtkView(view, drawableSizeWillChange: size)
 
         let renderPassDescriptor = MTLRenderPassDescriptor()
         renderPassDescriptor.colorAttachments[0].texture = texture
@@ -230,20 +238,17 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
     @discardableResult
     func draw(
         to texture: MTLTexture,
-        in view: SpineUIView,
+        pixelFormat: MTLPixelFormat,
         commandBuffer: MTLCommandBuffer,
         clearColor: MTLClearColor,
         completion: ((MTLCommandBuffer) -> Void)?
     ) -> Bool {
-        guard texture.pixelFormat == view.colorPixelFormat,
+        guard texture.pixelFormat == pixelFormat,
             texture.usage.contains(.renderTarget),
             commandBuffer.status == .notEnqueued
         else {
             return false
         }
-
-        let size = CGSize(width: texture.width, height: texture.height)
-        mtkView(view, drawableSizeWillChange: size)
 
         let renderPassDescriptor = MTLRenderPassDescriptor()
         renderPassDescriptor.colorAttachments[0].texture = texture

--- a/spine-ios/Sources/SpineiOS/Metal/SpineRenderer.swift
+++ b/spine-ios/Sources/SpineiOS/Metal/SpineRenderer.swift
@@ -186,9 +186,56 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
     }
 
     func draw(in view: MTKView) {
+        guard let renderPassDescriptor = view.currentRenderPassDescriptor else {
+            return
+        }
+        let drawable = view.currentDrawable
+        _ = draw(
+            renderPassDescriptor: renderPassDescriptor,
+            present: { commandBuffer in
+                drawable.flatMap { commandBuffer.present($0) }
+            }
+        )
+    }
+
+    @discardableResult
+    func draw(
+        to texture: MTLTexture,
+        in view: SpineUIView,
+        clearColor: MTLClearColor,
+        completion: ((MTLCommandBuffer) -> Void)?
+    ) -> Bool {
+        guard texture.pixelFormat == view.colorPixelFormat,
+            texture.usage.contains(.renderTarget)
+        else {
+            return false
+        }
+
+        let size = CGSize(width: texture.width, height: texture.height)
+        mtkView(view, drawableSizeWillChange: size)
+
+        let renderPassDescriptor = MTLRenderPassDescriptor()
+        renderPassDescriptor.colorAttachments[0].texture = texture
+        renderPassDescriptor.colorAttachments[0].loadAction = .clear
+        renderPassDescriptor.colorAttachments[0].storeAction = .store
+        renderPassDescriptor.colorAttachments[0].clearColor = clearColor
+
+        return draw(
+            renderPassDescriptor: renderPassDescriptor,
+            present: nil,
+            completion: completion
+        )
+    }
+
+    @discardableResult
+    private func draw(
+        renderPassDescriptor: MTLRenderPassDescriptor,
+        present: ((MTLCommandBuffer) -> Void)?,
+        completion: ((MTLCommandBuffer) -> Void)? = nil
+    ) -> Bool {
         guard dataSource?.isPlaying(self) ?? false else {
             lastDraw = CACurrentMediaTime()
-            return
+            return false
         }
 
         callNeedsUpdate()
@@ -200,31 +247,30 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
 
         guard let renderCommands = dataSource?.renderCommands(self),
             let commandBuffer = commandQueue.makeCommandBuffer(),
-            let renderPassDescriptor = view.currentRenderPassDescriptor,
             let renderEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor)
         else {
             // this can happen if,
             // - CAMetalLayer is configured with drawable timeout, and CAMetalLayer is run out of Drawable
             // - CAMetalLayer is added to the window with frame size of zero or incorrect layout constraint -> currentRenderPassDescriptor is null
             bufferingSemaphore.signal()
-            return
+            return false
         }
 
         delegate?.spineRendererWillDraw(self)
-        draw(renderCommands: renderCommands, renderEncoder: renderEncoder, in: view)
+        draw(renderCommands: renderCommands, renderEncoder: renderEncoder)
         delegate?.spineRendererDidDraw(self)
 
         renderEncoder.endEncoding()
-        view.currentDrawable.flatMap {
-            commandBuffer.present($0)
-        }
-        commandBuffer.addCompletedHandler { [bufferingSemaphore] _ in
+        present?(commandBuffer)
+        commandBuffer.addCompletedHandler { [bufferingSemaphore] commandBuffer in
             bufferingSemaphore.signal()
+            completion?(commandBuffer)
         }
         commandBuffer.commit()
         if waitUntilCompleted {
             commandBuffer.waitUntilCompleted()
         }
+        return true
     }
 
     private func setTransform(bounds: CGRect, mode: SpineContentMode, alignment: SpineAlignment) {
@@ -273,7 +319,7 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
         delegate?.spineRendererDidUpdate(self)
     }
 
-    private func draw(renderCommands: [RenderCommand], renderEncoder: MTLRenderCommandEncoder, in view: MTKView) {
+    private func draw(renderCommands: [RenderCommand], renderEncoder: MTLRenderCommandEncoder) {
         let allVertices = renderCommands.map { renderCommand in
             Array(renderCommand.getVertices())
         }

--- a/spine-ios/Sources/SpineiOS/Metal/SpineRenderer.swift
+++ b/spine-ios/Sources/SpineiOS/Metal/SpineRenderer.swift
@@ -228,10 +228,66 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
     }
 
     @discardableResult
+    func draw(
+        to texture: MTLTexture,
+        in view: SpineUIView,
+        commandBuffer: MTLCommandBuffer,
+        clearColor: MTLClearColor,
+        completion: ((MTLCommandBuffer) -> Void)?
+    ) -> Bool {
+        guard texture.pixelFormat == view.colorPixelFormat,
+            texture.usage.contains(.renderTarget),
+            commandBuffer.status == .notEnqueued
+        else {
+            return false
+        }
+
+        let size = CGSize(width: texture.width, height: texture.height)
+        mtkView(view, drawableSizeWillChange: size)
+
+        let renderPassDescriptor = MTLRenderPassDescriptor()
+        renderPassDescriptor.colorAttachments[0].texture = texture
+        renderPassDescriptor.colorAttachments[0].loadAction = .clear
+        renderPassDescriptor.colorAttachments[0].storeAction = .store
+        renderPassDescriptor.colorAttachments[0].clearColor = clearColor
+
+        return encode(
+            renderPassDescriptor: renderPassDescriptor,
+            commandBuffer: commandBuffer,
+            completion: completion
+        )
+    }
+
+    @discardableResult
     private func draw(
         renderPassDescriptor: MTLRenderPassDescriptor,
         present: ((MTLCommandBuffer) -> Void)?,
         completion: ((MTLCommandBuffer) -> Void)? = nil
+    ) -> Bool {
+        guard let commandBuffer = commandQueue.makeCommandBuffer() else {
+            return false
+        }
+        guard encode(
+            renderPassDescriptor: renderPassDescriptor,
+            commandBuffer: commandBuffer,
+            completion: completion
+        ) else {
+            return false
+        }
+
+        present?(commandBuffer)
+        commandBuffer.commit()
+        if waitUntilCompleted {
+            commandBuffer.waitUntilCompleted()
+        }
+        return true
+    }
+
+    @discardableResult
+    private func encode(
+        renderPassDescriptor: MTLRenderPassDescriptor,
+        commandBuffer: MTLCommandBuffer,
+        completion: ((MTLCommandBuffer) -> Void)?
     ) -> Bool {
         guard dataSource?.isPlaying(self) ?? false else {
             lastDraw = CACurrentMediaTime()
@@ -246,7 +302,6 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
         currentBufferIndex = (currentBufferIndex + 1) % SpineRenderer.numberOfBuffers
 
         guard let renderCommands = dataSource?.renderCommands(self),
-            let commandBuffer = commandQueue.makeCommandBuffer(),
             let renderEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor)
         else {
             // this can happen if,
@@ -261,14 +316,9 @@ internal final class SpineRenderer: NSObject, MTKViewDelegate {
         delegate?.spineRendererDidDraw(self)
 
         renderEncoder.endEncoding()
-        present?(commandBuffer)
         commandBuffer.addCompletedHandler { [bufferingSemaphore] commandBuffer in
             bufferingSemaphore.signal()
             completion?(commandBuffer)
-        }
-        commandBuffer.commit()
-        if waitUntilCompleted {
-            commandBuffer.waitUntilCompleted()
         }
         return true
     }

--- a/spine-ios/Sources/SpineiOS/SpineMetalRenderer.swift
+++ b/spine-ios/Sources/SpineiOS/SpineMetalRenderer.swift
@@ -1,0 +1,137 @@
+/******************************************************************************
+ * Spine Runtimes License Agreement
+ * Last updated April 5, 2025. Replaces all prior versions.
+ *
+ * Copyright (c) 2013-2025, Esoteric Software LLC
+ *
+ * Integration of the Spine Runtimes into software or otherwise creating
+ * derivative works of the Spine Runtimes is permitted under the terms and
+ * conditions of Section 2 of the Spine Editor License Agreement:
+ * http://esotericsoftware.com/spine-editor-license
+ *
+ * Otherwise, it is permitted to integrate the Spine Runtimes into software
+ * or otherwise create derivative works of the Spine Runtimes (collectively,
+ * "Products"), provided that each user of the Products must obtain their own
+ * Spine Editor license and redistribution of the Products in any form must
+ * include this license and copyright notice.
+ *
+ * THE SPINE RUNTIMES ARE PROVIDED BY ESOTERIC SOFTWARE LLC "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL ESOTERIC SOFTWARE LLC BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES,
+ * BUSINESS INTERRUPTION, OR LOSS OF USE, DATA, OR PROFITS) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+
+import CoreGraphics
+import Foundation
+import Metal
+import SpineSwift
+
+/// Renders a Spine skeleton into caller-owned Metal textures without creating
+/// an ``MTKView`` or participating in a view display loop.
+///
+/// The renderer uses the same animation updates, clipping, mesh deformation,
+/// slot order, blend modes, atlas textures, and controller callbacks as
+/// ``SpineUIView``. The caller owns presentation and may either let this class
+/// create and commit a command buffer or provide one for shared synchronization.
+@objcMembers
+public final class SpineMetalRenderer: NSObject {
+    public let controller: SpineController
+
+    private let renderer: SpineRenderer
+    private let bounds: CGRect
+    private let mode: SpineContentMode
+    private let alignment: SpineAlignment
+    private let pixelFormat: MTLPixelFormat
+
+    public init(
+        drawable: SkeletonDrawableWrapper,
+        controller: SpineController = SpineController(),
+        mode: SpineContentMode = .fit,
+        alignment: SpineAlignment = .center,
+        boundsProvider: BoundsProvider = SetupPoseBounds(),
+        pixelFormat: MTLPixelFormat = .bgra8Unorm,
+        textureFilter: SpineTextureFilter = .atlas
+    ) throws {
+        self.controller = controller
+        self.bounds = boundsProvider.computeBounds(for: drawable)
+        self.mode = mode
+        self.alignment = alignment
+        self.pixelFormat = pixelFormat
+
+        controller.drawable = drawable
+        let pma = controller.atlas.pages.count > 0
+            ? (controller.atlas.pages[0]?.pma ?? false)
+            : false
+        renderer = try SpineRenderer(
+            device: SpineObjects.shared.device,
+            commandQueue: SpineObjects.shared.commandQueue,
+            pixelFormat: pixelFormat,
+            atlas: controller.atlas,
+            atlasPages: drawable.atlasPages,
+            pma: pma,
+            textureFilter: textureFilter
+        )
+
+        super.init()
+
+        renderer.delegate = controller
+        renderer.dataSource = controller
+        controller.initialize()
+    }
+
+    /// Renders into a texture and commits a command buffer owned by the Spine
+    /// renderer. `sizeInPoints` controls content fitting and defaults to the
+    /// texture's pixel dimensions, producing a backing scale of one.
+    @discardableResult
+    public func render(
+        to texture: MTLTexture,
+        sizeInPoints: CGSize? = nil,
+        clearColor: MTLClearColor = MTLClearColorMake(0, 0, 0, 0),
+        completion: ((MTLCommandBuffer) -> Void)? = nil
+    ) -> Bool {
+        updateViewport(for: texture, sizeInPoints: sizeInPoints)
+        return renderer.draw(
+            to: texture,
+            pixelFormat: pixelFormat,
+            clearColor: clearColor,
+            completion: completion
+        )
+    }
+
+    /// Encodes into a caller-owned command buffer. The caller must commit the
+    /// command buffer after this method returns `true`.
+    @discardableResult
+    public func render(
+        to texture: MTLTexture,
+        commandBuffer: MTLCommandBuffer,
+        sizeInPoints: CGSize? = nil,
+        clearColor: MTLClearColor = MTLClearColorMake(0, 0, 0, 0),
+        completion: ((MTLCommandBuffer) -> Void)? = nil
+    ) -> Bool {
+        updateViewport(for: texture, sizeInPoints: sizeInPoints)
+        return renderer.draw(
+            to: texture,
+            pixelFormat: pixelFormat,
+            commandBuffer: commandBuffer,
+            clearColor: clearColor,
+            completion: completion
+        )
+    }
+
+    private func updateViewport(for texture: MTLTexture, sizeInPoints: CGSize?) {
+        let drawableSize = CGSize(width: texture.width, height: texture.height)
+        renderer.updateViewport(
+            sizeInPoints: sizeInPoints ?? drawableSize,
+            drawableSize: drawableSize,
+            bounds: bounds,
+            mode: mode,
+            alignment: alignment
+        )
+    }
+}

--- a/spine-ios/Sources/SpineiOS/SpineUIView.swift
+++ b/spine-ios/Sources/SpineiOS/SpineUIView.swift
@@ -321,6 +321,38 @@ public final class SpineUIView: MTKView {
             }
         }
     }
+
+    /// Renders the current skeleton pose directly into a caller-owned Metal
+    /// texture.
+    ///
+    /// The texture must use the same pixel format as ``colorPixelFormat`` and
+    /// include ``MTLTextureUsage/renderTarget`` in its usage. This method uses
+    /// the same renderer as the on-screen view, including animation updates,
+    /// clipping, mesh deformation, slot order, and blend modes.
+    ///
+    /// - Parameters:
+    ///   - texture: The Metal texture that receives the rendered frame.
+    ///   - clearColor: The color used to clear the texture before rendering.
+    ///     Defaults to the view's ``clearColor``.
+    ///   - completion: Called on Metal's completion queue after the GPU has
+    ///     finished rendering. Inspect the command buffer status and error to
+    ///     determine whether rendering succeeded.
+    /// - Returns: `true` when a command buffer was submitted, or `false` when
+    ///   the renderer is not initialized, paused, or could not encode a frame.
+    @discardableResult
+    public func render(
+        to texture: MTLTexture,
+        clearColor: MTLClearColor? = nil,
+        completion: ((MTLCommandBuffer) -> Void)? = nil
+    ) -> Bool {
+        guard let renderer else { return false }
+        return renderer.draw(
+            to: texture,
+            in: self,
+            clearColor: clearColor ?? self.clearColor,
+            completion: completion
+        )
+    }
 }
 
 extension SpineUIView {

--- a/spine-ios/Sources/SpineiOS/SpineUIView.swift
+++ b/spine-ios/Sources/SpineiOS/SpineUIView.swift
@@ -346,9 +346,13 @@ public final class SpineUIView: MTKView {
         completion: ((MTLCommandBuffer) -> Void)? = nil
     ) -> Bool {
         guard let renderer else { return false }
+        renderer.mtkView(
+            self,
+            drawableSizeWillChange: CGSize(width: texture.width, height: texture.height)
+        )
         return renderer.draw(
             to: texture,
-            in: self,
+            pixelFormat: colorPixelFormat,
             clearColor: clearColor ?? self.clearColor,
             completion: completion
         )
@@ -384,9 +388,13 @@ public final class SpineUIView: MTKView {
         completion: ((MTLCommandBuffer) -> Void)? = nil
     ) -> Bool {
         guard let renderer else { return false }
+        renderer.mtkView(
+            self,
+            drawableSizeWillChange: CGSize(width: texture.width, height: texture.height)
+        )
         return renderer.draw(
             to: texture,
-            in: self,
+            pixelFormat: colorPixelFormat,
             commandBuffer: commandBuffer,
             clearColor: clearColor ?? self.clearColor,
             completion: completion

--- a/spine-ios/Sources/SpineiOS/SpineUIView.swift
+++ b/spine-ios/Sources/SpineiOS/SpineUIView.swift
@@ -353,6 +353,45 @@ public final class SpineUIView: MTKView {
             completion: completion
         )
     }
+
+    /// Encodes the current skeleton pose directly into a caller-owned Metal
+    /// texture and command buffer.
+    ///
+    /// Use this overload when the destination texture is synchronized by the
+    /// caller's command buffer, such as a RealityKit `LowLevelTexture`. The
+    /// caller must commit the command buffer after this method returns `true`.
+    /// Spine adds its completion handler before returning and retains its
+    /// per-frame resources until the command buffer completes.
+    ///
+    /// The texture must use the same pixel format as ``colorPixelFormat`` and
+    /// include ``MTLTextureUsage/renderTarget`` in its usage. The command
+    /// buffer must not already be committed or completed.
+    ///
+    /// - Parameters:
+    ///   - texture: The Metal texture that receives the rendered frame.
+    ///   - commandBuffer: The caller-owned command buffer used for encoding.
+    ///   - clearColor: The color used to clear the texture before rendering.
+    ///     Defaults to the view's ``clearColor``.
+    ///   - completion: Called on Metal's completion queue after the caller
+    ///     commits the command buffer and the GPU finishes rendering.
+    /// - Returns: `true` when the frame was encoded, or `false` when the
+    ///   renderer is not initialized, paused, or could not encode a frame.
+    @discardableResult
+    public func render(
+        to texture: MTLTexture,
+        commandBuffer: MTLCommandBuffer,
+        clearColor: MTLClearColor? = nil,
+        completion: ((MTLCommandBuffer) -> Void)? = nil
+    ) -> Bool {
+        guard let renderer else { return false }
+        return renderer.draw(
+            to: texture,
+            in: self,
+            commandBuffer: commandBuffer,
+            clearColor: clearColor ?? self.clearColor,
+            completion: completion
+        )
+    }
 }
 
 extension SpineUIView {


### PR DESCRIPTION
* [x] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).

Closes #3159.

## Summary

Adds offscreen and headless Metal rendering paths to `spine-ios` without duplicating Spine rendering behavior:

- render the current pose into a caller-owned `MTLTexture`;
- optionally encode into a caller-owned, uncommitted `MTLCommandBuffer`;
- use the same internal renderer for on-screen, offscreen, and headless rendering;
- add `SpineMetalRenderer` for integrations that do not need or want an `MTKView`.

The headless API is useful when Spine is embedded in another Metal renderer such as RealityKit. It avoids creating a hidden view and an independent display/drawable lifecycle for every skeleton while retaining animation evaluation, clipping, mesh deformation, slot draw order, tinting, blend modes, callbacks, and existing `SpineController` behavior.

## API

```swift
let renderer = try SpineMetalRenderer(
    drawable: drawable,
    controller: controller,
    boundsProvider: boundsProvider,
    pixelFormat: .bgra8Unorm_srgb
)

renderer.render(to: texture)

renderer.render(
    to: texture,
    commandBuffer: commandBuffer
)
```

The existing `SpineUIView.render(to:)` overloads remain available and delegate to the same renderer.

## Ownership

For the command-buffer overload, the caller owns synchronization and commit. The runtime only encodes Spine's render pass.

## Why

External Metal renderers may own the destination texture lifecycle and require synchronization through their command buffer. Without these hooks, clients need another full-frame copy, a hidden `MTKView`, or a parallel implementation of Spine rendering behavior.

This keeps clipping, meshes, deformation, slot ordering, tinting, and blend modes inside the official runtime.

## Validation

- [x] `swift build --product SpineiOS`
- [x] consumed by an iOS app from this exact fork revision
- [x] full unsigned `iphoneos` application build
- [x] iOS 18+ RealityKit `LowLevelTexture` path using a caller-owned command buffer
- [x] older iOS `TextureResource.DrawableQueue` fallback
