### PR TITLE
[haxe] Fixed timeline property id corruption caused by Haxe 4 flash target rest-spread bug

### DIFF
--- a/spine-haxe/spine-haxe/spine/animation/CurveTimeline.hx
+++ b/spine-haxe/spine-haxe/spine/animation/CurveTimeline.hx
@@ -43,7 +43,12 @@ abstract class CurveTimeline extends Timeline {
 	/** @param bezierCount The maximum number of Bezier curves. See CurveTimeline.shrink().
 	 * @param propertyIds Unique identifiers for the properties the timeline modifies. */
 	public function new(frameCount:Int, bezierCount:Int, propertyIds:...String) {
+		#if (flash && !haxe5) // See HaxeFoundation/haxe#13017
+		super(frameCount);
+		this.propertyIds = propertyIds;
+		#else
 		super(frameCount, ...propertyIds);
+		#end
 		curves = ArrayUtils.resize(new Array<Float>(), frameCount + bezierCount * BEZIER_SIZE, 0);
 		curves[frameCount - 1] = STEPPED;
 	}

--- a/spine-haxe/spine-haxe/spine/animation/DrawOrderFolderTimeline.hx
+++ b/spine-haxe/spine-haxe/spine/animation/DrawOrderFolderTimeline.hx
@@ -44,7 +44,12 @@ class DrawOrderFolderTimeline extends Timeline {
 	/** @param slots spine.Skeleton.slots indices controlled by this timeline, in setup order.
 	 * @param slotCount The maximum number of slots in the skeleton. */
 	public function new(frameCount:Int, slots:Array<Int>, slotCount:Int) {
+		#if (flash && !haxe5) // See HaxeFoundation/haxe#13017
+		super(frameCount);
+		this.propertyIds = DrawOrderFolderTimeline.getPropertyIds(slots);
+		#else
 		super(frameCount, ...DrawOrderFolderTimeline.getPropertyIds(slots));
+		#end
 		this.slots = slots;
 		drawOrders = new Array<Array<Int>>();
 		drawOrders.resize(frameCount);

--- a/spine-haxe/spine-haxe/spine/animation/SlotCurveTimeline.hx
+++ b/spine-haxe/spine-haxe/spine/animation/SlotCurveTimeline.hx
@@ -33,7 +33,12 @@ abstract class SlotCurveTimeline extends CurveTimeline implements SlotTimeline {
 	public final slotIndex:Int;
 
 	public function new(frameCount:Int, bezierCount:Int, slotIndex:Int, propertyIds:...String) {
+		#if (flash && !haxe5) // See HaxeFoundation/haxe#13017
+		super(frameCount, bezierCount);
+		this.propertyIds = propertyIds;
+		#else
 		super(frameCount, bezierCount, ...propertyIds);
+		#end
 		this.slotIndex = slotIndex;
 	}
 


### PR DESCRIPTION
Timeline's constructors forwarded a rest argument with super(frameCount, ...propertyIds). The Haxe compiler miscompiles a call-site spread on the flash (AVM2) target: genswf9 built the expanded argument list as [rest...] @ List.rev fixed_args, so the fixed arguments arrived reversed with the rest items prepended. frameCount therefore arrives as a property id and propertyIds as [frameCount], with no compile error and no runtime exception -- property ids collide across timelines and AnimationState mixing corrupts. Fixed upstream in HaxeFoundation/haxe#13017, which is merged to development and so lands in Haxe 5 once it is GA.

Revised after @davidetan's review. The first version declared propertyIds as Array<String>, which changed the public constructor signatures and would have broken any user-defined timeline subclass. This version takes the approach he suggested -- call super() without the ids and assign propertyIds afterwards, which Timeline itself already does -- and changes no signatures anywhere.

Two things make it smaller than the original description implied. Only three call sites in the runtime actually spread: CurveTimeline, SlotCurveTimeline and DrawOrderFolderTimeline. The rest pass a fixed argument list into a rest parameter, which the compiler handles correctly and which was never affected -- so they need no change. And the workaround is guarded by #if (flash && !haxe5), with the original line unchanged in the #else, so every other target and Haxe 5 onward compile exactly what they do today. Three files, +15 lines, nothing deleted.

Verification:

compiles for -swf, -js, and -swf -D haxe5 (which type-checks the #else branch on the flash target)
propertyIds and frames identical to current 4.3 across 12 timeline types, with the guarded branch forced on a runnable target
haxelib run formatter --check clean
decompiled from a built SWC and confirmed in a shipping AIR app on Android: super(param1); propertyIds = rest.copy();, no spread and no length-dispatch chain. Reel symbols and animation mixing, both broken before, are correct.
While the conditional isn't strictly necessary, it serves as a monument to clarify the scope of the defect and avoid someone unknowingly reintroducing the defect.

* [X] I confirm this contribution is made under the Esoteric Software LLC [CLA](http://esotericsoftware.com/licenses/cla.txt).
